### PR TITLE
fix(ci): stage head branch before opening release PR

### DIFF
--- a/.changeset/release-pr-branch-staging.md
+++ b/.changeset/release-pr-branch-staging.md
@@ -1,0 +1,29 @@
+---
+"monorel.disaresta.com": patch
+---
+
+Fix release-pr workflows by staging the head branch before opening
+the always-open release PR.
+
+GitHub's PR-create API rejects PRs whose head branch doesn't exist
+on the remote (`422 Validation Failed [Field:head Code:invalid]`).
+Both `ci/github/action.yml` and the self-hosted `release-pr.yml`
+now create the configured head branch (default `monorel/release`)
+as a fast-forward of the default branch plus one empty marker
+commit, then force-push, before invoking `monorel preview --upsert`.
+
+The branch's diff stays empty by design; the rendered plan goes in
+the PR body, not in a code diff. At merge time, the squash commit
+inherits the orchestrator-set PR title (`chore(release): ...`),
+which `release.yml` filters on to trigger the post-merge release
+pipeline. So the marker commit's own subject is irrelevant after
+squash and there is no two-`chore(release):`-commit churn on main.
+
+Surfaced by loglayer-go's first monorel-driven release attempt,
+where the smoke-test PR's `release-pr` workflow run failed with
+the 422 error on PR creation.
+
+Branch staging in the orchestrator (Go code) is still on the
+roadmap; this CI-wrapper fix unblocks consumers in the meantime
+and is the right layer per the `Run` doc-comment ("delegated to
+the CI wrapper because it's a thin shell-out to git").

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,12 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
-      - run: bun scripts/lint-commit.mjs --range origin/${{ github.base_ref }}..HEAD
+      # Use head.sha rather than HEAD: on PRs, the runner checks out a
+      # synthetic test-merge commit at HEAD with subject `Merge <sha>
+      # into <sha>`, which is not conventional-commits format and
+      # always fails the parser. head.sha points at the PR branch's
+      # actual tip.
+      - run: bun scripts/lint-commit.mjs --range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
 
   docs-build:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,6 +33,22 @@ jobs:
           git config user.name  "monorel-bot[automation]"
           git config user.email "monorel-bot@users.noreply.github.com"
 
+      # GitHub's PR-create API requires the head branch to exist on
+      # the remote before opening a PR against it. Stage monorel/release
+      # as origin/main + one empty marker commit, force-push, then run
+      # the orchestrator. See ci/github/action.yml for the same logic
+      # with full commentary.
+      - name: Stage release branch
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          git branch -f monorel/release origin/main
+          git checkout -q monorel/release
+          git -c commit.gpgsign=false commit --allow-empty \
+            -m "chore(release): always-open release PR marker"
+          git push -f origin monorel/release
+          git checkout -q -
+
       - name: monorel preview --upsert
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/github/action.yml
+++ b/ci/github/action.yml
@@ -116,8 +116,31 @@ runs:
         set -euo pipefail
         case "$COMMAND" in
           pr)
-            # v1: pushes nothing to the head branch; the PR body
-            # shows the rendered plan. Branch staging is a follow-up.
+            # GitHub's PR-create API requires the head branch to exist
+            # on the remote before opening a PR against it. Stage
+            # monorel/release as a fast-forward of the default branch
+            # plus one empty marker commit, then force-push so the
+            # always-open release PR has somewhere to live.
+            #
+            # The branch's diff is empty (the rendered plan goes in the
+            # PR body, not the branch). At merge time, the squash
+            # commit's subject is the orchestrator-set PR title
+            # (`chore(release): ...`), which release.yml uses to gate.
+            #
+            # If the orchestrator decides the plan is empty (no pending
+            # changesets) it'll close any open release PR — the staged
+            # branch is harmless leftover state in that case and gets
+            # overwritten on the next non-empty plan.
+            base="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)"
+            base="${base:-$(git rev-parse --abbrev-ref HEAD)}"
+            git fetch --no-tags origin "$base"
+            git branch -f monorel/release "origin/$base"
+            git checkout -q monorel/release
+            git -c commit.gpgsign=false commit --allow-empty \
+              -m "chore(release): always-open release PR marker"
+            git push -f origin monorel/release
+            git checkout -q -
+
             monorel preview --config "$CONFIG" --upsert
             ;;
           release)


### PR DESCRIPTION
## Summary

Surfaced by loglayer-go's first monorel-driven release attempt: the always-open release PR fails to open with `422 Validation Failed [Field:head Code:invalid]` because GitHub's PR-create API requires the head branch (`monorel/release` by default) to exist on the remote, and monorel v0.1.0 doesn't push it.

The action wrapper (`ci/github/action.yml`) had a comment noting "branch staging is a follow-up." That follow-up is needed now.

## Fix

Both `ci/github/action.yml` (downstream consumers) and `.github/workflows/release-pr.yml` (monorel's self-hosted version, latent same bug) now do this before invoking `monorel preview --upsert`:

```sh
git fetch --no-tags origin <default-branch>
git branch -f monorel/release origin/<default-branch>
git checkout -q monorel/release
git -c commit.gpgsign=false commit --allow-empty \
  -m "chore(release): always-open release PR marker"
git push -f origin monorel/release
git checkout -q -
```

The branch's diff stays empty by design — the rendered plan lives in the PR body, not in a code diff. At squash-merge time the commit subject inherits the orchestrator-set PR title (`chore(release): ...`), which `release.yml` filters on, so the marker commit's own subject is invisible to the post-merge flow.

## Why CI-wrapper layer, not Go-code layer

The orchestrator's `Run` doc explicitly says: "branch management (creating / updating / pushing the release branch) is delegated to the CI wrapper because it's a thin shell-out to git." This change keeps that boundary; pushing branch-stage logic into `internal/orchestrator` would couple the Go code to forge-specific git semantics.

A future enhancement could move this into Go via an `internal/git` shell-out helper called from preview, with the action wrapper becoming a one-liner. Out of scope for this fix.

## Cutting v0.1.1

After this merges, this same bug means `release-pr` on monorel's main will also fail (same 422). Cut v0.1.1 via `workflow_dispatch` on `release.yml` directly — the dispatch path doesn't go through the always-open PR pattern and isn't affected.

## Test plan

- [x] `transports/blank` smoke-test PR on loglayer-go merged; the failed run is what surfaced this.
- [ ] After v0.1.1 cuts: bump loglayer-go's pin, re-trigger release-pr, confirm the always-open PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)