### PR TITLE
fix(ci): chain build-binaries + build-image from release.yml

### DIFF
--- a/.changeset/chain-asset-workflows.md
+++ b/.changeset/chain-asset-workflows.md
@@ -1,0 +1,33 @@
+---
+"monorel.disaresta.com": patch
+---
+
+Chain `build-release-binaries` and `build-image` into `release.yml`
+via `workflow_call` so they fire after every monorel-driven release.
+
+When `release.yml` pushes a tag using `secrets.GITHUB_TOKEN`, GitHub's
+anti-recursion rule suppresses the resulting `push: tags` event for
+other workflows. That meant downstream tag-triggered workflows (the
+binary builder and the container builder) silently didn't fire on
+real releases — only on the v0.1.0 bootstrap, which was cut via
+`workflow_dispatch` (a user-initiated run that doesn't trip the
+anti-recursion rule).
+
+Surfaced by monorel's own v0.1.1 release: the tag and GitHub Release
+appeared, but no binaries were attached and no image was pushed to
+GHCR. v0.1.1 is consequently usable only via `go install`, not via
+the action wrapper or `docker pull`.
+
+Mirrors the same `workflow_call` workaround `docs.yml` already uses
+(in loglayer-go's release.yml — monorel's docs.yml deploys on every
+push to main, so it doesn't need this).
+
+Both build workflows now accept a `tag` input via `workflow_call` and
+`workflow_dispatch`. The tag-push trigger is preserved so manual
+`git push <tag>` flows still work. `release.yml`'s release job
+captures the released root tag (`vX.Y.Z`) and passes it to both build
+workflows; the chain skips when no root tag was created (sub-module-
+only release; not yet possible for monorel itself, but forward-looking).
+
+v0.1.1's missing assets are not backfilled by this change; users on
+v0.1.1 should bump to v0.1.2.

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,9 +1,40 @@
 name: build-image
+
+# Builds and pushes the multi-arch monorel container image to GHCR.
+#
+# Triggers:
+#   push (refs/tags/v*)  — fires on a "natural" tag push. Subject to
+#                          GitHub's anti-recursion rule: a tag pushed
+#                          via secrets.GITHUB_TOKEN by another
+#                          workflow does NOT trigger this event.
+#   workflow_call        — invoked from release.yml after monorel cuts
+#                          a release. Sidesteps the anti-recursion
+#                          rule and is the steady-state trigger for
+#                          monorel-driven releases.
+#   workflow_dispatch    — manual escape hatch (no input → builds
+#                          :latest only; with `tag` input → builds
+#                          versioned tags too).
+#
+# When called via workflow_call / workflow_dispatch with `tag` set,
+# the workflow checks out at that ref and tags the image accordingly.
+# Otherwise it defaults to github.ref (the pushed tag).
+
 on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.1.2)."
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.1.2). Empty → :latest only."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -14,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
@@ -27,13 +60,22 @@ jobs:
 
       - name: Compute tags
         id: tags
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME#v}"
+          # Determine which ref this run represents:
+          #   - workflow_call / workflow_dispatch with an explicit tag
+          #     input → use that.
+          #   - tag-push trigger → GITHUB_REF_NAME is the tag.
+          #   - workflow_dispatch with no tag input → just :latest.
+          ref="$INPUT_TAG"
+          if [ -z "$ref" ] && [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            ref="$GITHUB_REF_NAME"
+          fi
+          tag="${ref#v}"
           repo="ghcr.io/${GITHUB_REPOSITORY,,}"
-          # Always tag :latest for tag pushes; :vX.Y.Z and :vX.Y for
-          # version pinning. workflow_dispatch only tags :latest.
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          if [[ "$ref" == v* ]]; then
             major_minor="${tag%.*}"
             echo "tags=${repo}:latest,${repo}:${tag},${repo}:${major_minor}" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -1,8 +1,42 @@
 name: build-release-binaries
+
+# Builds and uploads release artifacts (binaries, archives, checksums)
+# to a GitHub Release via GoReleaser.
+#
+# Triggers:
+#   push (refs/tags/v*)  — fires on a "natural" tag push (e.g. user
+#                          ran `git push --tags` themselves, or the
+#                          tag was pushed via a PAT). Subject to
+#                          GitHub's anti-recursion rule: a tag pushed
+#                          via secrets.GITHUB_TOKEN by another
+#                          workflow does NOT trigger this event.
+#   workflow_call        — invoked from release.yml after monorel cuts
+#                          a release. Sidesteps the anti-recursion
+#                          rule and is the steady-state trigger for
+#                          monorel-driven releases.
+#   workflow_dispatch    — manual escape hatch for backfilling a tag
+#                          whose downstream chain didn't fire.
+#
+# When called via workflow_call / workflow_dispatch, `tag` is required
+# and selects the ref to build at. When triggered by push, the workflow
+# defaults to github.ref (the pushed tag).
+
 on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.1.2)."
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.1.2)."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,6 +48,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,34 @@
 name: release
+
+# Cuts the release after the always-open release PR is merged.
+#
+# Triggers:
+#   push (main, "chore(release):") — the release PR's merge commit
+#     subject by monorel convention. The non-chore-release pushes are
+#     filtered out via the if guard on the `release` job.
+#   workflow_dispatch — manual escape hatch (the v0.1.0 bootstrap path).
+#
+# Pipeline (release job):
+#   1. monorel release       — write CHANGELOGs, delete consumed
+#                              .changeset/*.md, create the release
+#                              commit, create per-package tags locally.
+#   2. git push --follow-tags — push commit + tags to the remote so
+#                              the forge can validate them.
+#   3. monorel publish       — create one GitHub Release per tag,
+#                              body sourced from each tag's CHANGELOG
+#                              entry.
+#
+# Then build-binaries and build-image fire as workflow_call jobs
+# gated on the release job having cut a root-module (`vX.Y.Z`) tag.
+# Both are called inline rather than via the natural tag-push event:
+# secrets.GITHUB_TOKEN-driven tag pushes are subject to GitHub's
+# anti-recursion rule and don't propagate to push-triggered workflows.
+# The workflow_call path is the supported sidestep.
+
 on:
-  # Manual dispatch + on push of a `chore(release):` commit (the
-  # release PR's merge commit). Manual dispatch is the bootstrap path
-  # before v0.1.0; once monorel-driven releases are in place, the push
-  # path takes over.
-  workflow_dispatch:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -15,6 +37,13 @@ jobs:
   release:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
+    outputs:
+      # Latest bare vX.Y.Z tag created by `monorel release`. Empty when
+      # the release was sub-module-only (no root tag); the chained
+      # build jobs skip themselves in that case. monorel itself is
+      # single-package today, so this output is always set on a real
+      # release; the empty-output path is forward-looking.
+      root_tag: ${{ steps.root_tag.outputs.root_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,3 +71,38 @@ jobs:
           go run ./cmd/monorel release
           git push --follow-tags
           go run ./cmd/monorel publish
+
+      - name: Capture root tag
+        id: root_tag
+        # Pick the latest bare vX.Y.Z tag that points at the just-
+        # pushed release commit. Sub-module tags (path/vX.Y.Z) are
+        # excluded by the regex; if none of the released tags match,
+        # the output is empty and the chained build jobs skip.
+        run: |
+          set -euo pipefail
+          root_tag=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+          echo "root_tag=${root_tag}" >> "$GITHUB_OUTPUT"
+          if [ -n "$root_tag" ]; then
+            echo "Root module released as $root_tag; chaining build-binaries + build-image."
+          else
+            echo "No root tag at HEAD; build-binaries + build-image will skip."
+          fi
+
+  build-binaries:
+    needs: release
+    if: ${{ needs.release.result == 'success' && needs.release.outputs.root_tag != '' }}
+    uses: ./.github/workflows/build-release-binaries.yml
+    with:
+      tag: ${{ needs.release.outputs.root_tag }}
+    permissions:
+      contents: write
+
+  build-image:
+    needs: release
+    if: ${{ needs.release.result == 'success' && needs.release.outputs.root_tag != '' }}
+    uses: ./.github/workflows/build-image.yml
+    with:
+      tag: ${{ needs.release.outputs.root_tag }}
+    permissions:
+      contents: read
+      packages: write


### PR DESCRIPTION
## Summary

Surfaced by v0.1.1's empty GitHub Release: tag and Release page exist, but no binaries are attached and no image was pushed to GHCR. Same root cause as the docs-deploy `workflow_call` workaround — GitHub's anti-recursion rule suppresses `push: tags` events when the tag was pushed via `GITHUB_TOKEN` from another workflow run. v0.1.0 was unaffected because it was cut via `workflow_dispatch` (user-initiated).

## Fix

`release.yml` now chains both build workflows via `workflow_call` after the release job, gated on whether a root-module (`vX.Y.Z`) tag was actually cut. Both build workflows accept a `tag` input via `workflow_call` and `workflow_dispatch`; the natural `push: tags` trigger is preserved for direct-`git push` flows.

```yaml
# release.yml after the release job
build-binaries:
  needs: release
  if: \${{ needs.release.result == 'success' && needs.release.outputs.root_tag != '' }}
  uses: ./.github/workflows/build-release-binaries.yml
  with:
    tag: \${{ needs.release.outputs.root_tag }}
build-image:
  needs: release
  if: \${{ needs.release.result == 'success' && needs.release.outputs.root_tag != '' }}
  uses: ./.github/workflows/build-image.yml
  with:
    tag: \${{ needs.release.outputs.root_tag }}
```

The release job captures `root_tag` from `git tag --points-at HEAD | grep '^v[0-9]+\.[0-9]+\.[0-9]+$'`. Sub-module tags (`<path>/vX.Y.Z`) don't trigger the chain — both build workflows are root-module concerns.

## v0.1.1 status

v0.1.1 was published with no binaries and no image. Backfilling those assets is out of scope here; consumers on v0.1.1 should bump to v0.1.2 once this lands. Future-PR could either delete v0.1.1's empty Release or run goreleaser locally to upload the missing artifacts; not blocking.

## Test plan

- [x] All three build workflows still accept their original triggers (regression check via YAML structure).
- [ ] After merge, the always-open release PR opens for v0.1.2.
- [ ] Merging that PR: `release.yml` cuts the tag, `build-binaries` and `build-image` fire as `workflow_call` jobs, v0.1.2 ships with full assets.
- [ ] loglayer-go bumps to `disaresta-org/monorel/ci/github@v0.1.2` and the smoke-test PR pipeline completes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)