### PR TITLE
fix(ci): deploy docs only on release, not on every push to main

### DIFF
--- a/.changeset/docs-deploy-on-release.md
+++ b/.changeset/docs-deploy-on-release.md
@@ -1,0 +1,25 @@
+---
+"monorel.disaresta.com": patch
+---
+
+Deploy docs only on release, not on every push to main.
+
+Previously `docs.yml` deployed to GitHub Pages on every push to `main`,
+which meant any merge — even a typo fix in a Go file unrelated to
+docs — would re-deploy the site. Switch the deploy gate to match
+the loglayer-go pattern:
+
+- `pull_request` (paths-filtered to `docs/**`): build-only, for
+  verification that the site still builds.
+- `release: published`: deploy on manually-created GitHub Releases.
+- `workflow_dispatch`: manual escape hatch.
+- `workflow_call`: invoked from `release.yml` after a monorel-driven
+  release is cut. Sidesteps GitHub's anti-recursion rule (Releases
+  created via `GITHUB_TOKEN` don't propagate `release: published`
+  events to other workflows).
+
+`release.yml` chains `docs.yml` via `workflow_call` alongside the
+existing `build-binaries` and `build-image` chains, so every
+monorel-driven release deploys the docs that go with it. No
+deployment fires for non-release commits to main, even if they
+touch `docs/**`.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,31 @@
 name: docs
+
+# Builds the VitePress docs site and deploys it to GitHub Pages.
+#
+# Triggers:
+#   pull_request    — build only (no deploy), to verify the site
+#                     still builds when docs change. Path-filtered to
+#                     docs/** so unrelated PRs don't run this.
+#   release         — covers manually-created GitHub Releases. Releases
+#                     created by monorel via GITHUB_TOKEN don't
+#                     propagate this event (GitHub anti-recursion);
+#                     those flow through workflow_call from release.yml.
+#   workflow_dispatch — manual escape hatch ("redeploy current main").
+#   workflow_call   — invoked from release.yml after a monorel-driven
+#                     release is cut, so monorel-driven releases are
+#                     covered without the anti-recursion suppression.
+#
+# Cadence is "deploy on release," not "deploy on every commit to main."
+
 on:
-  push:
-    branches: [main]
   pull_request:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
@@ -13,7 +33,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: docs-${{ github.ref }}
+  group: pages
   cancel-in-progress: false
 
 jobs:
@@ -35,12 +55,12 @@ jobs:
         run: bun run docs:build
 
       - uses: actions/upload-pages-artifact@v3
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         with:
           path: docs/.vitepress/dist
 
   deploy:
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,15 @@ jobs:
             echo "No root tag at HEAD; build-binaries + build-image will skip."
           fi
 
+  deploy-docs:
+    needs: release
+    if: ${{ needs.release.result == 'success' }}
+    uses: ./.github/workflows/docs.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
   build-binaries:
     needs: release
     if: ${{ needs.release.result == 'success' && needs.release.outputs.root_tag != '' }}


### PR DESCRIPTION
## Summary

Tightens monorel's docs-deploy cadence from "on every push to main" to "on release only," matching loglayer-go's pattern.

## What changes

- **`docs.yml` triggers:** drop `push: branches: [main]`. Add `release: published`, `workflow_dispatch`, and `workflow_call`. PR builds stay (path-filtered to `docs/**`) for clean-build verification.
- **`release.yml`:** chain `docs.yml` via `workflow_call` after the release job, alongside the existing `build-binaries` and `build-image` chains.

## Why

Today every merge into main re-deploys the site, even pure Go changes. The natural cadence for static docs is "deploy when there's something to release" — and that's now what monorel does, with the same `workflow_call` sidestep already used for the build chains (since `GITHUB_TOKEN`-created Releases don't propagate `release: published` events).

## Bundling with v0.1.2

This will land alongside the asset-chain fix from PR #3. After merge, the `release-pr` workflow updates the open release PR (#4) to bundle both changesets at v0.1.2 (max bump across changesets is `:patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)