### PR TITLE
docs: replace loglayer-go recipe placeholder with real outcome

### DIFF
--- a/docs/src/recipes/loglayer-go.md
+++ b/docs/src/recipes/loglayer-go.md
@@ -1,29 +1,50 @@
 ---
-title: "loglayer-go: a 25-module migration"
-description: "Worked example of migrating loglayer-go from release-please to monorel. 25 sub-modules, mixed tag prefixes, hard-cut CHANGELOG."
+title: "loglayer-go: a 26-package migration"
+description: "Worked example of migrating loglayer-go from release-please to monorel. 25 sub-modules + 1 root, mixed tag prefixes, hard-cut CHANGELOG. Real outcome with PR links."
 ---
 
-# loglayer-go: a 25-module migration
+# loglayer-go: a 26-package migration
 
-`loglayer-go` is the repo whose release-please saga prompted monorel's existence. It has 25 modules: one main module at the repo root with bare `vX.Y.Z` tags, plus 24 sub-modules under `transports/`, `plugins/`, and `integrations/`.
+`loglayer-go` is the repo whose release-please saga prompted monorel's existence. It has 26 packages: one root module at the repo root with bare `vX.Y.Z` tags, plus 25 sub-modules under `transports/`, `plugins/`, and `integrations/` with `<path>/vX.Y.Z` tags. The migration completed end-to-end on 2026-05-01.
 
-This page walks through the migration as a worked example.
-
-::: warning Pending
-This recipe is a placeholder until the loglayer-go migration actually happens. The shape below is the intended outcome; commit-by-commit details land here once monorel itself reaches v1 and the migration is performed.
-:::
+The outcome surfaced two CI gaps in monorel itself, which were fixed in v0.1.1 and v0.1.2 mid-migration. This page walks through the actual sequence rather than the idealized version.
 
 ## Starting state
 
-- Tag history: bare `vX.Y.Z` for the main module, `<path>/vX.Y.Z` for sub-modules.
-- `.release-please-config.json` with 25 packages.
+- Tag history: bare `vX.Y.Z` for the root module (latest `v1.6.2`), `<path>/vX.Y.Z` for sub-modules (most at `v1.6.1`, a few at `v1.6.2` / `v1.0.0` / `v1.1.1` / `v1.2.0`).
+- `.release-please-config.json` with 26 packages.
 - `.release-please-manifest.json` with current per-package versions.
-- A root `CHANGELOG.md` and per-sub-module `CHANGELOG.md` files, all release-please-formatted.
-- Release workflows under `.github/workflows/release-please*.yml`.
+- A root `CHANGELOG.md` and per-sub-module `CHANGELOG.md` files. 13 of them have hand-written preambles referencing release-please by name; the other 13 are bare release-please-generated files.
+- Release workflows under `.github/workflows/release-please*.yml` (main + cleanup), plus a `release-please-state` pre-push lefthook hook backed by `scripts/check-release-please-state.sh`.
+- AGENTS.md sections covering the release-please workflow, the "release-please gotchas" we accumulated, and the multi-step "adding a new transport" recipe with release-please-specific steps.
 
-## Generated `monorel.toml`
+## Pre-merge audit
 
-A snippet (the full file has 25 package blocks):
+Before opening the migration PR, every package's latest tag was scripted-checked against the manifest. All 26 matched exactly:
+
+```
+PACKAGE                   MANIFEST  LATEST_TAG  STATUS
+.                         1.6.2     1.6.2       MATCH
+integrations/loghttp      1.2.0     1.2.0       MATCH
+integrations/sloghandler  1.1.1     1.1.1       MATCH
+plugins/datadogtrace      1.6.1     1.6.1       MATCH
+plugins/fmtlog            1.6.1     1.6.1       MATCH
+plugins/oteltrace         1.6.1     1.6.1       MATCH
+plugins/plugintest        1.0.0     1.0.0       MATCH
+plugins/redact            1.6.1     1.6.1       MATCH
+plugins/sampling          1.6.1     1.6.1       MATCH
+transports/blank          1.6.1     1.6.1       MATCH
+transports/charmlog       1.6.1     1.6.1       MATCH
+…  (all 26 matched)
+```
+
+A mismatch would have meant either the manifest was stale (safe to proceed; monorel's planner would pick the correct tag) or the latest tag was wrong (would have required deletion before merge). Neither case applied here.
+
+## The migration PR
+
+[loglayer/loglayer-go#44](https://github.com/loglayer/loglayer-go/pull/44) — single commit, all 25 modified files plus 4 added and 5 deleted.
+
+Generated `monorel.toml` mirrors the previous manifest 1:1 in the same order so the diff reviews as "delete config, add toml":
 
 ```toml
 [forge]
@@ -41,58 +62,69 @@ tag_prefix = "transports/zerolog"
 path       = "transports/zerolog"
 changelog  = "transports/zerolog/CHANGELOG.md"
 
-[packages."transports/zap"]
-tag_prefix = "transports/zap"
-path       = "transports/zap"
-changelog  = "transports/zap/CHANGELOG.md"
-
-# ... 22 more ...
+# … 24 more ...
 ```
 
-## Verification before merge
+Workflow swap: `release-please.yml` + `release-please-cleanup.yml` deleted; `release-pr.yml` + `release.yml` added, both wrapping `disaresta-org/monorel/ci/github`.
 
-```sh
-monorel plan
-# No pending changesets. Nothing to release.
+Prose rewrite: AGENTS.md release sections, README.md, CONTRIBUTING.md, package.json, `.claude/rules/documentation.md`, `scripts/lint-commit.mjs` all dropped "the same parser release-please uses" framing in favour of describing the conventional-commit linter on its own terms (releases are driven by changesets, not commit messages, so the lint stands on its own as a hygiene tool).
 
-# Spot-check: planner picks v1.6.1 for transports/zerolog
-git tag --list 'transports/zerolog/v*' | sort -V | tail -3
-# transports/zerolog/v1.6.1
-# transports/zerolog/v1.6.0
-# transports/zerolog/v1.5.0
+13 per-package CHANGELOG.md preambles (the ones that referenced release-please by name) were rewritten to point at monorel; the 13 release-please-generated bare CHANGELOGs were left alone.
+
+The PR shipped no `.changeset/*.md` files — the migration is tooling-only, not a release. The first real release happens in a follow-up PR.
+
+## Mid-migration: two monorel fixes
+
+The follow-up smoke-test PR ([loglayer-go#45](https://github.com/loglayer/loglayer-go/pull/45)) added a single `:patch` changeset on `transports/blank` (the lowest-blast-radius package — a no-op template transport). Merging it should have opened the always-open release PR. It didn't:
+
+```
+orchestrator: create PR: 422 Validation Failed [Field:head Code:invalid]
 ```
 
-The planner's "From" should match `release-please-manifest.json[transports/zerolog]` for every package.
+GitHub's PR-create API rejects PRs whose head branch doesn't exist on the remote. Monorel v0.1.0's CI wrapper documented "branch staging is a follow-up" but the always-open pattern fundamentally requires the branch to exist before the orchestrator can call CreatePR. loglayer-go was the first repo to surface this.
 
-## After merge
+### v0.1.1: branch staging
 
-The next time someone bumps a transport's API:
+[disaresta-org/monorel#1](https://github.com/disaresta-org/monorel/pull/1) — `ci/github/action.yml` and `.github/workflows/release-pr.yml` (monorel's own self-hosted version) now create `monorel/release` from `origin/<default-branch>` plus one empty marker commit before invoking `monorel preview --upsert`. The branch's diff stays empty by design — the rendered plan goes in the PR body.
 
-```sh
-monorel add \
-  --package "transports/zerolog:minor" \
-  --message "Adds Lazy() helper for deferred field evaluation."
-```
+The fix self-validated: merging PR #1 ran `release-pr` on monorel's main, which staged the branch successfully and opened monorel's first-ever monorel-driven release PR for v0.1.1.
 
-The release PR updates automatically on push to `main`. Merging it produces:
+### v0.1.2: workflow_call asset chain
 
-- Tag `transports/zerolog/v1.7.0`.
-- Entry in `transports/zerolog/CHANGELOG.md` under `## [1.7.0] - YYYY-MM-DD` / `### Minor Changes`.
-- A GitHub Release for `transports/zerolog/v1.7.0` with the body sourced from the changeset.
+v0.1.1's tag and GitHub Release were created, but the release had no binary assets attached and no GHCR image was pushed. Same anti-recursion gap that `docs.yml` already worked around: GitHub's `GITHUB_TOKEN` doesn't propagate `push: tags` events to other workflows, so `build-release-binaries.yml` and `build-image.yml` silently didn't fire. v0.1.0 was unaffected only because it was cut via `workflow_dispatch` (a user-initiated run that doesn't trip anti-recursion).
 
-The other 24 packages don't release; they have no pending changesets.
+[disaresta-org/monorel#3](https://github.com/disaresta-org/monorel/pull/3) chained both build workflows from `release.yml` via `workflow_call`, mirroring how `docs.yml` is chained. Both build workflows now accept a `tag` input via `workflow_call` and `workflow_dispatch`; the natural `push: tags` trigger is preserved for direct-`git push` flows.
 
-## What stays unchanged
+[disaresta-org/monorel#5](https://github.com/disaresta-org/monorel/pull/5) bundled in: `docs.yml` switched from "deploy on every push to main" to "deploy on release / dispatch / workflow_call," and `release.yml` now also chains `docs.yml` so monorel-driven releases trigger the docs deploy directly.
+
+Both fixes shipped in v0.1.2. v0.1.1 is left as-is — released but assetless. Consumers should pin to v0.1.2 directly.
+
+## Wrapping up the migration
+
+[loglayer-go#46](https://github.com/loglayer/loglayer-go/pull/46) bumped both action wrapper pins from `@v0.1.0` to `@v0.1.2`. After merge, the `release-pr` workflow ran cleanly on the smoke-test merge commit, staged `monorel/release`, picked up the changeset, and opened the always-open release PR.
+
+[loglayer-go#47](https://github.com/loglayer/loglayer-go/pull/47) — `chore(release): transports/blank v1.6.2` — was loglayer-go's first monorel-driven release PR. Merging it ran `release.yml`'s pipeline:
+
+- `monorel release`: wrote `transports/blank/CHANGELOG.md` entry, deleted the changeset, created the release commit and tag locally.
+- `git push --follow-tags`: pushed both to origin.
+- `monorel publish`: created the GitHub Release with the rendered changelog body.
+- `deploy-docs / Build` + `deploy-docs / Deploy to GitHub Pages`: docs site rebuilt and deployed via `workflow_call`.
+
+All four jobs green; tag `transports/blank/v1.6.2` lands on origin. The `workflow_call` docs-deploy chain — flagged as unverified in the migration spec — works as designed without requiring a Personal Access Token.
+
+## What stayed unchanged
 
 - Every existing tag.
 - Every existing GitHub Release.
-- The hand-written `[Unreleased]` section in the root CHANGELOG (if present).
-- The release-please-style headers for prior versions.
+- All 26 CHANGELOG.md historical entries (verbatim below the rewritten preambles).
+- The hand-written `[Unreleased]` section in the root CHANGELOG.
 
 monorel inserts new entries above the existing content; it never rewrites old entries.
 
-## Trade-offs the migration confirmed
+## Take-aways
 
-- **No tool can save you from forgetting the changeset.** Reviewers have to enforce "every release-affecting PR has a changeset" the way they previously enforced "every release-affecting PR has the right Conventional Commits subject."
-- **The CHANGELOG format split is real.** Pre-migration entries look different from post-migration entries. After a year, this is barely visible (only old entries diverge). Day-of, it's noticeable.
-- **The release PR's commit subject format changes** (release-please's `chore(main): release X` → monorel's `chore(release): X`). If you have automation keying on the old subject, update it.
+- **The CI-wrapper layer is where the always-open PR pattern needs branch staging.** The orchestrator's `Run` doc explicitly delegates branch management to the wrapper because git is shell-out-friendly there. Putting it in Go was tempting but unnecessary; v0.1.1 fixed it where it belongs.
+- **Anti-recursion-safe chaining matters for every downstream workflow.** Docs deploy was the known case; binary builds and image pushes weren't. Once one downstream chain is `workflow_call`-shaped, the others probably should be too.
+- **Self-hosting catches gaps fast.** monorel's first PR (PR #1) and first changeset-driven release (v0.1.1) both surfaced bugs no one would have hit unless they actually used the always-open PR pattern. Bootstrap-via-`workflow_dispatch` doesn't exercise either path.
+- **No tool removes the changeset discipline.** Reviewers still have to enforce "every release-affecting PR has a changeset," the way they previously enforced "every release-affecting PR has a Conventional Commits subject the parser could read."
+- **The CHANGELOG format split is real but localized.** Pre-migration entries are release-please-formatted (`## [1.6.1] (compare) (date)`); post-migration entries are Keep-a-Changelog (`## [1.7.0] - 2026-05-01` / `### Minor Changes`). Both render fine on GitHub. After a year, only the oldest entries look different.


### PR DESCRIPTION
## Summary

Replaces the `::: warning Pending` placeholder in `docs/src/recipes/loglayer-go.md` with the real migration outcome. Documents the actual sequence (including the two monorel patches surfaced mid-migration), not the idealized version.

## What's covered

- Pre-merge audit (all 26 packages' tags matched the manifest).
- The migration PR (loglayer-go#44) with file-list breakdown.
- Mid-migration: v0.1.1 (branch staging in CI wrapper) and v0.1.2 (workflow_call asset chain + docs-deploy on release), with links to monorel#1, #3, #5.
- The smoke-test PR (loglayer-go#45), action-pin bump (#46), first monorel-driven release PR (#47), and the resulting `transports/blank/v1.6.2` tag.
- Take-aways including: CI wrapper is the right layer for branch staging, anti-recursion-safe chaining for every downstream workflow, self-hosting catches gaps fast.

## No changeset

This is a docs-only change. After merge, `gh workflow run docs.yml --repo disaresta-org/monorel` deploys the updated recipe; otherwise it ships with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)