### PR TITLE
docs: review-feedback fixes for the loglayer-go recipe + squash-merge UI labels

### DIFF
--- a/docs/src/github-action.md
+++ b/docs/src/github-action.md
@@ -177,12 +177,13 @@ Recommended settings for the default branch:
 The release PR is special: monorel's `chore(release):` commit subject must reach `main` for `release.yml` to trigger. Squash-merging the release PR produces a single `chore(release): ...` commit; rebase-merging produces the same. Both work; just don't squash-merge into a different subject.
 
 ::: warning Squash-merge subject inheritance
-By default, the marker commit on the staged head branch carries the subject `chore(release): always-open release PR marker`. When you squash-merge the release PR, GitHub picks the squash subject from one of two sources depending on repo settings:
+By default, the marker commit on the staged head branch carries the subject `chore(release): always-open release PR marker`. When you squash-merge the release PR, GitHub picks the squash subject from one of four options under repo Settings → "Default commit message for squash merging":
 
-- **"Default to pull request title"**: the squash subject is the orchestrator-set PR title (e.g. `chore(release): transports/blank v1.6.2`). This is the cleaner outcome.
-- **"Default commit message"** (legacy): the squash subject is the marker commit's subject (e.g. `chore(release): always-open release PR marker`). Functionally equivalent — both start with `chore(release):` so `release.yml` fires either way — but visually less informative.
+- **`Default message`** (the legacy setting): the squash subject is the marker commit's subject when the PR has a single commit, e.g. `chore(release): always-open release PR marker`. Functionally fine, visually less informative.
+- **`Pull request title`** (recommended): the squash subject is the orchestrator-set PR title, e.g. `chore(release): transports/blank v1.6.2`. Cleaner.
+- **`Pull request title and commit details`** / **`Pull request title and description`**: the subject is the PR title (same as above); the body of the squash commit pulls in either the commits or the PR description. Either of these is fine for monorel.
 
-Set the repo's squash-merge default to "pull request title" to get the better-named merge commits. Either setting works for the release pipeline itself.
+The release pipeline works with any of the four — both the marker subject and the orchestrator-set PR title start with `chore(release):`, which is what `release.yml` filters on. Pick `Pull request title` (or one of the variants that uses it) so the merged commit carries the version-specific name instead of the generic marker text.
 :::
 
 ## Troubleshooting

--- a/docs/src/recipes/loglayer-go.md
+++ b/docs/src/recipes/loglayer-go.md
@@ -11,10 +11,10 @@ The outcome surfaced two CI gaps in monorel itself, which were fixed in v0.1.1 a
 
 ## Starting state
 
-- Tag history: bare `vX.Y.Z` for the root module (latest `v1.6.2`), `<path>/vX.Y.Z` for sub-modules (most at `v1.6.1`, a few at `v1.6.2` / `v1.0.0` / `v1.1.1` / `v1.2.0`).
+- Tag history: bare `vX.Y.Z` for the root module (latest `v1.6.2`); `<path>/vX.Y.Z` for sub-modules (most at `v1.6.1`, with outliers at `v1.0.0` for `transports/gcplogging` and `plugins/plugintest`, `v1.1.1` for `integrations/sloghandler`, and `v1.2.0` for `integrations/loghttp`). No sub-module is at `v1.6.2`; that's the root's version.
 - `.release-please-config.json` with 26 packages.
 - `.release-please-manifest.json` with current per-package versions.
-- A root `CHANGELOG.md` and per-sub-module `CHANGELOG.md` files. 13 of them have hand-written preambles referencing release-please by name; the other 13 are bare release-please-generated files.
+- 25 `CHANGELOG.md` files in the tree (root + 24 sub-modules). 13 of them have hand-written preambles referencing release-please by name; the other 12 are bare release-please-generated files. The 26th package, `plugins/plugintest`, has never been released and has no `CHANGELOG.md` to migrate.
 - Release workflows under `.github/workflows/release-please*.yml` (main + cleanup), plus a `release-please-state` pre-push lefthook hook backed by `scripts/check-release-please-state.sh`.
 - AGENTS.md sections covering the release-please workflow, the "release-please gotchas" we accumulated, and the multi-step "adding a new transport" recipe with release-please-specific steps.
 
@@ -42,7 +42,7 @@ A mismatch would have meant either the manifest was stale (safe to proceed; mono
 
 ## The migration PR
 
-[loglayer/loglayer-go#44](https://github.com/loglayer/loglayer-go/pull/44) — single commit, all 25 modified files plus 4 added and 5 deleted.
+[loglayer/loglayer-go#44](https://github.com/loglayer/loglayer-go/pull/44) — single commit: 25 modified, 5 added, 5 deleted.
 
 Generated `monorel.toml` mirrors the previous manifest 1:1 in the same order so the diff reviews as "delete config, add toml":
 
@@ -69,7 +69,7 @@ Workflow swap: `release-please.yml` + `release-please-cleanup.yml` deleted; `rel
 
 Prose rewrite: AGENTS.md release sections, README.md, CONTRIBUTING.md, package.json, `.claude/rules/documentation.md`, `scripts/lint-commit.mjs` all dropped "the same parser release-please uses" framing in favour of describing the conventional-commit linter on its own terms (releases are driven by changesets, not commit messages, so the lint stands on its own as a hygiene tool).
 
-13 per-package CHANGELOG.md preambles (the ones that referenced release-please by name) were rewritten to point at monorel; the 13 release-please-generated bare CHANGELOGs were left alone.
+13 per-package `CHANGELOG.md` preambles (the ones that referenced release-please by name) were rewritten to point at monorel; the 12 release-please-generated bare `CHANGELOG.md` files were left alone. `plugins/plugintest` had no `CHANGELOG.md` to touch (no prior releases).
 
 The PR shipped no `.changeset/*.md` files — the migration is tooling-only, not a release. The first real release happens in a follow-up PR.
 
@@ -116,7 +116,7 @@ All four jobs green; tag `transports/blank/v1.6.2` lands on origin. The `workflo
 
 - Every existing tag.
 - Every existing GitHub Release.
-- All 26 CHANGELOG.md historical entries (verbatim below the rewritten preambles).
+- All 25 existing `CHANGELOG.md` historical entries (verbatim below the rewritten preambles).
 - The hand-written `[Unreleased]` section in the root CHANGELOG.
 
 monorel inserts new entries above the existing content; it never rewrites old entries.


### PR DESCRIPTION
## Summary

Fixes five factual issues caught by code review on PR #6 (recipe) and PR #7 (template), both of which already merged. None affect the release pipeline; all are docs accuracy.

## recipes/loglayer-go.md (4 fixes from PR #6 review)

- **Sub-module version list dropped \`v1.6.2\`.** v1.6.2 is the root's version; no sub-module is at it. The outliers are now named individually: \`v1.0.0\` for \`transports/gcplogging\` and \`plugins/plugintest\`, \`v1.1.1\` for \`integrations/sloghandler\`, \`v1.2.0\` for \`integrations/loghttp\`.
- **CHANGELOG count math was wrong.** "13 of them have hand-written preambles; the other 13 are bare release-please-generated" sums to 26, but only 25 \`CHANGELOG.md\` files exist in the tree. \`plugins/plugintest\` has never released and has no \`CHANGELOG.md\` to migrate. Real count: 13 hand-written preambles + 12 release-please-generated bare files = 25.
- **File-ops count off by one.** "25 modified files plus 4 added and 5 deleted" → actual stats are 25 modified, **5** added, 5 deleted. The 5 added are \`.changeset/README.md\`, \`release-pr.yml\`, \`release.yml\`, the migration design spec, and \`monorel.toml\`.
- **"All 26 CHANGELOG.md historical entries"** in the "What stayed unchanged" section → "All 25 existing".

## github-action.md (1 fix from PR #7 review)

The squash-merge subject-inheritance warning referenced GitHub option names that don't exist as labels in the actual UI ("Default to pull request title" / "Default commit message"). GitHub's real labels under repo Settings → "Default commit message for squash merging" are:

- \`Default message\` (legacy)
- \`Pull request title\`
- \`Pull request title and commit details\`
- \`Pull request title and description\`

All four work for the release pipeline (both the marker subject and the orchestrator PR title start with \`chore(release):\`). Recommended: \`Pull request title\` (or any variant that uses it) for the cleanest merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)