### PR TITLE
fix(ci): drop monorel publish from monorel's own release.yml

### DIFF
--- a/.changeset/release-yml-skip-publish.md
+++ b/.changeset/release-yml-skip-publish.md
@@ -1,0 +1,39 @@
+---
+"monorel.disaresta.com": patch
+---
+
+Drop `monorel publish` from monorel's own release.yml.
+
+v0.2.0 surfaced a fatal interaction between `monorel publish` and
+goreleaser when both run in the same release pipeline:
+
+1. `monorel publish` creates the GitHub Release for the new tag,
+   with a body sourced from the rendered CHANGELOG entry.
+2. `build-binaries` runs goreleaser via `workflow_call`. Goreleaser
+   sees the existing release, attempts to PATCH it to attach the
+   built binaries, and (in recent goreleaser versions hitting
+   GitHub's new immutable-release feature) flips the release to
+   `immutable: true` as a side effect of the PATCH.
+3. Subsequent uploads fail with `422 Cannot upload assets to an
+   immutable release`.
+
+Once a tag has been used by an immutable release, GitHub permanently
+retains the tag name even if the release is deleted: no new release
+can be created with the same tag. v0.2.0 is therefore stuck without
+binaries; consumers should pin to v0.2.1 or later for the action
+wrapper.
+
+Fix: monorel's own release.yml lets goreleaser own release creation.
+The release job runs `monorel release` + `git push --follow-tags`
+only; goreleaser (via build-binaries) creates the release with its
+binary uploads in one step.
+
+Trade-off: monorel's own GitHub Release bodies are goreleaser's
+auto-generated commit list rather than the curated CHANGELOG entry.
+The per-package CHANGELOG.md still contains the curated entry; this
+only affects the body shown on the GitHub Release UI.
+
+This fix is monorel-self-hosting-specific. Other consumers
+(loglayer-go and similar) call the action wrapper, which still runs
+`monorel publish`. Those repos keep producing curated release bodies
+because they don't run goreleaser as part of their release flow.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,15 @@
 name: release
 
-# Cuts the release after the always-open release PR is merged.
+# Cuts monorel's own release after the always-open release PR is merged.
+# Self-hosted: this workflow is monorel-specific. Other consumers go
+# through the disaresta-org/monorel/ci/github composite action, which
+# does call `monorel publish` (since they don't run goreleaser
+# themselves; their releases need monorel publish to set bodies and
+# create the GitHub Release in the first place).
 #
 # Triggers:
 #   push (main, "chore(release):") — the release PR's merge commit
-#     subject by monorel convention. The non-chore-release pushes are
+#     subject by monorel convention. Non-chore-release pushes are
 #     filtered out via the if guard on the `release` job.
 #   workflow_dispatch — manual escape hatch (the v0.1.0 bootstrap path).
 #
@@ -12,15 +17,28 @@ name: release
 #   1. monorel release       — write CHANGELOGs, delete consumed
 #                              .changeset/*.md, create the release
 #                              commit, create per-package tags locally.
-#   2. git push --follow-tags — push commit + tags to the remote so
-#                              the forge can validate them.
-#   3. monorel publish       — create one GitHub Release per tag,
-#                              body sourced from each tag's CHANGELOG
-#                              entry.
+#   2. git push --follow-tags — push commit + tags to the remote.
 #
-# Then build-binaries and build-image fire as workflow_call jobs
-# gated on the release job having cut a root-module (`vX.Y.Z`) tag.
-# Both are called inline rather than via the natural tag-push event:
+# Notice the absence of `monorel publish`: monorel's own pipeline lets
+# goreleaser (in build-binaries) create the GitHub Release in one step
+# along with uploading binaries. v0.2.0 surfaced a fatal interaction
+# between `monorel publish` and goreleaser's recent versions — once
+# monorel publish creates the release, goreleaser's PATCH to attach
+# binaries flips it to GitHub's new immutable-release state, and the
+# upload then fails 422 ("Cannot upload assets to an immutable release").
+# Even deleting the immutable release doesn't free the tag-name
+# (GitHub permanently retains it). Letting goreleaser own release
+# creation avoids the conflict entirely.
+#
+# Trade-off: monorel's own GitHub Release bodies are goreleaser's
+# auto-generated commit list, not the curated CHANGELOG entry.
+# CHANGELOG.md still gets the curated entry via `monorel release`.
+# Other consumers (loglayer-go) keep getting curated bodies because
+# they call the action wrapper, which runs `monorel publish`.
+#
+# build-binaries and build-image fire as workflow_call jobs gated on
+# the release job having cut a root-module (`vX.Y.Z`) tag. Both are
+# called inline rather than via the natural tag-push event:
 # secrets.GITHUB_TOKEN-driven tag pushes are subject to GitHub's
 # anti-recursion rule and don't propagate to push-triggered workflows.
 # The workflow_call path is the supported sidestep.
@@ -63,14 +81,14 @@ jobs:
       - name: monorel release pipeline
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Order matters: tags must exist on the remote before the
-        # forge can validate them when creating the Release. See
-        # ci/github/README.md "Inputs" for the rationale.
+        # Note the absence of `monorel publish` (see workflow header
+        # comment for why). build-binaries chains downstream and lets
+        # goreleaser create the GitHub Release with its assets in one
+        # step.
         run: |
           set -euo pipefail
           go run ./cmd/monorel release
           git push --follow-tags
-          go run ./cmd/monorel publish
 
       - name: Capture root tag
         id: root_tag


### PR DESCRIPTION
## Summary

v0.2.0 surfaced a fatal interaction between \`monorel publish\` and goreleaser when both run in the same release pipeline:

1. \`monorel publish\` creates the GitHub Release for the new tag with the curated CHANGELOG body.
2. The chained \`build-binaries\` workflow_call runs goreleaser. Goreleaser sees the existing release, attempts to PATCH it to attach the built binaries.
3. The PATCH (under GitHub's new immutable-releases feature) flips the release to \`immutable: true\` as a side effect.
4. Subsequent uploads fail with \`422 Cannot upload assets to an immutable release\`.

Once a tag has been used by an immutable release, GitHub permanently retains the tag name. Even deleting the immutable release doesn't free it; no new release can be created at the same tag. **v0.2.0 is consequently stuck without binaries** — consumers should pin to v0.2.1+.

## Fix

monorel's own \`release.yml\` lets goreleaser own release creation. The release job runs \`monorel release\` + \`git push --follow-tags\` only; goreleaser (via the \`build-binaries\` workflow_call chain) creates the GitHub Release together with the binary uploads in one step.

## Trade-off

monorel's own GitHub Release body on the UI is goreleaser's auto-generated commit list, rather than the curated CHANGELOG entry. \`CHANGELOG.md\` itself still contains the curated entry. Acceptable for monorel-the-project's own releases; users can always read the per-version detail in CHANGELOG.md.

## Other consumers are not affected

The action wrapper at \`disaresta-org/monorel/ci/github\` still runs \`monorel publish\`. Repos that use the action wrapper (loglayer-go and similar) don't run goreleaser as part of their release flow, so the immutable-release conflict doesn't arise. Their releases keep getting curated bodies.

## v0.2.0 cleanup

- v0.2.0 git tag stays on origin. \`go install monorel.disaresta.com/cmd/monorel@v0.2.0\` works (Go module proxy cached the tag).
- The v0.2.0 GitHub Release is gone (the immutable original was deleted; the workaround draft was un-publishable).
- The \`disaresta-org/monorel/ci/github@v0.2.0\` action wrapper is broken because it can't download the binary. Consumers should pin to \`@v0.2.1\` once it lands.
- Will edit a forwarding note onto v0.2.0's would-be release page if GitHub permits a placeholder; otherwise document via release notes on v0.2.1.

## Test plan

- [ ] Merge this PR.
- [ ] Open release PR proposes v0.2.1.
- [ ] Merge release PR. Watch:
  - \`release\` job runs \`monorel release\` + push (no publish). ✓
  - \`build-binaries\` runs goreleaser → creates v0.2.1 release with all 7 assets, mutable.
  - \`build-image\` pushes ghcr image.
  - \`deploy-docs\` runs.
- [ ] Verify \`gh release view v0.2.1 --repo disaresta-org/monorel --json assets\` shows 7 assets.
- [ ] Verify \`disaresta-org/monorel/ci/github@v0.2.1\` downloads cleanly when an external workflow uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)