### PR TITLE
fix(ci): revert release-staging push to plain `-f`

### DIFF
--- a/.changeset/fix-force-push-stale-info.md
+++ b/.changeset/fix-force-push-stale-info.md
@@ -1,0 +1,17 @@
+---
+"monorel.disaresta.com": patch
+---
+
+Fix `release-pr` workflow regression where `git push --force-with-lease`
+rejected the staged release branch with "stale info". The previous
+`monorel apply` PR replaced `git push -f` with `--force-with-lease`
+on review feedback, but `--force-with-lease` requires a previously-
+fetched value of the remote ref to compare against — and the
+speculative-apply step builds the local `monorel/release` from
+`origin/main` without ever fetching the remote `monorel/release`,
+so the lease has no expected value and the push is rejected.
+
+Reverted to plain `git push -f` in both `.github/workflows/release-pr.yml`
+and `ci/github/action.yml`. The `monorel/release` branch is
+bot-exclusive (the workflow is its only writer), so blind force-push
+is the intended behavior. Comments updated to spell out why.

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -50,7 +50,13 @@ jobs:
           if echo "$apply_out" | grep -qF "Nothing to apply."; then
             git checkout -q -
           else
-            git push --force-with-lease origin monorel/release
+            # Plain -f: we just built monorel/release from origin/main
+            # without fetching the remote's monorel/release first, so
+            # --force-with-lease has no expected value to compare and
+            # rejects with "stale info". The branch is bot-exclusive
+            # (no humans push here), so blind force-push is the
+            # intended behavior.
+            git push -f origin monorel/release
             git checkout -q -
           fi
 

--- a/ci/github/action.yml
+++ b/ci/github/action.yml
@@ -140,7 +140,13 @@ runs:
               # preview with an empty plan.
               git checkout -q -
             else
-              git push --force-with-lease origin monorel/release
+              # Plain -f: we just built monorel/release from origin
+              # without fetching the remote's monorel/release first,
+              # so --force-with-lease has no expected value to compare
+              # and rejects with "stale info". The branch is
+              # bot-exclusive (no humans push here), so blind
+              # force-push is the intended behavior.
+              git push -f origin monorel/release
               git checkout -q -
             fi
 


### PR DESCRIPTION
## Summary

Hot-fix for the regression on main: \`release-pr\` workflow was failing with

\`\`\`
! [rejected]   monorel/release -> monorel/release (stale info)
error: failed to push some refs to 'https://github.com/disaresta-org/monorel'
\`\`\`

(See [run 25228529221](https://github.com/disaresta-org/monorel/actions/runs/25228529221/job/73978028333).)

## Cause

PR #16's review fix replaced \`git push -f\` with \`git push --force-with-lease\` as a defensive default. But:

- \`--force-with-lease\` requires a previously-fetched value of the remote ref to compare against (\"the lease\").
- The speculative-apply step does \`git fetch --no-tags origin main\` then \`git checkout -q -B monorel/release origin/main\` — it never fetches the remote's \`monorel/release\`, so the local clone has no view of what's currently there.
- \`--force-with-lease\` then rejects with \`stale info\` because there's no expected value to compare against.

## Fix

Reverted to plain \`git push -f\` in both \`.github/workflows/release-pr.yml\` and \`ci/github/action.yml\`. The safety \`--force-with-lease\` provides (catching concurrent writers) doesn't apply: \`monorel/release\` is bot-exclusive, written only by this workflow. Comments updated to make the bot-exclusive contract explicit so the suggestion doesn't get re-introduced.

## Test plan

- [ ] Merge → release-pr workflow runs against this PR's content → \`monorel apply\` produces the staged release commit → \`git push -f origin monorel/release\` succeeds → release PR upserts.
- [x] Comment on each call site explains why plain \`-f\` is the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)