### PR TITLE
feat(cli): implement `monorel init`

### DIFF
--- a/.changeset/init-command.md
+++ b/.changeset/init-command.md
@@ -1,0 +1,18 @@
+---
+"monorel.disaresta.com": minor
+---
+
+Implement `monorel init`. Walks every `go.mod` under the working
+directory (skipping `vendor/`, `node_modules/`, and hidden directories),
+infers `provider`, `owner`, and `repo` from `git config remote.origin.url`,
+and writes a starter `monorel.toml` with one `[packages]` block per
+detected Go module plus a `.changeset/README.md`.
+
+Flags: `--provider`, `--owner`, `--repo` (overrides for auto-detection),
+`--force` (overwrite existing `monorel.toml`).
+
+Refuses to run without at least one `go.mod`. Existing
+`.changeset/README.md` is preserved when present.
+
+Removes the "(Planned.)" placeholder from `docs/src/cli-reference.md`
+and replaces it with the real reference.

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -267,7 +267,27 @@ monorel pre status
 
 ## `monorel init`
 
-(Planned.) Scaffold a `monorel.toml` and `.changeset/` for a new repo.
+Scaffold a `monorel.toml` and `.changeset/` directory for a fresh repo. Walks every `go.mod` under the working directory (skipping `vendor/`, `node_modules/`, and hidden directories) and writes one `[packages]` block per Go module. Infers `provider`, `owner`, and `repo` from the git origin remote.
+
+```sh
+monorel init
+# Wrote monorel.toml with 2 package(s):
+#   github.com/acme/widget (path: ., tag prefix: "")
+#   sub/foo (path: sub/foo, tag prefix: "sub/foo")
+# Created .changeset/ with a README.
+# Next steps:
+#   monorel validate     # confirm the config
+#   monorel add          # write your first changeset
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--provider <name>` | string | Version-control host. Default `github`. Used as the `provider.name` value. |
+| `--owner <name>` | string | Repo owner. Auto-detected from `git config remote.origin.url` if empty. |
+| `--repo <name>` | string | Repo name. Auto-detected from `git config remote.origin.url` if empty. |
+| `--force` | bool | Overwrite an existing `monorel.toml` (otherwise the command refuses). |
+
+Refuses to run without at least one `go.mod`. Existing `.changeset/README.md` is preserved; only created when missing.
 
 ## Persistent flags
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/google/go-github/v68 v68.0.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/mod v0.35.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.42.0
 )

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,20 +1,302 @@
 package cli
 
 import (
+	"bufio"
 	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 func newInitCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Scaffold a monorel.toml + .changeset/ directory in the current repo.",
-		Long: `Creates an initial monorel.toml by walking go.work / go.mod files in the
-current repo, plus an empty .changeset/ directory. Skip if monorel.toml
-already exists.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("not implemented yet (Phase 11+)")
-		},
+		Long: `Walks go.mod files in the current repo to detect packages, infers
+owner/repo from the git origin remote, and writes:
+
+    monorel.toml  - one [packages] block per detected Go module
+    .changeset/   - directory with a README explaining the format
+
+Refuses to overwrite an existing monorel.toml unless --force is given.`,
+		RunE: runInit,
 	}
+	cmd.Flags().String("provider", "github", "Version-control host (github, gitlab, gitea, etc.).")
+	cmd.Flags().String("owner", "", "Repo owner. Auto-detected from git origin if empty.")
+	cmd.Flags().String("repo", "", "Repo name. Auto-detected from git origin if empty.")
+	cmd.Flags().Bool("force", false, "Overwrite an existing monorel.toml.")
+	return cmd
 }
+
+func runInit(cmd *cobra.Command, _ []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	configPath := filepath.Join(cwd, "monorel.toml")
+	force, _ := cmd.Flags().GetBool("force")
+	if !force {
+		if _, err := os.Stat(configPath); err == nil {
+			return errors.New("monorel.toml already exists; rerun with --force to overwrite")
+		}
+	}
+
+	provider, _ := cmd.Flags().GetString("provider")
+	owner, _ := cmd.Flags().GetString("owner")
+	repo, _ := cmd.Flags().GetString("repo")
+	if owner == "" || repo == "" {
+		detectedOwner, detectedRepo, err := detectGitRemote(cwd)
+		if err != nil {
+			return fmt.Errorf("could not auto-detect owner/repo from git origin: %w (pass --owner/--repo)", err)
+		}
+		if owner == "" {
+			owner = detectedOwner
+		}
+		if repo == "" {
+			repo = detectedRepo
+		}
+	}
+
+	pkgs, err := detectPackages(cwd)
+	if err != nil {
+		return err
+	}
+	if len(pkgs) == 0 {
+		return errors.New("no go.mod files found; monorel needs at least one Go module")
+	}
+
+	if err := os.WriteFile(configPath, []byte(renderInitTOML(provider, owner, repo, pkgs)), 0644); err != nil {
+		return fmt.Errorf("write monorel.toml: %w", err)
+	}
+
+	changesetDir := filepath.Join(cwd, ".changeset")
+	if err := os.MkdirAll(changesetDir, 0755); err != nil {
+		return fmt.Errorf("create .changeset/: %w", err)
+	}
+	readmePath := filepath.Join(changesetDir, "README.md")
+	if _, err := os.Stat(readmePath); errors.Is(err, fs.ErrNotExist) {
+		if err := os.WriteFile(readmePath, []byte(changesetReadme), 0644); err != nil {
+			return fmt.Errorf("write .changeset/README.md: %w", err)
+		}
+	}
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Wrote monorel.toml with %d package(s):\n", len(pkgs))
+	for _, p := range pkgs {
+		fmt.Fprintf(out, "  %s (path: %s, tag prefix: %q)\n", p.Name, p.Path, p.TagPrefix)
+	}
+	fmt.Fprintln(out, "Created .changeset/ with a README.")
+	fmt.Fprintln(out, "Next steps:")
+	fmt.Fprintln(out, "  monorel validate     # confirm the config")
+	fmt.Fprintln(out, "  monorel add          # write your first changeset")
+	return nil
+}
+
+// initPkg is the per-package shape rendered into monorel.toml. The
+// fields mirror config.PackageConfig; init.go owns the file format
+// rather than re-using the encoder so the output diff stays
+// hand-readable (aligned `=`, comments, blank lines between blocks).
+type initPkg struct {
+	Name      string
+	TagPrefix string
+	Path      string
+	Changelog string
+}
+
+// detectGitRemote runs `git config --get remote.origin.url` in dir
+// and parses the result. Supports the two URL shapes git emits:
+//
+//	https://github.com/<owner>/<repo>(.git)
+//	git@github.com:<owner>/<repo>(.git)
+//
+// Other hosts (gitlab.com, gitea.example.com) work the same way; we
+// don't validate the host part because monorel itself doesn't care
+// which host is named, only what owner/repo to put in monorel.toml.
+func detectGitRemote(dir string) (owner, repo string, err error) {
+	c := exec.Command("git", "config", "--get", "remote.origin.url")
+	c.Dir = dir
+	raw, err := c.Output()
+	if err != nil {
+		return "", "", fmt.Errorf("read git origin: %w", err)
+	}
+	url := strings.TrimSpace(string(raw))
+	url = strings.TrimSuffix(url, ".git")
+
+	// SSH form: git@<host>:<owner>/<repo>
+	if at := strings.Index(url, "@"); at >= 0 && strings.Contains(url, ":") && !strings.HasPrefix(url, "http") {
+		colon := strings.Index(url, ":")
+		path := url[colon+1:]
+		return splitOwnerRepo(path)
+	}
+	// HTTPS form: https://<host>/<owner>/<repo>
+	if i := strings.Index(url, "://"); i >= 0 {
+		path := url[i+3:]
+		// drop host
+		if slash := strings.Index(path, "/"); slash >= 0 {
+			path = path[slash+1:]
+		}
+		return splitOwnerRepo(path)
+	}
+	return "", "", fmt.Errorf("unrecognized remote URL shape: %q", url)
+}
+
+func splitOwnerRepo(path string) (owner, repo string, err error) {
+	parts := strings.SplitN(strings.TrimSuffix(path, "/"), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("could not split owner/repo from %q", path)
+	}
+	return parts[0], parts[1], nil
+}
+
+// detectPackages walks repoRoot looking for go.mod files. The
+// top-level module (if present) gets tag_prefix "" and path "."; sub-
+// module go.mod files get tag_prefix and path equal to their relative
+// directory. Skips vendor/, node_modules/, and any hidden directory.
+//
+// Detection is by go.mod presence, not by go.work parsing — go.work
+// is optional and missing in many real repos. When it exists, every
+// `use ./<path>` entry has its own go.mod, so walking go.mod files
+// covers the same packages.
+func detectPackages(repoRoot string) ([]initPkg, error) {
+	var pkgs []initPkg
+	walkErr := filepath.WalkDir(repoRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if path != repoRoot && (strings.HasPrefix(name, ".") || name == "vendor" || name == "node_modules") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != "go.mod" {
+			return nil
+		}
+		modPath, err := readModulePath(path)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		rel, err := filepath.Rel(repoRoot, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		// Normalize Windows separators in the recorded path.
+		rel = filepath.ToSlash(rel)
+
+		if rel == "." {
+			pkgs = append(pkgs, initPkg{
+				Name:      modPath,
+				TagPrefix: "",
+				Path:      ".",
+				Changelog: "CHANGELOG.md",
+			})
+			return nil
+		}
+		pkgs = append(pkgs, initPkg{
+			Name:      rel,
+			TagPrefix: rel,
+			Path:      rel,
+			Changelog: rel + "/CHANGELOG.md",
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	// Stable order: root first, then sub-modules alphabetically. Keeps
+	// the rendered monorel.toml diff-friendly across runs.
+	sort.SliceStable(pkgs, func(i, j int) bool {
+		if pkgs[i].Path == "." {
+			return true
+		}
+		if pkgs[j].Path == "." {
+			return false
+		}
+		return pkgs[i].Path < pkgs[j].Path
+	})
+	return pkgs, nil
+}
+
+// readModulePath returns the value of go.mod's `module` directive.
+// Tolerates blank lines, comments, and the // <comment> trailing form.
+func readModulePath(goModPath string) (string, error) {
+	f, err := os.Open(goModPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		if !strings.HasPrefix(line, "module ") {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		// Drop trailing comment if present.
+		if i := strings.Index(rest, "//"); i >= 0 {
+			rest = strings.TrimSpace(rest[:i])
+		}
+		// Strip surrounding quotes if any (rare but allowed by spec).
+		rest = strings.Trim(rest, `"`)
+		return rest, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("no module directive found")
+}
+
+func renderInitTOML(provider, owner, repo string, pkgs []initPkg) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, "# monorel configuration. See https://monorel.disaresta.com/configuration")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "[provider]")
+	fmt.Fprintf(&b, "name  = %q\n", provider)
+	fmt.Fprintf(&b, "owner = %q\n", owner)
+	fmt.Fprintf(&b, "repo  = %q\n", repo)
+	fmt.Fprintln(&b)
+	for _, p := range pkgs {
+		fmt.Fprintf(&b, "[packages.%q]\n", p.Name)
+		fmt.Fprintf(&b, "tag_prefix = %q\n", p.TagPrefix)
+		fmt.Fprintf(&b, "path       = %q\n", p.Path)
+		fmt.Fprintf(&b, "changelog  = %q\n", p.Changelog)
+		fmt.Fprintln(&b)
+	}
+	return b.String()
+}
+
+const changesetReadme = `# Changesets
+
+This directory holds pending release intents for [monorel](https://monorel.disaresta.com).
+
+## What's a changeset?
+
+A ` + "`.changeset/<name>.md`" + ` file declares which packages should release at what bump level when the next release lands, plus the changelog body to use for each release.
+
+Example:
+
+` + "```markdown" + `
+---
+"<package-name>": minor
+---
+
+What changed and why.
+` + "```" + `
+
+The frontmatter keys are package names from ` + "`monorel.toml`" + `. Bump levels are ` + "`major`" + `, ` + "`minor`" + `, or ` + "`patch`" + `. The body becomes the rendered changelog entry for every package the changeset names.
+
+## Authoring
+
+Run ` + "`monorel add`" + ` for the interactive flow, or write the file directly. See [the docs](https://monorel.disaresta.com/changesets) for details.
+`

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -43,12 +43,14 @@ defaults (CLI flags still override).`,
 // initOptions are the resolved inputs to doInit. All fields are
 // optional: empty strings get filled in from the existing
 // monorel.toml (when --force) or from `git config remote.origin.url`.
+// Type and fields are unexported; the struct exists only as a test
+// seam between cobra-driven runInit and the doInit body.
 type initOptions struct {
-	Dir      string // working directory; defaults to os.Getwd().
-	Provider string // empty -> existing/github fallback.
-	Owner    string // empty -> existing/git-origin fallback.
-	Repo     string // empty -> existing/git-origin fallback.
-	Force    bool
+	dir      string // working directory; defaults to os.Getwd().
+	provider string // empty -> existing/github fallback.
+	owner    string // empty -> existing/git-origin fallback.
+	repo     string // empty -> existing/git-origin fallback.
+	force    bool
 }
 
 func runInit(cmd *cobra.Command, _ []string) error {
@@ -56,37 +58,45 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	opts := initOptions{Dir: cwd}
-	opts.Provider, _ = cmd.Flags().GetString("provider")
-	opts.Owner, _ = cmd.Flags().GetString("owner")
-	opts.Repo, _ = cmd.Flags().GetString("repo")
-	opts.Force, _ = cmd.Flags().GetBool("force")
+	opts := initOptions{dir: cwd}
+	opts.provider, _ = cmd.Flags().GetString("provider")
+	opts.owner, _ = cmd.Flags().GetString("owner")
+	opts.repo, _ = cmd.Flags().GetString("repo")
+	opts.force, _ = cmd.Flags().GetBool("force")
 	return doInit(cmd.OutOrStdout(), opts)
 }
 
 // doInit is the body of `monorel init`, factored out of runInit so
 // tests can drive it without process-global os.Chdir.
 func doInit(out io.Writer, opts initOptions) error {
-	configPath := filepath.Join(opts.Dir, "monorel.toml")
+	configPath := filepath.Join(opts.dir, "monorel.toml")
 
-	if !opts.Force {
+	if !opts.force {
 		if _, err := os.Stat(configPath); err == nil {
 			return errors.New("monorel.toml already exists; rerun with --force to overwrite")
 		}
 	}
 
 	// On --force, reload the existing config so we can preserve
-	// provider/owner/repo edits the user made by hand. A parse
-	// failure means the file is broken anyway; init is going to
-	// overwrite it, so we just fall through to auto-detection.
+	// provider/owner/repo edits the user made by hand. If the file
+	// doesn't exist (--force on a fresh repo), silently fall through
+	// to auto-detect; any other load failure (malformed TOML, schema
+	// drift, validation error) gets a warning so the user knows their
+	// preserved-fields expectation just didn't fire.
 	var existing *config.Config
-	if opts.Force {
-		if cfg, err := config.Load(configPath); err == nil {
+	if opts.force {
+		cfg, err := config.Load(configPath)
+		switch {
+		case err == nil:
 			existing = cfg
+		case errors.Is(err, fs.ErrNotExist):
+			// Fresh repo; nothing to preserve.
+		default:
+			fmt.Fprintf(out, "warning: existing monorel.toml could not be loaded (%v); falling back to auto-detect\n", err)
 		}
 	}
 
-	provider := opts.Provider
+	provider := opts.provider
 	if provider == "" {
 		if existing != nil && existing.Provider.Name != "" {
 			provider = existing.Provider.Name
@@ -94,9 +104,16 @@ func doInit(out io.Writer, opts initOptions) error {
 			provider = "github"
 		}
 	}
+	// Fail upfront if the provider isn't one this build recognizes.
+	// Otherwise init would happily write a monorel.toml that
+	// `monorel validate` (and every command that calls config.Load)
+	// would refuse — confusing for a user who just ran scaffold.
+	if !config.IsKnownProvider(provider) {
+		return fmt.Errorf("provider %q is not recognized; supported: %v", provider, config.KnownProviders)
+	}
 
-	owner := opts.Owner
-	repo := opts.Repo
+	owner := opts.owner
+	repo := opts.repo
 	if existing != nil {
 		if owner == "" {
 			owner = existing.Provider.Owner
@@ -106,7 +123,7 @@ func doInit(out io.Writer, opts initOptions) error {
 		}
 	}
 	if owner == "" || repo == "" {
-		detectedOwner, detectedRepo, err := detectGitRemote(opts.Dir)
+		detectedOwner, detectedRepo, err := detectGitRemote(opts.dir)
 		if err != nil {
 			return fmt.Errorf("could not auto-detect owner/repo from git origin: %w (pass --owner/--repo)", err)
 		}
@@ -118,7 +135,7 @@ func doInit(out io.Writer, opts initOptions) error {
 		}
 	}
 
-	pkgs, err := detectPackages(opts.Dir)
+	pkgs, err := detectPackages(opts.dir)
 	if err != nil {
 		return err
 	}
@@ -130,7 +147,7 @@ func doInit(out io.Writer, opts initOptions) error {
 		return fmt.Errorf("write monorel.toml: %w", err)
 	}
 
-	changesetDir := filepath.Join(opts.Dir, ".changeset")
+	changesetDir := filepath.Join(opts.dir, ".changeset")
 	if err := os.MkdirAll(changesetDir, 0755); err != nil {
 		return fmt.Errorf("create .changeset/: %w", err)
 	}
@@ -138,10 +155,10 @@ func doInit(out io.Writer, opts initOptions) error {
 	switch _, err := os.Stat(readmePath); {
 	case errors.Is(err, fs.ErrNotExist):
 		if err := os.WriteFile(readmePath, []byte(changesetReadme), 0644); err != nil {
-			return fmt.Errorf("write .changeset/README.md: %w", err)
+			return fmt.Errorf("write %s: %w", readmePath, err)
 		}
 	case err != nil:
-		return fmt.Errorf("stat .changeset/README.md: %w", err)
+		return fmt.Errorf("stat %s: %w", readmePath, err)
 		// else: file present, leave it alone.
 	}
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -12,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/modfile"
 )
 
 func newInitCmd() *cobra.Command {
@@ -225,36 +225,23 @@ func detectPackages(repoRoot string) ([]initPkg, error) {
 	return pkgs, nil
 }
 
-// readModulePath returns the value of go.mod's `module` directive.
-// Tolerates blank lines, comments, and the // <comment> trailing form.
+// readModulePath returns the value of go.mod's `module` directive,
+// using the official x/mod/modfile parser so every spec-allowed shape
+// (block-form modules, comments, quoted paths, retract/exclude/replace
+// directives) is handled the same way `go` itself handles it.
 func readModulePath(goModPath string) (string, error) {
-	f, err := os.Open(goModPath)
+	data, err := os.ReadFile(goModPath)
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "//") {
-			continue
-		}
-		if !strings.HasPrefix(line, "module ") {
-			continue
-		}
-		rest := strings.TrimSpace(strings.TrimPrefix(line, "module "))
-		// Drop trailing comment if present.
-		if i := strings.Index(rest, "//"); i >= 0 {
-			rest = strings.TrimSpace(rest[:i])
-		}
-		// Strip surrounding quotes if any (rare but allowed by spec).
-		rest = strings.Trim(rest, `"`)
-		return rest, nil
-	}
-	if err := scanner.Err(); err != nil {
+	f, err := modfile.Parse(goModPath, data, nil)
+	if err != nil {
 		return "", err
 	}
-	return "", errors.New("no module directive found")
+	if f.Module == nil {
+		return "", errors.New("no module directive found")
+	}
+	return f.Module.Mod.Path, nil
 }
 
 func renderInitTOML(provider, owner, repo string, pkgs []initPkg) string {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +14,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/mod/modfile"
+
+	"monorel.disaresta.com/config"
 )
 
 func newInitCmd() *cobra.Command {
@@ -24,14 +28,27 @@ owner/repo from the git origin remote, and writes:
     monorel.toml  - one [packages] block per detected Go module
     .changeset/   - directory with a README explaining the format
 
-Refuses to overwrite an existing monorel.toml unless --force is given.`,
+Refuses to overwrite an existing monorel.toml unless --force is given.
+With --force, the existing provider/owner/repo are preserved as
+defaults (CLI flags still override).`,
 		RunE: runInit,
 	}
-	cmd.Flags().String("provider", "github", "Version-control host (github, gitlab, gitea, etc.).")
-	cmd.Flags().String("owner", "", "Repo owner. Auto-detected from git origin if empty.")
-	cmd.Flags().String("repo", "", "Repo name. Auto-detected from git origin if empty.")
+	cmd.Flags().String("provider", "", "Version-control host. Defaults to `github`, or to the existing monorel.toml's provider on --force.")
+	cmd.Flags().String("owner", "", "Repo owner. Auto-detected from git origin (or preserved from existing monorel.toml on --force).")
+	cmd.Flags().String("repo", "", "Repo name. Auto-detected from git origin (or preserved from existing monorel.toml on --force).")
 	cmd.Flags().Bool("force", false, "Overwrite an existing monorel.toml.")
 	return cmd
+}
+
+// initOptions are the resolved inputs to doInit. All fields are
+// optional: empty strings get filled in from the existing
+// monorel.toml (when --force) or from `git config remote.origin.url`.
+type initOptions struct {
+	Dir      string // working directory; defaults to os.Getwd().
+	Provider string // empty -> existing/github fallback.
+	Owner    string // empty -> existing/git-origin fallback.
+	Repo     string // empty -> existing/git-origin fallback.
+	Force    bool
 }
 
 func runInit(cmd *cobra.Command, _ []string) error {
@@ -39,20 +56,57 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	opts := initOptions{Dir: cwd}
+	opts.Provider, _ = cmd.Flags().GetString("provider")
+	opts.Owner, _ = cmd.Flags().GetString("owner")
+	opts.Repo, _ = cmd.Flags().GetString("repo")
+	opts.Force, _ = cmd.Flags().GetBool("force")
+	return doInit(cmd.OutOrStdout(), opts)
+}
 
-	configPath := filepath.Join(cwd, "monorel.toml")
-	force, _ := cmd.Flags().GetBool("force")
-	if !force {
+// doInit is the body of `monorel init`, factored out of runInit so
+// tests can drive it without process-global os.Chdir.
+func doInit(out io.Writer, opts initOptions) error {
+	configPath := filepath.Join(opts.Dir, "monorel.toml")
+
+	if !opts.Force {
 		if _, err := os.Stat(configPath); err == nil {
 			return errors.New("monorel.toml already exists; rerun with --force to overwrite")
 		}
 	}
 
-	provider, _ := cmd.Flags().GetString("provider")
-	owner, _ := cmd.Flags().GetString("owner")
-	repo, _ := cmd.Flags().GetString("repo")
+	// On --force, reload the existing config so we can preserve
+	// provider/owner/repo edits the user made by hand. A parse
+	// failure means the file is broken anyway; init is going to
+	// overwrite it, so we just fall through to auto-detection.
+	var existing *config.Config
+	if opts.Force {
+		if cfg, err := config.Load(configPath); err == nil {
+			existing = cfg
+		}
+	}
+
+	provider := opts.Provider
+	if provider == "" {
+		if existing != nil && existing.Provider.Name != "" {
+			provider = existing.Provider.Name
+		} else {
+			provider = "github"
+		}
+	}
+
+	owner := opts.Owner
+	repo := opts.Repo
+	if existing != nil {
+		if owner == "" {
+			owner = existing.Provider.Owner
+		}
+		if repo == "" {
+			repo = existing.Provider.Repo
+		}
+	}
 	if owner == "" || repo == "" {
-		detectedOwner, detectedRepo, err := detectGitRemote(cwd)
+		detectedOwner, detectedRepo, err := detectGitRemote(opts.Dir)
 		if err != nil {
 			return fmt.Errorf("could not auto-detect owner/repo from git origin: %w (pass --owner/--repo)", err)
 		}
@@ -64,7 +118,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	pkgs, err := detectPackages(cwd)
+	pkgs, err := detectPackages(opts.Dir)
 	if err != nil {
 		return err
 	}
@@ -76,18 +130,21 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("write monorel.toml: %w", err)
 	}
 
-	changesetDir := filepath.Join(cwd, ".changeset")
+	changesetDir := filepath.Join(opts.Dir, ".changeset")
 	if err := os.MkdirAll(changesetDir, 0755); err != nil {
 		return fmt.Errorf("create .changeset/: %w", err)
 	}
 	readmePath := filepath.Join(changesetDir, "README.md")
-	if _, err := os.Stat(readmePath); errors.Is(err, fs.ErrNotExist) {
+	switch _, err := os.Stat(readmePath); {
+	case errors.Is(err, fs.ErrNotExist):
 		if err := os.WriteFile(readmePath, []byte(changesetReadme), 0644); err != nil {
 			return fmt.Errorf("write .changeset/README.md: %w", err)
 		}
+	case err != nil:
+		return fmt.Errorf("stat .changeset/README.md: %w", err)
+		// else: file present, leave it alone.
 	}
 
-	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "Wrote monorel.toml with %d package(s):\n", len(pkgs))
 	for _, p := range pkgs {
 		fmt.Fprintf(out, "  %s (path: %s, tag prefix: %q)\n", p.Name, p.Path, p.TagPrefix)
@@ -111,14 +168,7 @@ type initPkg struct {
 }
 
 // detectGitRemote runs `git config --get remote.origin.url` in dir
-// and parses the result. Supports the two URL shapes git emits:
-//
-//	https://github.com/<owner>/<repo>(.git)
-//	git@github.com:<owner>/<repo>(.git)
-//
-// Other hosts (gitlab.com, gitea.example.com) work the same way; we
-// don't validate the host part because monorel itself doesn't care
-// which host is named, only what owner/repo to put in monorel.toml.
+// and parses the result. See parseGitRemote for supported URL shapes.
 func detectGitRemote(dir string) (owner, repo string, err error) {
 	c := exec.Command("git", "config", "--get", "remote.origin.url")
 	c.Dir = dir
@@ -126,25 +176,48 @@ func detectGitRemote(dir string) (owner, repo string, err error) {
 	if err != nil {
 		return "", "", fmt.Errorf("read git origin: %w", err)
 	}
-	url := strings.TrimSpace(string(raw))
-	url = strings.TrimSuffix(url, ".git")
+	return parseGitRemote(strings.TrimSpace(string(raw)))
+}
 
-	// SSH form: git@<host>:<owner>/<repo>
-	if at := strings.Index(url, "@"); at >= 0 && strings.Contains(url, ":") && !strings.HasPrefix(url, "http") {
-		colon := strings.Index(url, ":")
-		path := url[colon+1:]
-		return splitOwnerRepo(path)
-	}
-	// HTTPS form: https://<host>/<owner>/<repo>
-	if i := strings.Index(url, "://"); i >= 0 {
-		path := url[i+3:]
-		// drop host
-		if slash := strings.Index(path, "/"); slash >= 0 {
-			path = path[slash+1:]
+// parseGitRemote covers the URL shapes git emits in the wild:
+//
+//   - HTTPS / HTTP: https://<host>/<owner>/<repo>(.git)
+//   - SSH (with scheme): ssh://git@<host>/<owner>/<repo>(.git)
+//   - SSH (scp-like, no scheme): git@<host>:<owner>/<repo>(.git)
+//   - git: git://<host>/<owner>/<repo>(.git)
+//
+// Schemed URLs are parsed via net/url, which handles credentials,
+// custom ports, IPv6 hosts, and percent-encoding for free. file://
+// URLs are explicitly rejected since they have no owner/repo concept.
+//
+// monorel doesn't validate the host part because it doesn't care
+// which host is named, only what owner/repo to put in monorel.toml.
+func parseGitRemote(raw string) (owner, repo string, err error) {
+	raw = strings.TrimSuffix(raw, ".git")
+
+	// Schemed URLs (https://, ssh://, git://, file://, etc.).
+	if strings.Contains(raw, "://") {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return "", "", fmt.Errorf("parse remote URL %q: %w", raw, err)
 		}
+		if u.Scheme == "file" {
+			return "", "", fmt.Errorf("remote URL is file://; pass --owner/--repo explicitly")
+		}
+		path := strings.TrimPrefix(u.Path, "/")
 		return splitOwnerRepo(path)
 	}
-	return "", "", fmt.Errorf("unrecognized remote URL shape: %q", url)
+
+	// SSH scp-like form: git@<host>:<owner>/<repo>
+	if at := strings.Index(raw, "@"); at >= 0 {
+		// Find the colon AFTER the @ to skip user@ separators.
+		colon := strings.Index(raw[at:], ":")
+		if colon >= 0 {
+			path := raw[at+colon+1:]
+			return splitOwnerRepo(path)
+		}
+	}
+	return "", "", fmt.Errorf("unrecognized remote URL shape: %q (pass --owner/--repo)", raw)
 }
 
 func splitOwnerRepo(path string) (owner, repo string, err error) {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -36,36 +36,60 @@ func TestSplitOwnerRepo(t *testing.T) {
 	}
 }
 
-func TestDetectGitRemote(t *testing.T) {
+func TestParseGitRemote(t *testing.T) {
 	cases := []struct {
 		name      string
 		remoteURL string
 		owner     string
 		repo      string
+		shouldErr bool
 	}{
-		{"https with .git", "https://github.com/acme/widget.git", "acme", "widget"},
-		{"https without .git", "https://github.com/acme/widget", "acme", "widget"},
-		{"ssh", "git@github.com:acme/widget.git", "acme", "widget"},
-		{"ssh no .git", "git@gitlab.com:acme/widget", "acme", "widget"},
-		{"https with subgroup (gitlab)", "https://gitlab.com/team/sub/widget.git", "team", "sub/widget"},
+		{"https with .git", "https://github.com/acme/widget.git", "acme", "widget", false},
+		{"https without .git", "https://github.com/acme/widget", "acme", "widget", false},
+		{"http", "http://gitea.example.com/acme/widget.git", "acme", "widget", false},
+		{"ssh-with-scheme", "ssh://git@github.com/acme/widget.git", "acme", "widget", false},
+		{"ssh-with-scheme custom port", "ssh://git@github.com:2222/acme/widget.git", "acme", "widget", false},
+		{"ssh scp-like", "git@github.com:acme/widget.git", "acme", "widget", false},
+		{"ssh scp-like no .git", "git@gitlab.com:acme/widget", "acme", "widget", false},
+		{"git scheme", "git://github.com/acme/widget.git", "acme", "widget", false},
+		{"https with credentials", "https://user:pass@github.com/acme/widget.git", "acme", "widget", false},
+		{"https with subgroup (gitlab)", "https://gitlab.com/team/sub/widget.git", "team", "sub/widget", false},
+		{"https IPv6 host", "https://[::1]/acme/widget", "acme", "widget", false},
+		// Rejected shapes.
+		{"file URL", "file:///home/me/repo", "", "", true},
+		{"unrecognized", "random-string-no-colon", "", "", true},
+		{"git@ no colon", "git@github.com", "", "", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			runGit(t, dir, "init", "-q")
-			runGit(t, dir, "remote", "add", "origin", tc.remoteURL)
-			owner, repo, err := detectGitRemote(dir)
-			if err != nil {
-				t.Fatalf("detectGitRemote: %v", err)
+			owner, repo, err := parseGitRemote(tc.remoteURL)
+			gotErr := err != nil
+			if gotErr != tc.shouldErr {
+				t.Errorf("parseGitRemote(%q): err=%v want shouldErr=%v", tc.remoteURL, err, tc.shouldErr)
 			}
-			if owner != tc.owner || repo != tc.repo {
-				t.Errorf("got owner=%q repo=%q, want %q, %q", owner, repo, tc.owner, tc.repo)
+			if !tc.shouldErr && (owner != tc.owner || repo != tc.repo) {
+				t.Errorf("parseGitRemote(%q) = %q, %q, want %q, %q", tc.remoteURL, owner, repo, tc.owner, tc.repo)
 			}
 		})
 	}
 }
 
+func TestDetectGitRemote(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	owner, repo, err := detectGitRemote(dir)
+	if err != nil {
+		t.Fatalf("detectGitRemote: %v", err)
+	}
+	if owner != "acme" || repo != "widget" {
+		t.Errorf("got owner=%q repo=%q, want acme/widget", owner, repo)
+	}
+}
+
 func TestDetectGitRemote_NoRemote(t *testing.T) {
+	requireGit(t)
 	dir := t.TempDir()
 	runGit(t, dir, "init", "-q")
 	if _, _, err := detectGitRemote(dir); err == nil {
@@ -117,6 +141,9 @@ func TestDetectPackages(t *testing.T) {
 	writeMod(t, dir, "go.mod", "module example.com/root\n")
 	writeMod(t, dir, "transports/zerolog/go.mod", "module example.com/root/transports/zerolog\n")
 	writeMod(t, dir, "transports/zap/go.mod", "module example.com/root/transports/zap\n")
+	// Three-level nesting. Tests that filepath.ToSlash normalizes
+	// separators and that the rendered path contains forward slashes.
+	writeMod(t, dir, "plugins/foo/livetest/go.mod", "module example.com/root/plugins/foo/livetest\n")
 	// vendor and hidden dirs ignored.
 	writeMod(t, dir, "vendor/github.com/x/y/go.mod", "module github.com/x/y\n")
 	writeMod(t, dir, ".tooling/skip/go.mod", "module example.com/skip\n")
@@ -125,21 +152,24 @@ func TestDetectPackages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("detectPackages: %v", err)
 	}
-	if len(pkgs) != 3 {
-		t.Fatalf("want 3 packages, got %d: %+v", len(pkgs), pkgs)
+	if len(pkgs) != 4 {
+		t.Fatalf("want 4 packages, got %d: %+v", len(pkgs), pkgs)
 	}
 	// Root first, then sub-modules alphabetical by path.
 	if pkgs[0].Path != "." || pkgs[0].Name != "example.com/root" {
 		t.Errorf("[0] = %+v, want root", pkgs[0])
 	}
-	if pkgs[1].Path != "transports/zap" {
-		t.Errorf("[1] = %+v, want transports/zap", pkgs[1])
+	if pkgs[1].Path != "plugins/foo/livetest" {
+		t.Errorf("[1] = %+v, want plugins/foo/livetest", pkgs[1])
 	}
-	if pkgs[2].Path != "transports/zerolog" {
-		t.Errorf("[2] = %+v, want transports/zerolog", pkgs[2])
+	if pkgs[1].Changelog != "plugins/foo/livetest/CHANGELOG.md" {
+		t.Errorf("[1].Changelog = %q, want plugins/foo/livetest/CHANGELOG.md", pkgs[1].Changelog)
 	}
-	if pkgs[1].Changelog != "transports/zap/CHANGELOG.md" {
-		t.Errorf("[1].Changelog = %q", pkgs[1].Changelog)
+	if pkgs[2].Path != "transports/zap" {
+		t.Errorf("[2] = %+v, want transports/zap", pkgs[2])
+	}
+	if pkgs[3].Path != "transports/zerolog" {
+		t.Errorf("[3] = %+v, want transports/zerolog", pkgs[3])
 	}
 }
 
@@ -165,25 +195,16 @@ func TestRenderInitTOML(t *testing.T) {
 	}
 }
 
-func TestInitCmd_EndToEnd(t *testing.T) {
+func TestDoInit_FreshRepo(t *testing.T) {
+	requireGit(t)
 	dir := t.TempDir()
 	runGit(t, dir, "init", "-q")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/acme/widget.git")
 	writeMod(t, dir, "go.mod", "module github.com/acme/widget\n")
 
-	prevWd, _ := os.Getwd()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(prevWd) })
-
-	root := newRootCmd()
-	var stdout, stderr bytes.Buffer
-	root.SetOut(&stdout)
-	root.SetErr(&stderr)
-	root.SetArgs([]string{"init"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("init: %v\nstderr: %s", err, stderr.String())
+	var out bytes.Buffer
+	if err := doInit(&out, initOptions{Dir: dir}); err != nil {
+		t.Fatalf("doInit: %v", err)
 	}
 
 	if !fileExists(filepath.Join(dir, "monorel.toml")) {
@@ -193,51 +214,163 @@ func TestInitCmd_EndToEnd(t *testing.T) {
 		t.Fatal(".changeset/README.md not created")
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, "monorel.toml"))
-	for _, want := range []string{`name  = "github"`, `owner = "acme"`, `repo  = "widget"`, `[packages."github.com/acme/widget"]`} {
+	for _, want := range []string{
+		`name  = "github"`,
+		`owner = "acme"`,
+		`repo  = "widget"`,
+		`[packages."github.com/acme/widget"]`,
+	} {
 		if !strings.Contains(string(body), want) {
 			t.Errorf("monorel.toml missing %q", want)
 		}
 	}
+}
 
-	// Re-run without --force should refuse.
-	root2 := newRootCmd()
-	var stderr2 bytes.Buffer
-	root2.SetOut(&bytes.Buffer{})
-	root2.SetErr(&stderr2)
-	root2.SetArgs([]string{"init"})
-	if err := root2.Execute(); err == nil {
-		t.Fatal("expected error on rerun without --force")
+func TestDoInit_RefusesWithoutForce(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "monorel.toml"), []byte("# stub\n"), 0644); err != nil {
+		t.Fatal(err)
 	}
+	writeMod(t, dir, "go.mod", "module example.com/foo\n")
 
-	// With --force, allowed.
-	root3 := newRootCmd()
-	root3.SetOut(&bytes.Buffer{})
-	root3.SetErr(&bytes.Buffer{})
-	root3.SetArgs([]string{"init", "--force"})
-	if err := root3.Execute(); err != nil {
-		t.Errorf("init --force should succeed: %v", err)
+	err := doInit(&bytes.Buffer{}, initOptions{Dir: dir, Owner: "a", Repo: "b"})
+	if err == nil {
+		t.Fatal("expected error when monorel.toml exists without --force")
 	}
 }
 
-func TestInitCmd_OwnerRepoOverride(t *testing.T) {
+func TestDoInit_ForcePreservesExistingProvider(t *testing.T) {
+	requireGit(t)
 	dir := t.TempDir()
-	runGit(t, dir, "init", "-q")
-	// No origin remote configured. --owner/--repo flags must be honored.
-	writeMod(t, dir, "go.mod", "module example.com/foo\n")
+	// Existing monorel.toml with hand-edited provider/owner/repo. Uses
+	// "github" because Validate() rejects unknown provider names; the
+	// preserve path requires a loadable existing config.
+	original := `[provider]
+name  = "github"
+owner = "preserved-team"
+repo  = "preserved-name"
 
-	prevWd, _ := os.Getwd()
-	if err := os.Chdir(dir); err != nil {
+[packages."example.com/foo"]
+tag_prefix = ""
+path       = "."
+changelog  = "CHANGELOG.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "monorel.toml"), []byte(original), 0644); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(prevWd) })
+	writeMod(t, dir, "go.mod", "module example.com/foo\n")
+	// Origin remote points somewhere else; init must NOT overwrite the
+	// owner/repo with the auto-detected values when --force reloads the
+	// existing config.
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/wrong/wrong.git")
 
-	root := newRootCmd()
-	var stderr bytes.Buffer
-	root.SetOut(&bytes.Buffer{})
-	root.SetErr(&stderr)
-	root.SetArgs([]string{"init", "--owner", "acme", "--repo", "widget", "--provider", "gitlab"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("init: %v\nstderr: %s", err, stderr.String())
+	if err := doInit(&bytes.Buffer{}, initOptions{Dir: dir, Force: true}); err != nil {
+		t.Fatalf("doInit --force: %v", err)
+	}
+
+	body, _ := os.ReadFile(filepath.Join(dir, "monorel.toml"))
+	for _, want := range []string{
+		`name  = "github"`,
+		`owner = "preserved-team"`,
+		`repo  = "preserved-name"`,
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("preserved field missing: want %q\nfull:\n%s", want, body)
+		}
+	}
+	// Sanity: the wrong values from origin must NOT appear.
+	if strings.Contains(string(body), `owner = "wrong"`) {
+		t.Error("origin auto-detect leaked into preserved provider block")
+	}
+}
+
+func TestDoInit_ForceFlagsOverrideExisting(t *testing.T) {
+	dir := t.TempDir()
+	original := `[provider]
+name  = "github"
+owner = "old-team"
+repo  = "old-name"
+
+[packages."example.com/foo"]
+tag_prefix = ""
+path       = "."
+changelog  = "CHANGELOG.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "monorel.toml"), []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeMod(t, dir, "go.mod", "module example.com/foo\n")
+
+	if err := doInit(&bytes.Buffer{}, initOptions{
+		Dir:   dir,
+		Force: true,
+		Owner: "new-team",
+		Repo:  "new-name",
+	}); err != nil {
+		t.Fatalf("doInit: %v", err)
+	}
+
+	body, _ := os.ReadFile(filepath.Join(dir, "monorel.toml"))
+	for _, want := range []string{
+		`owner = "new-team"`,
+		`repo  = "new-name"`,
+	} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("flag override missing: %q\nfull:\n%s", want, body)
+		}
+	}
+	if strings.Contains(string(body), `"old-team"`) || strings.Contains(string(body), `"old-name"`) {
+		t.Errorf("override should drop old values\nfull:\n%s", body)
+	}
+}
+
+func TestDoInit_ForcePreservesExistingReadme(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".changeset"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	customReadme := "# My custom changeset readme\n"
+	readmePath := filepath.Join(dir, ".changeset", "README.md")
+	if err := os.WriteFile(readmePath, []byte(customReadme), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeMod(t, dir, "go.mod", "module example.com/foo\n")
+
+	if err := doInit(&bytes.Buffer{}, initOptions{
+		Dir:   dir,
+		Owner: "acme",
+		Repo:  "widget",
+	}); err != nil {
+		t.Fatalf("doInit: %v", err)
+	}
+	got, _ := os.ReadFile(readmePath)
+	if string(got) != customReadme {
+		t.Errorf("README.md was overwritten: got %q, want %q", got, customReadme)
+	}
+}
+
+func TestDoInit_NoGoMod(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	if err := doInit(&bytes.Buffer{}, initOptions{Dir: dir}); err == nil {
+		t.Fatal("expected error when no go.mod files are present")
+	}
+}
+
+func TestDoInit_OwnerRepoOverrideNoRemote(t *testing.T) {
+	dir := t.TempDir()
+	// No git init at all. Must rely on flag-supplied values.
+	writeMod(t, dir, "go.mod", "module example.com/foo\n")
+	if err := doInit(&bytes.Buffer{}, initOptions{
+		Dir:      dir,
+		Provider: "gitlab",
+		Owner:    "acme",
+		Repo:     "widget",
+	}); err != nil {
+		t.Fatalf("doInit: %v", err)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, "monorel.toml"))
 	for _, want := range []string{`name  = "gitlab"`, `owner = "acme"`, `repo  = "widget"`} {
@@ -253,6 +386,13 @@ func runGit(t *testing.T, dir string, args ...string) {
 	c.Dir = dir
 	if out, err := c.CombinedOutput(); err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not on PATH: %v", err)
 	}
 }
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSplitOwnerRepo(t *testing.T) {
+	cases := []struct {
+		in        string
+		owner     string
+		repo      string
+		shouldErr bool
+	}{
+		{"acme/widget", "acme", "widget", false},
+		{"acme/widget/", "acme", "widget", false},
+		{"a/b/c", "a", "b/c", false},
+		{"acme", "", "", true},
+		{"/widget", "", "", true},
+		{"acme/", "", "", true},
+		{"", "", "", true},
+	}
+	for _, tc := range cases {
+		owner, repo, err := splitOwnerRepo(tc.in)
+		gotErr := err != nil
+		if gotErr != tc.shouldErr {
+			t.Errorf("splitOwnerRepo(%q): err=%v want shouldErr=%v", tc.in, err, tc.shouldErr)
+		}
+		if !tc.shouldErr && (owner != tc.owner || repo != tc.repo) {
+			t.Errorf("splitOwnerRepo(%q) = %q, %q, want %q, %q", tc.in, owner, repo, tc.owner, tc.repo)
+		}
+	}
+}
+
+func TestDetectGitRemote(t *testing.T) {
+	cases := []struct {
+		name      string
+		remoteURL string
+		owner     string
+		repo      string
+	}{
+		{"https with .git", "https://github.com/acme/widget.git", "acme", "widget"},
+		{"https without .git", "https://github.com/acme/widget", "acme", "widget"},
+		{"ssh", "git@github.com:acme/widget.git", "acme", "widget"},
+		{"ssh no .git", "git@gitlab.com:acme/widget", "acme", "widget"},
+		{"https with subgroup (gitlab)", "https://gitlab.com/team/sub/widget.git", "team", "sub/widget"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			runGit(t, dir, "init", "-q")
+			runGit(t, dir, "remote", "add", "origin", tc.remoteURL)
+			owner, repo, err := detectGitRemote(dir)
+			if err != nil {
+				t.Fatalf("detectGitRemote: %v", err)
+			}
+			if owner != tc.owner || repo != tc.repo {
+				t.Errorf("got owner=%q repo=%q, want %q, %q", owner, repo, tc.owner, tc.repo)
+			}
+		})
+	}
+}
+
+func TestDetectGitRemote_NoRemote(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	if _, _, err := detectGitRemote(dir); err == nil {
+		t.Fatal("expected error when origin remote is missing")
+	}
+}
+
+func TestReadModulePath(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"basic", "module github.com/acme/widget\n\ngo 1.23\n", "github.com/acme/widget"},
+		{"leading blank", "\n\nmodule example.com/foo\n", "example.com/foo"},
+		{"with comment", "// header\nmodule example.com/foo\n", "example.com/foo"},
+		{"trailing comment", "module example.com/foo // canonical\n", "example.com/foo"},
+		{"quoted", `module "example.com/foo"` + "\n", "example.com/foo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "go.mod")
+			if err := os.WriteFile(path, []byte(tc.body), 0644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := readModulePath(path)
+			if err != nil {
+				t.Fatalf("readModulePath: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadModulePath_Missing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "go.mod")
+	if err := os.WriteFile(path, []byte("// no module here\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readModulePath(path); err == nil {
+		t.Fatal("expected error when module directive is missing")
+	}
+}
+
+func TestDetectPackages(t *testing.T) {
+	dir := t.TempDir()
+	writeMod(t, dir, "go.mod", "module example.com/root\n")
+	writeMod(t, dir, "transports/zerolog/go.mod", "module example.com/root/transports/zerolog\n")
+	writeMod(t, dir, "transports/zap/go.mod", "module example.com/root/transports/zap\n")
+	// vendor and hidden dirs ignored.
+	writeMod(t, dir, "vendor/github.com/x/y/go.mod", "module github.com/x/y\n")
+	writeMod(t, dir, ".tooling/skip/go.mod", "module example.com/skip\n")
+
+	pkgs, err := detectPackages(dir)
+	if err != nil {
+		t.Fatalf("detectPackages: %v", err)
+	}
+	if len(pkgs) != 3 {
+		t.Fatalf("want 3 packages, got %d: %+v", len(pkgs), pkgs)
+	}
+	// Root first, then sub-modules alphabetical by path.
+	if pkgs[0].Path != "." || pkgs[0].Name != "example.com/root" {
+		t.Errorf("[0] = %+v, want root", pkgs[0])
+	}
+	if pkgs[1].Path != "transports/zap" {
+		t.Errorf("[1] = %+v, want transports/zap", pkgs[1])
+	}
+	if pkgs[2].Path != "transports/zerolog" {
+		t.Errorf("[2] = %+v, want transports/zerolog", pkgs[2])
+	}
+	if pkgs[1].Changelog != "transports/zap/CHANGELOG.md" {
+		t.Errorf("[1].Changelog = %q", pkgs[1].Changelog)
+	}
+}
+
+func TestRenderInitTOML(t *testing.T) {
+	got := renderInitTOML("github", "acme", "widget", []initPkg{
+		{Name: "example.com/root", TagPrefix: "", Path: ".", Changelog: "CHANGELOG.md"},
+		{Name: "transports/zap", TagPrefix: "transports/zap", Path: "transports/zap", Changelog: "transports/zap/CHANGELOG.md"},
+	})
+	for _, want := range []string{
+		`[provider]`,
+		`name  = "github"`,
+		`owner = "acme"`,
+		`repo  = "widget"`,
+		`[packages."example.com/root"]`,
+		`tag_prefix = ""`,
+		`path       = "."`,
+		`[packages."transports/zap"]`,
+		`tag_prefix = "transports/zap"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered TOML missing %q\nfull:\n%s", want, got)
+		}
+	}
+}
+
+func TestInitCmd_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/acme/widget.git")
+	writeMod(t, dir, "go.mod", "module github.com/acme/widget\n")
+
+	prevWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWd) })
+
+	root := newRootCmd()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"init"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init: %v\nstderr: %s", err, stderr.String())
+	}
+
+	if !fileExists(filepath.Join(dir, "monorel.toml")) {
+		t.Fatal("monorel.toml not created")
+	}
+	if !fileExists(filepath.Join(dir, ".changeset", "README.md")) {
+		t.Fatal(".changeset/README.md not created")
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, "monorel.toml"))
+	for _, want := range []string{`name  = "github"`, `owner = "acme"`, `repo  = "widget"`, `[packages."github.com/acme/widget"]`} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("monorel.toml missing %q", want)
+		}
+	}
+
+	// Re-run without --force should refuse.
+	root2 := newRootCmd()
+	var stderr2 bytes.Buffer
+	root2.SetOut(&bytes.Buffer{})
+	root2.SetErr(&stderr2)
+	root2.SetArgs([]string{"init"})
+	if err := root2.Execute(); err == nil {
+		t.Fatal("expected error on rerun without --force")
+	}
+
+	// With --force, allowed.
+	root3 := newRootCmd()
+	root3.SetOut(&bytes.Buffer{})
+	root3.SetErr(&bytes.Buffer{})
+	root3.SetArgs([]string{"init", "--force"})
+	if err := root3.Execute(); err != nil {
+		t.Errorf("init --force should succeed: %v", err)
+	}
+}
+
+func TestInitCmd_OwnerRepoOverride(t *testing.T) {
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-q")
+	// No origin remote configured. --owner/--repo flags must be honored.
+	writeMod(t, dir, "go.mod", "module example.com/foo\n")
+
+	prevWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWd) })
+
+	root := newRootCmd()
+	var stderr bytes.Buffer
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"init", "--owner", "acme", "--repo", "widget", "--provider", "gitlab"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init: %v\nstderr: %s", err, stderr.String())
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, "monorel.toml"))
+	for _, want := range []string{`name  = "gitlab"`, `owner = "acme"`, `repo  = "widget"`} {
+		if !strings.Contains(string(body), want) {
+			t.Errorf("monorel.toml missing %q", want)
+		}
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	c := exec.Command("git", args...)
+	c.Dir = dir
+	if out, err := c.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func writeMod(t *testing.T, root, rel, body string) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -203,7 +203,7 @@ func TestDoInit_FreshRepo(t *testing.T) {
 	writeMod(t, dir, "go.mod", "module github.com/acme/widget\n")
 
 	var out bytes.Buffer
-	if err := doInit(&out, initOptions{Dir: dir}); err != nil {
+	if err := doInit(&out, initOptions{dir: dir}); err != nil {
 		t.Fatalf("doInit: %v", err)
 	}
 
@@ -233,7 +233,7 @@ func TestDoInit_RefusesWithoutForce(t *testing.T) {
 	}
 	writeMod(t, dir, "go.mod", "module example.com/foo\n")
 
-	err := doInit(&bytes.Buffer{}, initOptions{Dir: dir, Owner: "a", Repo: "b"})
+	err := doInit(&bytes.Buffer{}, initOptions{dir: dir, owner: "a", repo: "b"})
 	if err == nil {
 		t.Fatal("expected error when monorel.toml exists without --force")
 	}
@@ -265,7 +265,7 @@ changelog  = "CHANGELOG.md"
 	runGit(t, dir, "init", "-q")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/wrong/wrong.git")
 
-	if err := doInit(&bytes.Buffer{}, initOptions{Dir: dir, Force: true}); err != nil {
+	if err := doInit(&bytes.Buffer{}, initOptions{dir: dir, force: true}); err != nil {
 		t.Fatalf("doInit --force: %v", err)
 	}
 
@@ -303,10 +303,10 @@ changelog  = "CHANGELOG.md"
 	writeMod(t, dir, "go.mod", "module example.com/foo\n")
 
 	if err := doInit(&bytes.Buffer{}, initOptions{
-		Dir:   dir,
-		Force: true,
-		Owner: "new-team",
-		Repo:  "new-name",
+		dir:   dir,
+		force: true,
+		owner: "new-team",
+		repo:  "new-name",
 	}); err != nil {
 		t.Fatalf("doInit: %v", err)
 	}
@@ -338,9 +338,9 @@ func TestDoInit_ForcePreservesExistingReadme(t *testing.T) {
 	writeMod(t, dir, "go.mod", "module example.com/foo\n")
 
 	if err := doInit(&bytes.Buffer{}, initOptions{
-		Dir:   dir,
-		Owner: "acme",
-		Repo:  "widget",
+		dir:   dir,
+		owner: "acme",
+		repo:  "widget",
 	}); err != nil {
 		t.Fatalf("doInit: %v", err)
 	}
@@ -355,28 +355,91 @@ func TestDoInit_NoGoMod(t *testing.T) {
 	dir := t.TempDir()
 	runGit(t, dir, "init", "-q")
 	runGit(t, dir, "remote", "add", "origin", "https://github.com/acme/widget.git")
-	if err := doInit(&bytes.Buffer{}, initOptions{Dir: dir}); err == nil {
+	if err := doInit(&bytes.Buffer{}, initOptions{dir: dir}); err == nil {
 		t.Fatal("expected error when no go.mod files are present")
 	}
 }
 
 func TestDoInit_OwnerRepoOverrideNoRemote(t *testing.T) {
 	dir := t.TempDir()
-	// No git init at all. Must rely on flag-supplied values.
+	// No git init at all. Must rely on flag-supplied values. Provider
+	// stays at the default (github) because init validates against
+	// KnownProviders before writing.
 	writeMod(t, dir, "go.mod", "module example.com/foo\n")
 	if err := doInit(&bytes.Buffer{}, initOptions{
-		Dir:      dir,
-		Provider: "gitlab",
-		Owner:    "acme",
-		Repo:     "widget",
+		dir:   dir,
+		owner: "acme",
+		repo:  "widget",
 	}); err != nil {
 		t.Fatalf("doInit: %v", err)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, "monorel.toml"))
-	for _, want := range []string{`name  = "gitlab"`, `owner = "acme"`, `repo  = "widget"`} {
+	for _, want := range []string{`name  = "github"`, `owner = "acme"`, `repo  = "widget"`} {
 		if !strings.Contains(string(body), want) {
 			t.Errorf("monorel.toml missing %q", want)
 		}
+	}
+}
+
+func TestDoInit_RejectsUnknownProvider(t *testing.T) {
+	dir := t.TempDir()
+	writeMod(t, dir, "go.mod", "module example.com/foo\n")
+	err := doInit(&bytes.Buffer{}, initOptions{
+		dir:      dir,
+		provider: "gitlab", // not in KnownProviders today.
+		owner:    "acme",
+		repo:     "widget",
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+	if !strings.Contains(err.Error(), "not recognized") {
+		t.Errorf("err = %v, want one mentioning unrecognized provider", err)
+	}
+	if fileExists(filepath.Join(dir, "monorel.toml")) {
+		t.Error("monorel.toml should not be written when provider is rejected")
+	}
+}
+
+func TestDoInit_ForceMalformedConfigFallsThrough(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	// Existing config that fails to parse (unknown TOML key from
+	// the pre-v0.3.0 layout). config.Load returns an error; init
+	// should warn AND fall through to git auto-detect rather than
+	// silently using empty defaults.
+	stale := `[forge]
+name  = "github"
+owner = "old-team"
+repo  = "old-name"
+
+[packages."example.com/foo"]
+tag_prefix = ""
+path       = "."
+changelog  = "CHANGELOG.md"
+`
+	if err := os.WriteFile(filepath.Join(dir, "monorel.toml"), []byte(stale), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeMod(t, dir, "go.mod", "module example.com/foo\n")
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/auto-detected/from-origin.git")
+
+	var out bytes.Buffer
+	if err := doInit(&out, initOptions{dir: dir, force: true}); err != nil {
+		t.Fatalf("doInit: %v", err)
+	}
+	if !strings.Contains(out.String(), "warning") {
+		t.Errorf("expected a warning when malformed config falls through, got:\n%s", out.String())
+	}
+	body, _ := os.ReadFile(filepath.Join(dir, "monorel.toml"))
+	if !strings.Contains(string(body), `owner = "auto-detected"`) || !strings.Contains(string(body), `repo  = "from-origin"`) {
+		t.Errorf("expected git-origin auto-detect to fill owner/repo:\n%s", body)
+	}
+	// And the stale "old-team"/"old-name" must NOT appear (preserved
+	// values from a malformed file would be a footgun).
+	if strings.Contains(string(body), `"old-team"`) || strings.Contains(string(body), `"old-name"`) {
+		t.Errorf("stale values leaked from malformed config:\n%s", body)
 	}
 }
 
@@ -389,6 +452,11 @@ func runGit(t *testing.T, dir string, args ...string) {
 	}
 }
 
+// requireGit skips when git isn't on PATH. CI is expected to have
+// git; this guard exists for contributor laptops or sparse runner
+// images. If a CI run reports lots of skipped tests, check that git
+// is installed in the runner image — silent skips would otherwise
+// erode integration coverage unnoticed.
 func requireGit(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("git"); err != nil {


### PR DESCRIPTION
## Summary

Closes the last placeholder on the path to v1.0: \`monorel init\` scaffolds a starter \`monorel.toml\` and \`.changeset/\` directory in a fresh repo. Walks every \`go.mod\` under the working directory (skipping \`vendor/\`, \`node_modules/\`, hidden directories), infers \`provider\` / \`owner\` / \`repo\` from \`git config remote.origin.url\`, and writes one \`[packages]\` block per detected Go module.

## What's in the box

\`\`\`sh
monorel init
# Wrote monorel.toml with 2 package(s):
#   github.com/acme/widget (path: ., tag prefix: "")
#   sub/foo (path: sub/foo, tag prefix: "sub/foo")
# Created .changeset/ with a README.
# Next steps:
#   monorel validate     # confirm the config
#   monorel add          # write your first changeset
\`\`\`

Flags:
- \`--provider\` (default \`github\`; falls through to existing monorel.toml on \`--force\`).
- \`--owner\` / \`--repo\` (override auto-detection from git origin or existing config).
- \`--force\` (overwrite existing monorel.toml; preserves hand-edited provider block from the existing file).

## Library choices

- **\`golang.org/x/mod/modfile.Parse\`** for go.mod parsing. The official Go modfile parser, used by \`go\` itself; handles every spec-allowed shape (block-form modules, comments, quoted paths, retract/exclude/replace directives) without our hand-rolled scanner reinventing edge cases.
- **\`net/url.Parse\`** for schemed git remote URLs (\`https://\`, \`http://\`, \`ssh://\`, \`git://\`, with credentials, custom ports, IPv6 hosts). The SCP-like SSH form (\`git@host:owner/repo\`) stays hand-rolled since it's not a real URL.
- **\`github.com/BurntSushi/toml\`** (existing project dep) for *reading* the existing config on \`--force\`. *Writing* the rendered TOML is hand-rolled \`fmt.Fprintf\` (~25 lines) for cosmetic reasons: aligned \`=\`, leading file comment, no nested-block indentation. The encoder would lose all three.

## Two review rounds applied

The implementation went through two superpowers:code-reviewer rounds. Findings (and where they landed):

**Round 1:**
- Critical: none.
- Important — git URL parser silently produced wrong owner/repo for \`file://\` URLs and gave a vague error for \`ssh://\`-prefixed URLs. **Fixed via \`net/url.Parse\` swap.**
- Important — end-to-end tests used \`os.Chdir\`, would Heisenbug under future \`t.Parallel()\`. **Fixed by extracting \`runInit\` body into \`doInit(out, opts)\` so tests pass an explicit working directory.**
- Important — \`--force\` silently clobbered hand-edited provider/owner/repo. **Fixed by reloading existing config on \`--force\` and treating its values as defaults.**
- Minors fixed: README stat errors no longer silently skipped, \`--provider\` help text trimmed, \`requireGit\` test helper added.

**Round 2:**
- Important — \`init\` would write configs that \`validate\` rejects (e.g. \`--provider gitlab\`). **Fixed by validating the resolved provider against \`config.KnownProviders\` upfront.**
- Important — silent fallthrough on malformed existing config (\`Load\` errors swallowed). **Fixed: now warns to output and falls through to git auto-detect.**
- Important — missing test for the malformed-config fallthrough path. **Added \`TestDoInit_ForceMalformedConfigFallsThrough\`.**
- Minor: \`initOptions\` struct fields lowercased to match the unexported type, README stat error message uses the \`readmePath\` variable, \`requireGit\` got a comment explaining skip semantics.

**Deferred to separate-PR scope** (called out in commits, agreed with reviewer):
- \`--exclude <pattern>\` flag for non-standard build dirs (\`dist/\`, \`target/\`, etc).
- Atomic-write helper across init/add/release (project-wide consistency change, not init-specific).

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./...\` clean — 17 init test cases including URL-parser table, package detection at three nesting levels, \`--force\` preserve / override / malformed-fallthrough cases, unknown-provider rejection.
- [x] \`go vet ./...\` clean.
- [x] \`staticcheck ./...\` clean.
- [x] Smoke-tested \`init\` end-to-end on a fresh repo with \`ssh://git@github.com:2222/acme/widget.git\` (the case the original parser broke on).
- [x] Generated \`monorel.toml\` round-trips through \`monorel validate\` cleanly.

## Path to 1.0

This is item 2 of 6 from the v1.0 punch list:

- ~~Item 1: loglayer-go migration~~ (done in loglayer-go#50)
- **Item 2: \`monorel init\` (this PR)**
- Item 3: PAT/GitHub App guidance + helper for required-status-check anti-recursion.
- Item 4: another release cycle of trailer-format soak time (passive).
- Item 5: API stability declaration.
- Item 6: \`whats-new.md\` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)