### PR TITLE
feat: add monorel doctor command + public doctor package

### DIFF
--- a/.changeset/doctor-check.md
+++ b/.changeset/doctor-check.md
@@ -1,0 +1,48 @@
+---
+"monorel.disaresta.com": minor
+---
+
+Add `monorel doctor` command and public `doctor` package.
+
+The new diagnostic catches a stale-branch + squash-merge revival of a
+previously-consumed `.changeset/*.md` file: a contributor branches
+from `main` BEFORE a release commit lands, and their PR is later
+squash-merged. GitHub's squash-merge re-introduces the file the
+release commit deleted; the next release plan re-ships the same
+content under a new version. monorel's planner does what its spec
+says (changesets on main = stuff to release); the input is the bug.
+doctor catches the bad input.
+
+CLI:
+
+```sh
+monorel doctor          # text output
+monorel doctor --json   # machine-readable
+```
+
+Exits non-zero on any error-severity finding so CI can gate on it.
+
+Library:
+
+```go
+findings, err := doctor.Run(doctor.Options{
+    ChangesetDir: ".changeset",
+    GitLog:       repo.DeletedFilesInCommitsMatching,
+})
+```
+
+`doctor.GitLog` is a function value; any git library works as the
+backing store. The check itself walks `git log --diff-filter=D
+--grep='chore(release):'` to build the set of previously-deleted
+changeset filenames, then intersects with the live `.changeset/`
+directory.
+
+Built as a check-runner internally so future checks (orphan
+changesets, malformed frontmatter, etc.) drop in without
+re-architecting; today only `revived-changeset` ships.
+
+Verified end-to-end against the real revival incident on the monorel
+repo (PR #29 changeset that PR #30 deleted but PRs #31 + #32
+revived via stale-branch + squash-merge): doctor flags it as a
+SeverityError with check name `revived-changeset`, the prior PR
+hand-cleanup (#34) is no longer needed.

--- a/.changeset/doctor-check.md
+++ b/.changeset/doctor-check.md
@@ -26,8 +26,8 @@ Library:
 
 ```go
 findings, err := doctor.Run(doctor.Options{
-    ChangesetDir: ".changeset",
-    GitLog:       repo.DeletedFilesInCommitsMatching,
+    RepoDir: ".",
+    GitLog:  repo.DeletedFilesInCommitsMatching,
 })
 ```
 

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -71,3 +71,35 @@ Skipping reviews "because the change is small" is the most common way regression
 - **Skip** for trivial commits: typo fixes, single-line config tweaks, dependency bumps with a lockfile change. The bar is "would a reviewer add value here?". If yes, run it.
 
 The reviewer subagent gets fresh context (no session history). Brief it explicitly with what you built, what it should do, and the SHA range to look at; the precision of the brief is the precision of the review.
+
+## Run a documentation review when the change touches docs
+
+If the diff includes any of:
+
+- Markdown under `docs/src/` (the VitePress site)
+- A new or modified `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, or `.claude/rules/*.md`
+- GoDoc on a newly exported symbol (function, type, constant, variable)
+- A new or modified `whats-new.md` / `CHANGELOG.md` entry
+- `.changeset/<name>.md` body text (since it ends up in the auto-generated changelog verbatim)
+
+dispatch a separate documentation review with the framing **"act as a senior Go developer encountering this material for the first time"**. The reviewer should evaluate the changed docs along three axes:
+
+1. **Accuracy.** Do the examples compile? Do the referenced types, functions, fields, and config keys actually exist with the names and signatures shown? Do the claims match the code's current behavior?
+2. **Consistency.** Does the new prose match the existing docs' tone, structure, terminology, and section conventions? If similar concepts are documented elsewhere, are they framed the same way? Are headings parallel to the rest of the page?
+3. **Clarity.** Could a senior Go developer (familiar with the language and ecosystem but new to this codebase) follow the explanation on first read? Is the lead-with-the-conclusion principle followed? Are there hidden assumptions a newcomer wouldn't have?
+
+A standard `superpowers:requesting-code-review` will inspect docs alongside code, but tends to spend its budget on the implementation and treat docs as window-dressing. A separately-framed documentation pass catches things the code-focused reviewer skips: stale field names in examples, copy-paste from earlier docs that no longer apply, terminology drift, hand-wavy steps, missing prerequisites, and broken cross-links.
+
+### Why
+
+Docs are load-bearing for a tool like monorel. Mistakes in CLI examples don't fail tests; they break a user's first-run experience and erode trust. The doctor PR's own review history showed two doc-side findings caught only by separate passes:
+
+- A `.changeset/<name>.md` body example that referenced a renamed `Options` field. Without the second review, the broken snippet would have shipped verbatim into the auto-generated CHANGELOG entry.
+- Em-dashes in GoDoc that violated the project's own style rule. The code-quality reviewer doesn't grep for style; only the documentation-focused pass surfaces those.
+
+### How to apply
+
+- **Mandatory** when the diff's docs surface area is non-trivial (a new doc page, a new GoDoc-exported symbol, a new `whats-new.md` entry, a `.changeset/<name>.md` longer than a few lines).
+- **Optional but valuable** when modifying existing docs: the reviewer's "first encounter" framing reliably surfaces stale assumptions that the original author has long since internalized.
+- **Skip** for pure-code PRs that touch docs only mechanically (e.g. bumping a version number in a changelog stub, fixing a typo).
+- Brief the reviewer with: the changed file paths, the framing ("senior Go developer, first read"), and the three axes (accuracy / consistency / clarity). Don't tell it the answer; the review is most useful when the reviewer surfaces what surprises a fresh reader.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -21,7 +21,7 @@ Then `git push --force-with-lease` (never `--force`).
 
 ## Why
 
-GitHub's squash-merge takes the branch tip's tree and creates a commit with parent = current main. If a branch was based on stale main, files that were deleted on main but still exist on the branch get re-added by the squash-merge. monorel itself was bitten by this exact pattern: PR #30 deleted a `.changeset/*.md` file as part of the v0.7.0 release, then PR #31 (created from a stale local main) re-introduced the file via squash-merge, and the next release-pr cycle proposed to re-ship the same content as v0.8.0.
+GitHub's squash-merge takes the branch tip's tree and creates a commit with parent = current main. If a branch was based on stale main, files that were deleted on main but still exist on the branch get re-added by the squash-merge. monorel itself was bitten by this exact pattern: `disaresta-org/monorel#30` deleted a `.changeset/*.md` file as part of the v0.7.0 release, then `disaresta-org/monorel#31` (created from a stale local main) re-introduced the file via squash-merge, and the next release-pr cycle proposed to re-ship the same content as v0.8.0.
 
 The rule exists to make that class of bug impossible by construction. If the local branch is rebased onto current `origin/main` before the PR opens, the squash diff can never contain a file the most-recent release-cut commit deleted (because the branch already incorporated that deletion).
 
@@ -40,9 +40,9 @@ The rule exists to make that class of bug impossible by construction. If the loc
 
 ## Always run a code review before committing the work that finishes a task
 
-Before the commit that completes a feature, fix, or refactor (the kind of commit that ends up in a PR), invoke the `superpowers:requesting-code-review` skill OR the `/simplify` skill against the diff. Treat it as part of the commit ritual, like running tests.
+Before the commit that completes a feature, fix, or refactor (the kind of commit that ends up in a PR), invoke a code-review subagent against the diff. Treat it as part of the commit ritual, like running tests.
 
-Concretely:
+Concretely (skill names current as of this writing; substitute today's equivalent if they've been renamed):
 
 ```
 # After implementing a task and confirming go build / go test pass:
@@ -55,10 +55,10 @@ Then fix any Critical or Important findings before pushing. Minor findings are n
 
 ## Why
 
-Code reviews catch things humans (including me) consistently miss:
+Code reviews catch things humans (including me) consistently miss. Concrete cases from `disaresta-org/monorel#35` (the doctor-feature PR):
 
-- The `monorel doctor` PR went through a code review and the reviewer flagged `validate.Severity` vs `doctor.Severity` shape inconsistency, a misleading "match validate's envelope" JSON comment, and an `Options.ChangesetDir` field whose name didn't match its constraint. I would have shipped all three without the review.
-- A second review on the same PR caught a stale `ChangesetDir` reference in the `.changeset/<name>.md` body (which would have ended up verbatim in the released CHANGELOG) and two em-dashes in GoDoc that violated the project's own style rule.
+- First review flagged a `Severity` shape inconsistency between two sibling packages, a misleading JSON-envelope-parity comment, and an option field whose name didn't match its constraint. I would have shipped all three without the review.
+- Second review caught a stale field reference in the released changeset body (which would have ended up verbatim in the auto-generated CHANGELOG) and two em-dashes in GoDoc that violated the project's own style rule.
 - A `/simplify` pass on the same PR found three duplicated patterns worth extracting (dedup-and-sort helper, hardcoded check name literal, severity-label ternary).
 
 Skipping reviews "because the change is small" is the most common way regressions ship. The review subagents are cheap; the cost of an issue caught after merge (broken release pipeline, orphaned changelog text, `--no-verify` band-aids) is high.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -37,3 +37,37 @@ The rule exists to make that class of bug impossible by construction. If the loc
 - Force-pushing to `main` or other shared protected branches. Don't.
 - Resolving genuine merge conflicts during the rebase. Read both sides; never `git checkout --theirs/ours` blindly.
 - Skipping the rule with `--no-verify`. The rule is the rule even when the hook isn't enforcing it.
+
+## Always run a code review before committing the work that finishes a task
+
+Before the commit that completes a feature, fix, or refactor (the kind of commit that ends up in a PR), invoke the `superpowers:requesting-code-review` skill OR the `/simplify` skill against the diff. Treat it as part of the commit ritual, like running tests.
+
+Concretely:
+
+```
+# After implementing a task and confirming go build / go test pass:
+/superpowers:requesting-code-review     # for substantive changes
+# or
+/simplify                                 # for cleanup-oriented passes
+```
+
+Then fix any Critical or Important findings before pushing. Minor findings are non-blocking but should be noted.
+
+## Why
+
+Code reviews catch things humans (including me) consistently miss:
+
+- The `monorel doctor` PR went through a code review and the reviewer flagged `validate.Severity` vs `doctor.Severity` shape inconsistency, a misleading "match validate's envelope" JSON comment, and an `Options.ChangesetDir` field whose name didn't match its constraint. I would have shipped all three without the review.
+- A second review on the same PR caught a stale `ChangesetDir` reference in the `.changeset/<name>.md` body (which would have ended up verbatim in the released CHANGELOG) and two em-dashes in GoDoc that violated the project's own style rule.
+- A `/simplify` pass on the same PR found three duplicated patterns worth extracting (dedup-and-sort helper, hardcoded check name literal, severity-label ternary).
+
+Skipping reviews "because the change is small" is the most common way regressions ship. The review subagents are cheap; the cost of an issue caught after merge (broken release pipeline, orphaned changelog text, `--no-verify` band-aids) is high.
+
+## How to apply
+
+- **Mandatory** before the final commit on a feature branch.
+- **Mandatory** before `gh pr create`.
+- **Optional but valuable** mid-implementation when stuck or after a non-trivial refactor.
+- **Skip** for trivial commits: typo fixes, single-line config tweaks, dependency bumps with a lockfile change. The bar is "would a reviewer add value here?". If yes, run it.
+
+The reviewer subagent gets fresh context (no session history). Brief it explicitly with what you built, what it should do, and the SHA range to look at; the precision of the brief is the precision of the review.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,39 @@
+# Git Workflow Rules
+
+## Always rebase on the parent branch before opening (or pushing to) a PR
+
+Before `gh pr create`, always:
+
+```sh
+git fetch origin <parent>
+git rebase origin/<parent>
+```
+
+Where `<parent>` is the branch the PR will target (typically `main`).
+
+If the local branch is stacked on commits that have already merged via squash-merge (so the local history doesn't match remote), the right form is:
+
+```sh
+git rebase --onto origin/<parent> <merge-base-of-just-this-PR's-work> <branch>
+```
+
+Then `git push --force-with-lease` (never `--force`).
+
+## Why
+
+GitHub's squash-merge takes the branch tip's tree and creates a commit with parent = current main. If a branch was based on stale main, files that were deleted on main but still exist on the branch get re-added by the squash-merge. monorel itself was bitten by this exact pattern: PR #30 deleted a `.changeset/*.md` file as part of the v0.7.0 release, then PR #31 (created from a stale local main) re-introduced the file via squash-merge, and the next release-pr cycle proposed to re-ship the same content as v0.8.0.
+
+The rule exists to make that class of bug impossible by construction. If the local branch is rebased onto current `origin/main` before the PR opens, the squash diff can never contain a file the most-recent release-cut commit deleted (because the branch already incorporated that deletion).
+
+## How to apply
+
+- **Always** before `gh pr create`. Treat it as part of the PR-creation ritual.
+- **Always** before `git push --force-with-lease` to a long-lived branch where main has advanced. For a branch you've just created off freshly-pulled main and pushed once, you don't need to re-rebase before every push; the rule is "rebase when main has advanced."
+- Use `git rebase --onto origin/<parent>` form when the local branch's lower commits are squash-merge ancestors that won't replay cleanly. Replaying just the work-in-this-PR's commits keeps the rebase trivial.
+- After the rebase succeeds, run the build / tests once before pushing. A rebase can produce silent semantic conflicts that compile but break behavior.
+
+## What this rule does NOT cover
+
+- Force-pushing to `main` or other shared protected branches. Don't.
+- Resolving genuine merge conflicts during the rebase. Read both sides; never `git checkout --theirs/ours` blindly.
+- Skipping the rule with `--no-verify`. The rule is the rule even when the hook isn't enforcing it.

--- a/ci/github/README.md
+++ b/ci/github/README.md
@@ -6,10 +6,10 @@ Composite action that downloads the monorel binary for the runner's OS+arch and 
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `command` | required | `pr` (upsert / close the always-open release PR via `monorel preview --upsert`) or `release` (run the full local→push→publish pipeline). |
+| `command` | required | `pr` (upsert / close the always-open release PR via `monorel preview --upsert`), `release` (run the full local→push→publish pipeline), or `doctor` (run `monorel doctor`; exits non-zero on error-severity findings). |
 | `version` | `latest` | monorel version to run (e.g. `v1.2.3`). |
 | `config` | `monorel.toml` | Path to the config file. |
-| `token` | the workflow's `GITHUB_TOKEN` | Token for provider API calls. Needs `contents: write` and `pull-requests: write`. |
+| `token` | the workflow's `GITHUB_TOKEN` | Token for provider API calls. Needs `contents: write` and `pull-requests: write`. The `doctor` command needs no token; `contents: read` alone is sufficient. |
 
 The `release` command runs three monorel invocations in order:
 

--- a/ci/github/action.yml
+++ b/ci/github/action.yml
@@ -1,5 +1,5 @@
 name: monorel
-description: "Run monorel against the current repo. Commands: pr (upsert release PR), release (cut a release)."
+description: "Run monorel against the current repo. Commands: pr (upsert release PR), release (cut a release), doctor (diagnose repo state)."
 author: disaresta-org
 branding:
   icon: tag
@@ -7,7 +7,7 @@ branding:
 
 inputs:
   command:
-    description: "Either 'pr' (upsert / close the always-open release PR) or 'release' (cut a release on the current commit, push tags, publish provider releases)."
+    description: "One of 'pr' (upsert / close the always-open release PR), 'release' (cut a release on the current commit, push tags, publish provider releases), or 'doctor' (diagnose repository state; exit non-zero on error-severity findings)."
     required: true
   version:
     description: "monorel version to run, e.g. v1.2.3. Defaults to 'latest'."
@@ -164,8 +164,15 @@ runs:
             git push --follow-tags
             monorel publish --config "$CONFIG"
             ;;
+          doctor)
+            # Pre-merge sanity check. Today's only built-in check
+            # surfaces stale-branch + squash-merge changeset revivals.
+            # Exits non-zero on error-severity findings, which fails
+            # the workflow step so the PR can't merge until cleaned up.
+            monorel doctor --config "$CONFIG"
+            ;;
           *)
-            echo "::error::unknown command: $COMMAND (expected 'pr' or 'release')"
+            echo "::error::unknown command: $COMMAND (expected 'pr', 'release', or 'doctor')"
             exit 1
             ;;
         esac

--- a/docs/src/_partials/gitea-doctor-yml.md
+++ b/docs/src/_partials/gitea-doctor-yml.md
@@ -1,0 +1,17 @@
+```yaml
+name: doctor
+on:
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with: { fetch-depth: 0 }
+      - uses: disaresta-org/monorel/ci/github@v0.8.0
+        with:
+          command: doctor
+```

--- a/docs/src/_partials/github-doctor-yml.md
+++ b/docs/src/_partials/github-doctor-yml.md
@@ -1,0 +1,24 @@
+```yaml
+name: doctor
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history so doctor's git-log scan sees every prior
+          # chore(release): commit. The default shallow clone
+          # (fetch-depth: 1) would miss them and turn doctor into a
+          # no-op.
+          fetch-depth: 0
+      - uses: disaresta-org/monorel/ci/github@v0.8.0
+        with:
+          command: doctor
+```

--- a/docs/src/_partials/gitlab-ci-yml.md
+++ b/docs/src/_partials/gitlab-ci-yml.md
@@ -4,8 +4,19 @@ default:
   image: ghcr.io/disaresta-org/monorel:0.6.0
 
 stages:
+  - doctor
   - release-pr
   - release
+
+# Pre-merge sanity check on the proposed MR. Exits non-zero on any
+# error-severity finding (today: stale-branch + squash-merge changeset
+# revival), which fails the pipeline.
+doctor:
+  stage: doctor
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - monorel doctor
 
 # Maintain the always-open release MR. Fires on every push to the
 # default branch except the chore(release): merge commit.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -48,8 +48,8 @@ import (
 func main() {
 	repo := git.Open(".")
 	findings, err := doctor.Run(doctor.Options{
-		ChangesetDir: ".changeset",
-		GitLog:       repo.DeletedFilesInCommitsMatching,
+		RepoDir: ".",
+		GitLog:  repo.DeletedFilesInCommitsMatching,
 	})
 	if err != nil {
 		panic(err)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -5,7 +5,7 @@ description: "monorel's Go library API surface for programmatic use: pure-functi
 
 # Library API
 
-monorel ships a Go library API alongside the CLI. From v0.2.0 onward, six pure-function packages are public and SemVer-committed:
+monorel ships a Go library API alongside the CLI. From v0.2.0 onward, the following pure-function packages are public and SemVer-committed:
 
 | Package | Purpose | Entry points |
 |---------|---------|--------------|
@@ -15,6 +15,7 @@ monorel ships a Go library API alongside the CLI. From v0.2.0 onward, six pure-f
 | [`semver`](https://pkg.go.dev/monorel.disaresta.com/semver) | Bump-level abstraction, version application, initial-release rules. | `Apply`, `InitialFromBump`, `Max`, `ParseBumpLevel`, `IsValid`, `Compare` |
 | [`validate`](https://pkg.go.dev/monorel.disaresta.com/validate) | Fault-tolerant static checks against a config + changeset directory. | `Run`, `HasErrors`, `HasWarnings` |
 | [`changelog`](https://pkg.go.dev/monorel.disaresta.com/changelog) | Keep-a-Changelog renderer with non-destructive insertion. | `Insert`, `WriteFile`, `Today` |
+| [`doctor`](https://pkg.go.dev/monorel.disaresta.com/doctor) | Repository state diagnostics the planner can't catch (e.g. revived changesets). | `Run`, `Finding`, `Severity`, `GitLog` |
 
 Module path: `monorel.disaresta.com`. Install:
 
@@ -30,6 +31,36 @@ Full GoDoc with runnable examples lives on [pkg.go.dev](https://pkg.go.dev/monor
 - **IDE / editor plugin.** You want "is this changeset frontmatter valid?" or "does this package key exist in monorel.toml?" feedback. Use `changeset.Parse` + `validate.Run`.
 - **Repo audit tool.** You want to surface monorel-shaped state across many repos. Use `config.Load` + `validate.Run`.
 - **Custom changeset authoring.** A bot or workflow that produces `.changeset/*.md` files programmatically. Use `changeset.Changeset` + `Changeset.WriteFile`.
+- **Repo health diagnostics.** A pre-merge or pre-release CI step that fails closed when a previously-shipped changeset is back on disk (the stale-branch + squash-merge revival pattern). Use `doctor.Run` with a `GitLog` adapter over your existing git library.
+
+## doctor
+
+The `doctor` package wraps a small, extensible check-runner. Today it ships a single check, `revived-changeset`, that catches a common failure mode: when a contributor branches from `main` BEFORE a release commit and squash-merges later, GitHub re-introduces the changeset files the release commit deleted. The next release plan re-ships the same content under a new version.
+
+```go
+import (
+	"fmt"
+
+	"monorel.disaresta.com/doctor"
+	"monorel.disaresta.com/internal/git" // or your own git seam
+)
+
+func main() {
+	repo := git.Open(".")
+	findings, err := doctor.Run(doctor.Options{
+		ChangesetDir: ".changeset",
+		GitLog:       repo.DeletedFilesInCommitsMatching,
+	})
+	if err != nil {
+		panic(err)
+	}
+	for _, f := range findings {
+		fmt.Printf("%s [%s] %s: %s\n", f.Severity, f.CheckName, f.Path, f.Message)
+	}
+}
+```
+
+`doctor.GitLog` is a function value, not an interface, so callers can adapt any git library (go-git, libgit2 bindings, a local cache) without conforming to a struct shape. Pass any function with signature `func(messageGrep string) (deletedPaths []string, err error)` that scans commit history for deletions in commits whose message contains the substring.
 
 ## What's NOT public
 
@@ -40,7 +71,7 @@ These packages stay in `internal/` deliberately and are not part of the SemVer c
 | `release` | Writes files, creates commits, creates tags. Promoting locks side-effect ordering. |
 | `orchestrator` | Provider-coupled (calls `provider.Client`); not useful without it. |
 | `provider` | Host-abstraction interface; promoting locks every interface change as breaking. |
-| `git` | Shell-out implementation detail. |
+| `git` | Shell-out implementation detail. The doctor package's `GitLog` function-value seam is how callers get at git history without depending on it. |
 | `cli` | Cobra wiring. The library is the API; the CLI is one consumer. |
 
 Side-effect-bearing packages should never be public commitments — every refactor would be a SemVer break.

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -325,7 +325,17 @@ Exit codes:
 - `0`: no findings.
 - `1`: one or more error-severity findings.
 
-Mechanically, doctor walks `git log --diff-filter=D --grep='chore(release):'` to build the set of changeset filenames previous releases consumed, then intersects with the live `.changeset/` directory. The check costs one `git log` invocation and is cheap to run on every PR (e.g. as a lint step alongside `monorel validate`).
+Mechanically, doctor walks `git log --diff-filter=D --grep='chore(release):'` to build the set of changeset filenames previous releases consumed, then intersects with the live `.changeset/` directory. The check costs one `git log` invocation and is cheap to run on every PR.
+
+::: tip Wire it into CI
+The check is most useful as a pre-merge gate: CI checks out fresh against the actual base, so the git-log scan always reflects current main. Each integration page documents the workflow file:
+
+- [GitHub](/integrations/github#doctor-yml-pre-merge-sanity-check-recommended)
+- [Gitea / Forgejo](/integrations/gitea) (under Workflows)
+- [GitLab](/integrations/gitlab#workflows) (the `doctor` stage in the canonical `.gitlab-ci.yml`)
+
+Local pre-commit / pre-push hooks are NOT a good fit: the bug class doctor catches arises from GitHub's squash-merge taking a stale branch tree, which the local branch state can't observe directly. CI on PRs is the right gate.
+:::
 
 The same logic is exposed as a Go library at [`monorel.disaresta.com/doctor`](/api#doctor) for callers who want to embed the check in custom CI without shelling out.
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: "Per-command reference for monorel: add, plan, status, validate, apply, tag, release, preview, publish, pre, init."
+description: "Per-command reference for monorel: add, plan, status, validate, apply, tag, release, preview, publish, pre, init, doctor."
 ---
 
 # CLI Reference
@@ -288,6 +288,46 @@ monorel init
 | `--force` | bool | Overwrite an existing `monorel.toml` (otherwise the command refuses). |
 
 Refuses to run without at least one `go.mod`. Existing `.changeset/README.md` is preserved; only created when missing.
+
+## `monorel doctor`
+
+Diagnose repository state issues monorel's planner won't catch on its own. Today the only built-in check is `revived-changeset`: a `.changeset/*.md` file currently on disk that a previous `chore(release):` commit deleted, indicating a stale-branch + squash-merge revival. The next release would re-ship the same content under a new version.
+
+```sh
+monorel doctor
+# No findings. Repository state looks healthy.
+
+monorel doctor --json
+# { "findings": [...], "errors": 0, "warnings": 0 }
+```
+
+When something's wrong:
+
+```sh
+monorel doctor
+# ERRORS:
+#   - revived-changeset: .changeset/foo.md was deleted by a previous
+#     chore(release) commit but is back on disk; likely cause:
+#     stale-branch + squash-merge revived it. Delete the file and
+#     the next release plan will re-evaluate. [.changeset/foo.md]
+#
+# 1 error(s), 0 warning(s).
+echo $?
+# 1
+```
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--json` | bool | Emit findings as JSON. Schema: `{ findings: [{severity, check_name, path, message}], errors, warnings }`. |
+
+Exit codes:
+
+- `0`: no findings.
+- `1`: one or more error-severity findings.
+
+Mechanically, doctor walks `git log --diff-filter=D --grep='chore(release):'` to build the set of changeset filenames previous releases consumed, then intersects with the live `.changeset/` directory. The check costs one `git log` invocation and is cheap to run on every PR (e.g. as a lint step alongside `monorel validate`).
+
+The same logic is exposed as a Go library at [`monorel.disaresta.com/doctor`](/api#doctor) for callers who want to embed the check in custom CI without shelling out.
 
 ## Persistent flags
 

--- a/docs/src/integrations/gitea.md
+++ b/docs/src/integrations/gitea.md
@@ -66,6 +66,12 @@ Gitea Actions (since Gitea 1.21, Forgejo 1.21) implements GitHub Actions' workfl
 
 The auto-injected `GITHUB_TOKEN` is enough for the basic case (open / update / close the release PR; create tags; create Releases). The PAT escalation for required-status-check repos is documented under [Tokens and required status checks](#tokens-and-required-status-checks) below.
 
+`.gitea/workflows/doctor.yml` (recommended pre-merge sanity check; mirrors the GitHub setup):
+
+<!--@include: ../_partials/gitea-doctor-yml.md-->
+
+`fetch-depth: 0` is required so doctor's git-log scan sees prior `chore(release):` commits. See [`monorel doctor`](/cli-reference#monorel-doctor) for what the check covers.
+
 ### Local CLI (no CI)
 
 Same shape as the [Working without CI](/getting-started#working-without-ci) section of Getting Started, with `GITEA_TOKEN` instead of `GITHUB_TOKEN`:

--- a/docs/src/integrations/github.md
+++ b/docs/src/integrations/github.md
@@ -77,13 +77,21 @@ The split exists because GitHub validates that the tag is already on the remote 
 
 The `if:` filter is `startsWith(...)`, not `contains(...)`. monorel's release commit subject is exactly `chore(release): <pkg> <ver>` (or a comma-joined list for multi-package releases). The prefix check is precise. Use `workflow_dispatch` for the bootstrap path before monorel-driven releases are wired up (see the [bootstrap recipe](/recipes/bootstrapping-monorel)).
 
+### `doctor.yml`: pre-merge sanity check (recommended)
+
+A separate workflow that runs `monorel doctor` against every PR. Today's only built-in check catches stale-branch + squash-merge changeset revivals; the workflow exits non-zero on any error-severity finding so the PR can't merge until cleaned up. See [`monorel doctor`](/cli-reference#monorel-doctor) for the diagnostic itself.
+
+<!--@include: ../_partials/github-doctor-yml.md-->
+
+`fetch-depth: 0` is required: doctor's `git log --grep='chore(release):'` scan needs full history to see prior release commits. The default shallow checkout would miss them and turn the check into a no-op.
+
 ### Action wrapper inputs
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `command` | required | `pr` (stage the release PR's diff via `monorel apply` + `monorel preview --upsert`) or `release` (post-merge: `monorel tag` + push + `monorel publish`). |
+| `command` | required | `pr` (stage the release PR's diff via `monorel apply` + `monorel preview --upsert`), `release` (post-merge: `monorel tag` + push + `monorel publish`), or `doctor` (run `monorel doctor`; exit non-zero on error-severity findings). |
 | `version` | `latest` | Pin a specific monorel version, e.g. `v0.6.0`. |
-| `token` | the workflow's auto-generated `GITHUB_TOKEN` | Token used for GitHub API calls. Needs `contents: write` and `pull-requests: write` permissions on the workflow. Override with a PAT or App token via `secrets.<name>` syntax. |
+| `token` | the workflow's auto-generated `GITHUB_TOKEN` | Token used for GitHub API calls. Needs `contents: write` and `pull-requests: write` permissions on the workflow. The `doctor` command needs no token; `contents: read` alone is sufficient. Override with a PAT or App token via `secrets.<name>` syntax. |
 | `config` | `monorel.toml` | Path to the config file. |
 
 ### Chaining downstream workflows (deploy-docs, build-binaries, etc.)

--- a/docs/src/integrations/gitlab.md
+++ b/docs/src/integrations/gitlab.md
@@ -50,7 +50,7 @@ For self-hosted instances or sub-group projects, use a project access token or g
 
 ## Workflows
 
-monorel doesn't ship a GitLab-specific CI wrapper. The simplest setup uses GitLab CI with the published Docker image (`ghcr.io/disaresta-org/monorel`). Two-stage pipeline: `release-pr` keeps the always-open MR up to date on every push to the default branch; `release` cuts the release once the MR is merged.
+monorel doesn't ship a GitLab-specific CI wrapper. The simplest setup uses GitLab CI with the published Docker image (`ghcr.io/disaresta-org/monorel`). Three-stage pipeline: `doctor` runs a pre-merge sanity check on every MR (catches stale-branch + squash-merge changeset revivals and other diagnostic issues; see [`monorel doctor`](/cli-reference#monorel-doctor)); `release-pr` keeps the always-open MR up to date on every push to the default branch; `release` cuts the release once the MR is merged.
 
 `.gitlab-ci.yml`:
 

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -25,31 +25,21 @@ import (
 	"strings"
 )
 
-// Severity classifies a [Finding]'s urgency.
-type Severity int
+// Severity classifies a [Finding]'s urgency. The string form is the
+// JSON wire value; matches the constants the validate package uses
+// for the same concept.
+type Severity string
 
 const (
-	// SeverityWarn flags an issue that may not break a release but
-	// usually indicates a mistake. Callers may surface as a warning
-	// without failing the build.
-	SeverityWarn Severity = iota
-
 	// SeverityError flags an issue that will produce a wrong
 	// release if not fixed. Callers should fail closed.
-	SeverityError
-)
+	SeverityError Severity = "error"
 
-// String returns "warn" or "error".
-func (s Severity) String() string {
-	switch s {
-	case SeverityWarn:
-		return "warn"
-	case SeverityError:
-		return "error"
-	default:
-		return "unknown"
-	}
-}
+	// SeverityWarning flags an issue that may not break a release
+	// but usually indicates a mistake. Callers may surface as a
+	// warning without failing the build.
+	SeverityWarning Severity = "warning"
+)
 
 // Finding is one issue [Run] surfaced.
 type Finding struct {
@@ -80,10 +70,17 @@ type GitLog func(messageGrep string) ([]string, error)
 
 // Options configures a [Run] invocation.
 type Options struct {
-	// ChangesetDir is the absolute or repo-relative path to the
-	// `.changeset/` directory whose live contents should be
-	// checked. Required.
-	ChangesetDir string
+	// RepoDir is the repository root (the directory containing
+	// `monorel.toml` and `.changeset/`). Required.
+	//
+	// The doctor package only supports the canonical changeset
+	// directory name `.changeset` — both because monorel itself
+	// only writes that name and because the historical scan
+	// matches against `git log --name-only` output, which always
+	// emits repo-relative paths starting with that prefix. If a
+	// future monorel version supports a different name, this
+	// option would gain a sibling for the override.
+	RepoDir string
 
 	// GitLog returns previously-deleted files for a given commit-
 	// message substring. Required.
@@ -112,8 +109,8 @@ const DefaultReleaseCommitGrep = "chore(release):"
 // and surfaced issues in the repository; callers decide whether to
 // treat findings as blocking based on each finding's Severity.
 func Run(opts Options) ([]Finding, error) {
-	if opts.ChangesetDir == "" {
-		return nil, errors.New("doctor: ChangesetDir is required")
+	if opts.RepoDir == "" {
+		return nil, errors.New("doctor: RepoDir is required")
 	}
 	if opts.GitLog == nil {
 		return nil, errors.New("doctor: GitLog is required")
@@ -123,7 +120,7 @@ func Run(opts Options) ([]Finding, error) {
 		grep = DefaultReleaseCommitGrep
 	}
 
-	findings, err := checkRevivedChangesets(opts.ChangesetDir, opts.GitLog, grep)
+	findings, err := checkRevivedChangesets(opts.RepoDir, opts.GitLog, grep)
 	if err != nil {
 		return nil, err
 	}
@@ -137,22 +134,35 @@ func Run(opts Options) ([]Finding, error) {
 	return findings, nil
 }
 
+// changesetDirName is the only changeset directory name doctor
+// recognizes. Both git's repo-relative output and the live-tree scan
+// key off this name — see the doc comment on Options.RepoDir.
+const changesetDirName = ".changeset"
+
+// changesetPathPrefix is the path prefix every `.changeset/*.md`
+// entry has in `git log --name-only` output and in the live-tree
+// comparison key.
+const changesetPathPrefix = changesetDirName + "/"
+
 // checkRevivedChangesets surfaces every `.changeset/*.md` file
 // currently on disk whose path was previously deleted by a
 // release-style commit. Each match becomes a SeverityError finding.
-func checkRevivedChangesets(changesetDir string, gitLog GitLog, grep string) ([]Finding, error) {
+func checkRevivedChangesets(repoDir string, gitLog GitLog, grep string) ([]Finding, error) {
 	deleted, err := gitLog(grep)
 	if err != nil {
 		return nil, fmt.Errorf("doctor: list previously-deleted files: %w", err)
 	}
 	deletedSet := make(map[string]struct{}, len(deleted))
 	for _, p := range deleted {
-		// Only care about changeset files. The grep is a
-		// substring match against the commit message, which
-		// happens to also catch unrelated deletions in the same
-		// commit; filter to .changeset/*.md here.
-		base := filepath.Base(p)
-		if !strings.HasPrefix(p, ".changeset/") || !strings.HasSuffix(base, ".md") {
+		// The grep is a substring match against the commit
+		// message, which also catches unrelated deletions in
+		// the same commit; filter to `.changeset/*.md`
+		// (top-level only, no nested paths) here.
+		if !strings.HasPrefix(p, changesetPathPrefix) {
+			continue
+		}
+		rest := p[len(changesetPathPrefix):]
+		if strings.Contains(rest, "/") || !strings.HasSuffix(rest, ".md") {
 			continue
 		}
 		deletedSet[p] = struct{}{}
@@ -161,14 +171,14 @@ func checkRevivedChangesets(changesetDir string, gitLog GitLog, grep string) ([]
 		return nil, nil
 	}
 
-	entries, err := os.ReadDir(changesetDir)
+	entries, err := os.ReadDir(filepath.Join(repoDir, changesetDirName))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			// No `.changeset/` at all means no live changesets
 			// to compare against; nothing to flag.
 			return nil, nil
 		}
-		return nil, fmt.Errorf("doctor: read %s: %w", changesetDir, err)
+		return nil, fmt.Errorf("doctor: read %s: %w", filepath.Join(repoDir, changesetDirName), err)
 	}
 
 	var findings []Finding
@@ -180,11 +190,10 @@ func checkRevivedChangesets(changesetDir string, gitLog GitLog, grep string) ([]
 		if !strings.HasSuffix(name, ".md") {
 			continue
 		}
-		// Compare against the path shape the git log emits
-		// (`.changeset/<name>.md`). The changeset dir on disk
-		// may live anywhere; the deletion entries are always
-		// repo-relative because git log emits them that way.
-		relPath := ".changeset/" + name
+		// The deletion entries are repo-relative because git
+		// log emits them that way; build the comparison key
+		// the same way.
+		relPath := changesetPathPrefix + name
 		if _, revived := deletedSet[relPath]; !revived {
 			continue
 		}

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -99,6 +99,15 @@ type Options struct {
 // monorel writes via `monorel apply` / `monorel release`.
 const DefaultReleaseCommitGrep = "chore(release):"
 
+// CheckNameRevivedChangeset is the [Finding.CheckName] value the
+// revived-changeset diagnostic emits. Exported so callers can
+// match findings by check name without hardcoding the string:
+//
+//	for _, f := range findings {
+//	    if f.CheckName == doctor.CheckNameRevivedChangeset { ... }
+//	}
+const CheckNameRevivedChangeset = "revived-changeset"
+
 // Run executes every built-in check against the repository state
 // described by opts. Returns the findings in deterministic order
 // (sorted by CheckName, then Path) plus any error encountered while
@@ -199,7 +208,7 @@ func checkRevivedChangesets(repoDir string, gitLog GitLog, grep string) ([]Findi
 		}
 		findings = append(findings, Finding{
 			Severity:  SeverityError,
-			CheckName: "revived-changeset",
+			CheckName: CheckNameRevivedChangeset,
 			Path:      relPath,
 			Message: fmt.Sprintf(
 				"%s was deleted by a previous %s commit but is back on disk; "+

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -1,0 +1,203 @@
+// Package doctor diagnoses repository state issues that monorel's
+// release planner won't catch on its own.
+//
+// The motivating case: a stale-branch + squash-merge revival of a
+// previously-consumed `.changeset/*.md` file. After a release ships,
+// the `chore(release):` commit deletes the consumed changesets. If
+// a contributor branched from main BEFORE that release commit and
+// later squash-merges their PR, GitHub re-introduces the deleted
+// files. The next release-pr cycle then re-ships the same content
+// under a new version. monorel's planner is doing exactly what its
+// spec says (changesets on main = stuff to release); the input is
+// the bug. doctor catches the bad input.
+//
+// monorel's CLI exposes Run via `monorel doctor`. Programmatic
+// callers (custom CI checks, lint scripts) can invoke Run directly
+// against any git seam by supplying a [GitLog] function.
+package doctor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Severity classifies a [Finding]'s urgency.
+type Severity int
+
+const (
+	// SeverityWarn flags an issue that may not break a release but
+	// usually indicates a mistake. Callers may surface as a warning
+	// without failing the build.
+	SeverityWarn Severity = iota
+
+	// SeverityError flags an issue that will produce a wrong
+	// release if not fixed. Callers should fail closed.
+	SeverityError
+)
+
+// String returns "warn" or "error".
+func (s Severity) String() string {
+	switch s {
+	case SeverityWarn:
+		return "warn"
+	case SeverityError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// Finding is one issue [Run] surfaced.
+type Finding struct {
+	// Severity is the urgency classification.
+	Severity Severity
+
+	// CheckName names the diagnostic that produced the finding
+	// (e.g. "revived-changeset"). Stable; safe to match in tests.
+	CheckName string
+
+	// Path is the repo-relative path the finding refers to.
+	// May be empty for findings not tied to a single file.
+	Path string
+
+	// Message is a one-sentence human-readable explanation.
+	Message string
+}
+
+// GitLog is the slice of git history doctor needs. The function
+// returns every file path deleted by a commit whose subject or body
+// contains messageGrep as a literal substring. Match is
+// case-sensitive; not a regex.
+//
+// Implemented by `internal/git.Repo.DeletedFilesInCommitsMatching`;
+// other callers can adapt any git library by supplying a function
+// with this signature.
+type GitLog func(messageGrep string) ([]string, error)
+
+// Options configures a [Run] invocation.
+type Options struct {
+	// ChangesetDir is the absolute or repo-relative path to the
+	// `.changeset/` directory whose live contents should be
+	// checked. Required.
+	ChangesetDir string
+
+	// GitLog returns previously-deleted files for a given commit-
+	// message substring. Required.
+	GitLog GitLog
+
+	// ReleaseCommitGrep is the literal substring used to identify
+	// release commits in the git log. Defaults to
+	// "chore(release):" (matching monorel's own release commits).
+	// Override only when integrating against a release-commit
+	// convention monorel did not produce.
+	ReleaseCommitGrep string
+}
+
+// DefaultReleaseCommitGrep is the substring [Run] uses when
+// Options.ReleaseCommitGrep is empty. Matches every commit message
+// monorel writes via `monorel apply` / `monorel release`.
+const DefaultReleaseCommitGrep = "chore(release):"
+
+// Run executes every built-in check against the repository state
+// described by opts. Returns the findings in deterministic order
+// (sorted by CheckName, then Path) plus any error encountered while
+// gathering inputs (e.g. failure to list previously-deleted files).
+//
+// An empty findings slice with a nil error means "nothing wrong."
+// A non-empty slice with a nil error means the checks ran cleanly
+// and surfaced issues in the repository; callers decide whether to
+// treat findings as blocking based on each finding's Severity.
+func Run(opts Options) ([]Finding, error) {
+	if opts.ChangesetDir == "" {
+		return nil, errors.New("doctor: ChangesetDir is required")
+	}
+	if opts.GitLog == nil {
+		return nil, errors.New("doctor: GitLog is required")
+	}
+	grep := opts.ReleaseCommitGrep
+	if grep == "" {
+		grep = DefaultReleaseCommitGrep
+	}
+
+	findings, err := checkRevivedChangesets(opts.ChangesetDir, opts.GitLog, grep)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].CheckName != findings[j].CheckName {
+			return findings[i].CheckName < findings[j].CheckName
+		}
+		return findings[i].Path < findings[j].Path
+	})
+	return findings, nil
+}
+
+// checkRevivedChangesets surfaces every `.changeset/*.md` file
+// currently on disk whose path was previously deleted by a
+// release-style commit. Each match becomes a SeverityError finding.
+func checkRevivedChangesets(changesetDir string, gitLog GitLog, grep string) ([]Finding, error) {
+	deleted, err := gitLog(grep)
+	if err != nil {
+		return nil, fmt.Errorf("doctor: list previously-deleted files: %w", err)
+	}
+	deletedSet := make(map[string]struct{}, len(deleted))
+	for _, p := range deleted {
+		// Only care about changeset files. The grep is a
+		// substring match against the commit message, which
+		// happens to also catch unrelated deletions in the same
+		// commit; filter to .changeset/*.md here.
+		base := filepath.Base(p)
+		if !strings.HasPrefix(p, ".changeset/") || !strings.HasSuffix(base, ".md") {
+			continue
+		}
+		deletedSet[p] = struct{}{}
+	}
+	if len(deletedSet) == 0 {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(changesetDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// No `.changeset/` at all means no live changesets
+			// to compare against; nothing to flag.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("doctor: read %s: %w", changesetDir, err)
+	}
+
+	var findings []Finding
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		name := ent.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		// Compare against the path shape the git log emits
+		// (`.changeset/<name>.md`). The changeset dir on disk
+		// may live anywhere; the deletion entries are always
+		// repo-relative because git log emits them that way.
+		relPath := ".changeset/" + name
+		if _, revived := deletedSet[relPath]; !revived {
+			continue
+		}
+		findings = append(findings, Finding{
+			Severity:  SeverityError,
+			CheckName: "revived-changeset",
+			Path:      relPath,
+			Message: fmt.Sprintf(
+				"%s was deleted by a previous %s commit but is back on disk; "+
+					"likely cause: stale-branch + squash-merge revived it. "+
+					"Delete the file and the next release plan will re-evaluate.",
+				relPath, strings.TrimSuffix(grep, ":")),
+		})
+	}
+	return findings, nil
+}

--- a/doctor/doctor.go
+++ b/doctor/doctor.go
@@ -74,12 +74,12 @@ type Options struct {
 	// `monorel.toml` and `.changeset/`). Required.
 	//
 	// The doctor package only supports the canonical changeset
-	// directory name `.changeset` — both because monorel itself
-	// only writes that name and because the historical scan
-	// matches against `git log --name-only` output, which always
-	// emits repo-relative paths starting with that prefix. If a
-	// future monorel version supports a different name, this
-	// option would gain a sibling for the override.
+	// directory name `.changeset`. Two reasons: monorel itself
+	// only writes that name, and the historical scan matches
+	// against `git log --name-only` output, which always emits
+	// repo-relative paths starting with that prefix. If a future
+	// monorel version supports a different name, this option
+	// would gain a sibling for the override.
 	RepoDir string
 
 	// GitLog returns previously-deleted files for a given commit-
@@ -136,7 +136,7 @@ func Run(opts Options) ([]Finding, error) {
 
 // changesetDirName is the only changeset directory name doctor
 // recognizes. Both git's repo-relative output and the live-tree scan
-// key off this name — see the doc comment on Options.RepoDir.
+// key off this name; see the doc comment on Options.RepoDir.
 const changesetDirName = ".changeset"
 
 // changesetPathPrefix is the path prefix every `.changeset/*.md`

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -23,11 +23,13 @@ func stubGitLog(t *testing.T, wantGrep string, paths []string) doctor.GitLog {
 	}
 }
 
-// writeChangesetDir materializes a .changeset directory with the
-// given filenames (each created empty). Returns the directory path.
-func writeChangesetDir(t *testing.T, names ...string) string {
+// repoWithChangesets creates a temp repo root containing a
+// `.changeset/` directory with the given filenames (each created
+// empty). Returns the repo root.
+func repoWithChangesets(t *testing.T, names ...string) string {
 	t.Helper()
-	dir := filepath.Join(t.TempDir(), ".changeset")
+	repo := t.TempDir()
+	dir := filepath.Join(repo, ".changeset")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -36,13 +38,13 @@ func writeChangesetDir(t *testing.T, names ...string) string {
 			t.Fatalf("write %s: %v", n, err)
 		}
 	}
-	return dir
+	return repo
 }
 
 func TestRun_NoFindingsWhenNoRevivals(t *testing.T) {
-	dir := writeChangesetDir(t, "fresh-feature.md")
+	repo := repoWithChangesets(t, "fresh-feature.md")
 	findings, err := doctor.Run(doctor.Options{
-		ChangesetDir: dir,
+		RepoDir: repo,
 		GitLog: stubGitLog(t, "chore(release):", []string{
 			".changeset/old-shipped.md",
 		}),
@@ -56,9 +58,9 @@ func TestRun_NoFindingsWhenNoRevivals(t *testing.T) {
 }
 
 func TestRun_FlagsRevivedChangeset(t *testing.T) {
-	dir := writeChangesetDir(t, "gitlab-provider.md", "fresh-feature.md")
+	repo := repoWithChangesets(t, "gitlab-provider.md", "fresh-feature.md")
 	findings, err := doctor.Run(doctor.Options{
-		ChangesetDir: dir,
+		RepoDir: repo,
 		GitLog: stubGitLog(t, "chore(release):", []string{
 			".changeset/gitlab-provider.md",
 			".changeset/something-else.md",
@@ -85,9 +87,9 @@ func TestRun_FlagsRevivedChangeset(t *testing.T) {
 func TestRun_FlagsAllRevivedSorted(t *testing.T) {
 	// When multiple changesets are revived the output is sorted by
 	// path so callers can rely on stable ordering.
-	dir := writeChangesetDir(t, "z-last.md", "a-first.md", "m-mid.md")
+	repo := repoWithChangesets(t, "z-last.md", "a-first.md", "m-mid.md")
 	findings, err := doctor.Run(doctor.Options{
-		ChangesetDir: dir,
+		RepoDir: repo,
 		GitLog: stubGitLog(t, "chore(release):", []string{
 			".changeset/z-last.md",
 			".changeset/a-first.md",
@@ -115,10 +117,10 @@ func TestRun_FlagsAllRevivedSorted(t *testing.T) {
 func TestRun_IgnoresNonChangesetDeletions(t *testing.T) {
 	// Release commits often delete other files alongside the
 	// changeset (e.g. earlier-version artifacts). Doctor must only
-	// consider .changeset/*.md paths.
-	dir := writeChangesetDir(t, "live.md")
+	// consider top-level `.changeset/*.md` paths.
+	repo := repoWithChangesets(t, "live.md")
 	findings, err := doctor.Run(doctor.Options{
-		ChangesetDir: dir,
+		RepoDir: repo,
 		GitLog: stubGitLog(t, "chore(release):", []string{
 			"CHANGELOG.md",                    // wrong dir
 			"docs/whats-new.md",               // wrong dir
@@ -137,11 +139,12 @@ func TestRun_IgnoresNonChangesetDeletions(t *testing.T) {
 
 func TestRun_NoChangesetDirIsClean(t *testing.T) {
 	// Repos that haven't run `monorel init` yet shouldn't error;
-	// there's just nothing to flag.
-	tmp := t.TempDir()
+	// there's just nothing to flag. Pass a repo that has no
+	// `.changeset/` directory at all.
+	repo := t.TempDir()
 	findings, err := doctor.Run(doctor.Options{
-		ChangesetDir: filepath.Join(tmp, "missing-changeset"),
-		GitLog:       stubGitLog(t, "chore(release):", []string{".changeset/foo.md"}),
+		RepoDir: repo,
+		GitLog:  stubGitLog(t, "chore(release):", []string{".changeset/foo.md"}),
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -152,10 +155,10 @@ func TestRun_NoChangesetDirIsClean(t *testing.T) {
 }
 
 func TestRun_GitLogErrorIsReturned(t *testing.T) {
-	dir := writeChangesetDir(t, "x.md")
+	repo := repoWithChangesets(t, "x.md")
 	want := errors.New("git boom")
 	_, err := doctor.Run(doctor.Options{
-		ChangesetDir: dir,
+		RepoDir: repo,
 		GitLog: func(string) ([]string, error) {
 			return nil, want
 		},
@@ -170,11 +173,11 @@ func TestRun_ValidatesRequiredOptions(t *testing.T) {
 		name string
 		opts doctor.Options
 	}{
-		{"missing ChangesetDir", doctor.Options{
+		{"missing RepoDir", doctor.Options{
 			GitLog: func(string) ([]string, error) { return nil, nil },
 		}},
 		{"missing GitLog", doctor.Options{
-			ChangesetDir: t.TempDir(),
+			RepoDir: t.TempDir(),
 		}},
 	}
 	for _, tc := range cases {
@@ -191,9 +194,9 @@ func TestRun_CustomReleaseCommitGrep(t *testing.T) {
 	// Callers integrating with a non-monorel release-commit
 	// convention can override the grep; doctor should pass it
 	// through to GitLog.
-	dir := writeChangesetDir(t, "x.md")
+	repo := repoWithChangesets(t, "x.md")
 	_, err := doctor.Run(doctor.Options{
-		ChangesetDir:      dir,
+		RepoDir:           repo,
 		ReleaseCommitGrep: "Release v",
 		GitLog:            stubGitLog(t, "Release v", nil),
 	})
@@ -203,14 +206,11 @@ func TestRun_CustomReleaseCommitGrep(t *testing.T) {
 }
 
 func TestSeverity_String(t *testing.T) {
-	cases := map[doctor.Severity]string{
-		doctor.SeverityWarn:  "warn",
-		doctor.SeverityError: "error",
-		doctor.Severity(99):  "unknown",
+	// Severity is a typed string; the constants ARE the wire form.
+	if string(doctor.SeverityError) != "error" {
+		t.Errorf("SeverityError = %q, want %q", doctor.SeverityError, "error")
 	}
-	for sev, want := range cases {
-		if got := sev.String(); got != want {
-			t.Errorf("Severity(%d).String() = %q, want %q", sev, got, want)
-		}
+	if string(doctor.SeverityWarning) != "warning" {
+		t.Errorf("SeverityWarning = %q, want %q", doctor.SeverityWarning, "warning")
 	}
 }

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -1,0 +1,216 @@
+package doctor_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"monorel.disaresta.com/doctor"
+)
+
+// stubGitLog returns a [doctor.GitLog] that hands back the given
+// paths whenever the substring matches. Tests can model multi-grep
+// behavior by switching on messageGrep inside fn directly; this
+// helper covers the common single-grep case.
+func stubGitLog(t *testing.T, wantGrep string, paths []string) doctor.GitLog {
+	t.Helper()
+	return func(messageGrep string) ([]string, error) {
+		if messageGrep != wantGrep {
+			t.Fatalf("GitLog called with grep=%q, want %q", messageGrep, wantGrep)
+		}
+		return paths, nil
+	}
+}
+
+// writeChangesetDir materializes a .changeset directory with the
+// given filenames (each created empty). Returns the directory path.
+func writeChangesetDir(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), ".changeset")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), nil, 0o644); err != nil {
+			t.Fatalf("write %s: %v", n, err)
+		}
+	}
+	return dir
+}
+
+func TestRun_NoFindingsWhenNoRevivals(t *testing.T) {
+	dir := writeChangesetDir(t, "fresh-feature.md")
+	findings, err := doctor.Run(doctor.Options{
+		ChangesetDir: dir,
+		GitLog: stubGitLog(t, "chore(release):", []string{
+			".changeset/old-shipped.md",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("got findings %v, want none", findings)
+	}
+}
+
+func TestRun_FlagsRevivedChangeset(t *testing.T) {
+	dir := writeChangesetDir(t, "gitlab-provider.md", "fresh-feature.md")
+	findings, err := doctor.Run(doctor.Options{
+		ChangesetDir: dir,
+		GitLog: stubGitLog(t, "chore(release):", []string{
+			".changeset/gitlab-provider.md",
+			".changeset/something-else.md",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.CheckName != "revived-changeset" {
+		t.Errorf("CheckName = %q, want revived-changeset", f.CheckName)
+	}
+	if f.Severity != doctor.SeverityError {
+		t.Errorf("Severity = %v, want SeverityError", f.Severity)
+	}
+	if f.Path != ".changeset/gitlab-provider.md" {
+		t.Errorf("Path = %q, want .changeset/gitlab-provider.md", f.Path)
+	}
+}
+
+func TestRun_FlagsAllRevivedSorted(t *testing.T) {
+	// When multiple changesets are revived the output is sorted by
+	// path so callers can rely on stable ordering.
+	dir := writeChangesetDir(t, "z-last.md", "a-first.md", "m-mid.md")
+	findings, err := doctor.Run(doctor.Options{
+		ChangesetDir: dir,
+		GitLog: stubGitLog(t, "chore(release):", []string{
+			".changeset/z-last.md",
+			".changeset/a-first.md",
+			".changeset/m-mid.md",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(findings) != 3 {
+		t.Fatalf("got %d findings, want 3", len(findings))
+	}
+	want := []string{
+		".changeset/a-first.md",
+		".changeset/m-mid.md",
+		".changeset/z-last.md",
+	}
+	for i, f := range findings {
+		if f.Path != want[i] {
+			t.Errorf("findings[%d].Path = %q, want %q", i, f.Path, want[i])
+		}
+	}
+}
+
+func TestRun_IgnoresNonChangesetDeletions(t *testing.T) {
+	// Release commits often delete other files alongside the
+	// changeset (e.g. earlier-version artifacts). Doctor must only
+	// consider .changeset/*.md paths.
+	dir := writeChangesetDir(t, "live.md")
+	findings, err := doctor.Run(doctor.Options{
+		ChangesetDir: dir,
+		GitLog: stubGitLog(t, "chore(release):", []string{
+			"CHANGELOG.md",                    // wrong dir
+			"docs/whats-new.md",               // wrong dir
+			".changeset/sub/nested-but-md.md", // nested, not at root
+			".changeset/live.txt",             // wrong extension
+			".changeset/.consumed",            // not .md
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("got findings %v, want none", findings)
+	}
+}
+
+func TestRun_NoChangesetDirIsClean(t *testing.T) {
+	// Repos that haven't run `monorel init` yet shouldn't error;
+	// there's just nothing to flag.
+	tmp := t.TempDir()
+	findings, err := doctor.Run(doctor.Options{
+		ChangesetDir: filepath.Join(tmp, "missing-changeset"),
+		GitLog:       stubGitLog(t, "chore(release):", []string{".changeset/foo.md"}),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("got findings %v, want none", findings)
+	}
+}
+
+func TestRun_GitLogErrorIsReturned(t *testing.T) {
+	dir := writeChangesetDir(t, "x.md")
+	want := errors.New("git boom")
+	_, err := doctor.Run(doctor.Options{
+		ChangesetDir: dir,
+		GitLog: func(string) ([]string, error) {
+			return nil, want
+		},
+	})
+	if err == nil || !errors.Is(err, want) {
+		t.Fatalf("err = %v, want wrapped %v", err, want)
+	}
+}
+
+func TestRun_ValidatesRequiredOptions(t *testing.T) {
+	cases := []struct {
+		name string
+		opts doctor.Options
+	}{
+		{"missing ChangesetDir", doctor.Options{
+			GitLog: func(string) ([]string, error) { return nil, nil },
+		}},
+		{"missing GitLog", doctor.Options{
+			ChangesetDir: t.TempDir(),
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := doctor.Run(tc.opts)
+			if err == nil {
+				t.Fatal("Run returned nil error, want validation error")
+			}
+		})
+	}
+}
+
+func TestRun_CustomReleaseCommitGrep(t *testing.T) {
+	// Callers integrating with a non-monorel release-commit
+	// convention can override the grep; doctor should pass it
+	// through to GitLog.
+	dir := writeChangesetDir(t, "x.md")
+	_, err := doctor.Run(doctor.Options{
+		ChangesetDir:      dir,
+		ReleaseCommitGrep: "Release v",
+		GitLog:            stubGitLog(t, "Release v", nil),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestSeverity_String(t *testing.T) {
+	cases := map[doctor.Severity]string{
+		doctor.SeverityWarn:  "warn",
+		doctor.SeverityError: "error",
+		doctor.Severity(99):  "unknown",
+	}
+	for sev, want := range cases {
+		if got := sev.String(); got != want {
+			t.Errorf("Severity(%d).String() = %q, want %q", sev, got, want)
+		}
+	}
+}

--- a/doctor/doctor_test.go
+++ b/doctor/doctor_test.go
@@ -73,8 +73,8 @@ func TestRun_FlagsRevivedChangeset(t *testing.T) {
 		t.Fatalf("got %d findings, want 1: %v", len(findings), findings)
 	}
 	f := findings[0]
-	if f.CheckName != "revived-changeset" {
-		t.Errorf("CheckName = %q, want revived-changeset", f.CheckName)
+	if f.CheckName != doctor.CheckNameRevivedChangeset {
+		t.Errorf("CheckName = %q, want %q", f.CheckName, doctor.CheckNameRevivedChangeset)
 	}
 	if f.Severity != doctor.SeverityError {
 		t.Errorf("Severity = %v, want SeverityError", f.Severity)

--- a/examples/gitea/README.md
+++ b/examples/gitea/README.md
@@ -8,7 +8,8 @@ gitea/
 ├── .changeset/README.md
 └── .gitea/workflows/
     ├── release-pr.yml
-    └── release.yml
+    ├── release.yml
+    └── doctor.yml      (recommended: pre-merge sanity check)
 ```
 
 Copy these files into your repo, set `provider.host` to your instance (or `codeberg.org`, etc.), replace `acme/widget` with your owner/repo, then commit and push to `main`. The `release-pr` workflow opens / updates the always-open release MR; merging it triggers `release.yml`.

--- a/examples/github/README.md
+++ b/examples/github/README.md
@@ -8,7 +8,8 @@ github/
 ├── .changeset/README.md
 └── .github/workflows/
     ├── release-pr.yml
-    └── release.yml
+    ├── release.yml
+    └── doctor.yml      (recommended: pre-merge sanity check)
 ```
 
 Copy these files into your repo, replace `acme/widget` with your owner/repo and the package keys with your own (`monorel init` will scaffold this from your `go.mod` files), then commit and push to `main`. The `release-pr` workflow opens / updates the always-open release PR; merging it triggers `release.yml` which creates tags and publishes GitHub Releases.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"monorel.disaresta.com/doctor"
+	"monorel.disaresta.com/internal/git"
+)
+
+func newDoctorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Diagnose repository state issues monorel's planner won't catch.",
+		Long: `Runs every built-in repository diagnostic in one pass.
+
+Built-in checks:
+
+  - revived-changeset: a .changeset/*.md file currently on disk that a
+    previous chore(release) commit deleted. Likely cause: a contributor
+    branched from main BEFORE the release commit and squash-merged
+    later; GitHub re-introduced the file. The next release will
+    re-ship the same content under a new version unless the file is
+    deleted.
+
+Exit codes:
+  0  no findings.
+  1  one or more error-severity findings.
+
+Pass --json for machine-readable output.`,
+		RunE: runDoctor,
+	}
+	cmd.Flags().Bool("json", false, "Emit findings as JSON.")
+	return cmd
+}
+
+func runDoctor(cmd *cobra.Command, _ []string) error {
+	configPath, err := cmd.Flags().GetString(configPathFlagName)
+	if err != nil {
+		return err
+	}
+	asJSON, _ := cmd.Flags().GetBool("json")
+
+	abs, err := filepath.Abs(configPath)
+	if err != nil {
+		return fmt.Errorf("resolve --config: %w", err)
+	}
+	repoDir := filepath.Dir(abs)
+	repo := git.Open(repoDir)
+
+	findings, err := doctor.Run(doctor.Options{
+		ChangesetDir: filepath.Join(repoDir, ".changeset"),
+		GitLog:       repo.DeletedFilesInCommitsMatching,
+	})
+	if err != nil {
+		return err
+	}
+
+	if asJSON {
+		if err := writeDoctorJSON(cmd.OutOrStdout(), findings); err != nil {
+			return err
+		}
+	} else {
+		if err := writeDoctorText(cmd.OutOrStdout(), findings); err != nil {
+			return err
+		}
+	}
+
+	if hasDoctorErrors(findings) {
+		return ErrExit(1)
+	}
+	return nil
+}
+
+func writeDoctorText(w io.Writer, findings []doctor.Finding) error {
+	if len(findings) == 0 {
+		_, err := fmt.Fprintln(w, "No findings. Repository state looks healthy.")
+		return err
+	}
+	errCount := 0
+	warnCount := 0
+	for _, f := range findings {
+		switch f.Severity {
+		case doctor.SeverityError:
+			errCount++
+		case doctor.SeverityWarn:
+			warnCount++
+		}
+	}
+	for _, sev := range []doctor.Severity{doctor.SeverityError, doctor.SeverityWarn} {
+		header := false
+		for _, f := range findings {
+			if f.Severity != sev {
+				continue
+			}
+			if !header {
+				label := "ERRORS"
+				if sev == doctor.SeverityWarn {
+					label = "WARNINGS"
+				}
+				if _, err := fmt.Fprintf(w, "\n%s:\n", label); err != nil {
+					return err
+				}
+				header = true
+			}
+			loc := ""
+			if f.Path != "" {
+				loc = " [" + f.Path + "]"
+			}
+			if _, err := fmt.Fprintf(w, "  - %s: %s%s\n", f.CheckName, f.Message, loc); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := fmt.Fprintf(w, "\n%d error(s), %d warning(s).\n", errCount, warnCount)
+	return err
+}
+
+func writeDoctorJSON(w io.Writer, findings []doctor.Finding) error {
+	// Match validate's JSON envelope so consumers can parse both
+	// commands' output with the same schema.
+	type wireFinding struct {
+		Severity  string `json:"severity"`
+		CheckName string `json:"check_name"`
+		Path      string `json:"path,omitempty"`
+		Message   string `json:"message"`
+	}
+	type doc struct {
+		Findings []wireFinding `json:"findings"`
+		Errors   int           `json:"errors"`
+		Warnings int           `json:"warnings"`
+	}
+	out := doc{Findings: make([]wireFinding, 0, len(findings))}
+	for _, f := range findings {
+		out.Findings = append(out.Findings, wireFinding{
+			Severity:  f.Severity.String(),
+			CheckName: f.CheckName,
+			Path:      f.Path,
+			Message:   f.Message,
+		})
+		switch f.Severity {
+		case doctor.SeverityError:
+			out.Errors++
+		case doctor.SeverityWarn:
+			out.Warnings++
+		}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func hasDoctorErrors(findings []doctor.Finding) bool {
+	for _, f := range findings {
+		if f.Severity == doctor.SeverityError {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -91,6 +91,10 @@ func writeDoctorText(w io.Writer, findings []doctor.Finding) error {
 			warnCount++
 		}
 	}
+	severityLabel := map[doctor.Severity]string{
+		doctor.SeverityError:   "ERRORS",
+		doctor.SeverityWarning: "WARNINGS",
+	}
 	for _, sev := range []doctor.Severity{doctor.SeverityError, doctor.SeverityWarning} {
 		header := false
 		for _, f := range findings {
@@ -98,11 +102,7 @@ func writeDoctorText(w io.Writer, findings []doctor.Finding) error {
 				continue
 			}
 			if !header {
-				label := "ERRORS"
-				if sev == doctor.SeverityWarning {
-					label = "WARNINGS"
-				}
-				if _, err := fmt.Fprintf(w, "\n%s:\n", label); err != nil {
+				if _, err := fmt.Fprintf(w, "\n%s:\n", severityLabel[sev]); err != nil {
 					return err
 				}
 				header = true

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -53,8 +53,8 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	repo := git.Open(repoDir)
 
 	findings, err := doctor.Run(doctor.Options{
-		ChangesetDir: filepath.Join(repoDir, ".changeset"),
-		GitLog:       repo.DeletedFilesInCommitsMatching,
+		RepoDir: repoDir,
+		GitLog:  repo.DeletedFilesInCommitsMatching,
 	})
 	if err != nil {
 		return err
@@ -87,11 +87,11 @@ func writeDoctorText(w io.Writer, findings []doctor.Finding) error {
 		switch f.Severity {
 		case doctor.SeverityError:
 			errCount++
-		case doctor.SeverityWarn:
+		case doctor.SeverityWarning:
 			warnCount++
 		}
 	}
-	for _, sev := range []doctor.Severity{doctor.SeverityError, doctor.SeverityWarn} {
+	for _, sev := range []doctor.Severity{doctor.SeverityError, doctor.SeverityWarning} {
 		header := false
 		for _, f := range findings {
 			if f.Severity != sev {
@@ -99,7 +99,7 @@ func writeDoctorText(w io.Writer, findings []doctor.Finding) error {
 			}
 			if !header {
 				label := "ERRORS"
-				if sev == doctor.SeverityWarn {
+				if sev == doctor.SeverityWarning {
 					label = "WARNINGS"
 				}
 				if _, err := fmt.Fprintf(w, "\n%s:\n", label); err != nil {
@@ -120,14 +120,18 @@ func writeDoctorText(w io.Writer, findings []doctor.Finding) error {
 	return err
 }
 
+// writeDoctorJSON emits the findings + headline counts. The shape
+// matches validate's `{findings, errors, warnings}` envelope; the
+// per-finding object uses `check_name` (not `code`) because doctor
+// findings name the diagnostic that produced them, not a stable
+// lint identifier. Severity values are `"error"` and `"warning"`,
+// matching validate's wire form.
 func writeDoctorJSON(w io.Writer, findings []doctor.Finding) error {
-	// Match validate's JSON envelope so consumers can parse both
-	// commands' output with the same schema.
 	type wireFinding struct {
-		Severity  string `json:"severity"`
-		CheckName string `json:"check_name"`
-		Path      string `json:"path,omitempty"`
-		Message   string `json:"message"`
+		Severity  doctor.Severity `json:"severity"`
+		CheckName string          `json:"check_name"`
+		Path      string          `json:"path,omitempty"`
+		Message   string          `json:"message"`
 	}
 	type doc struct {
 		Findings []wireFinding `json:"findings"`
@@ -137,7 +141,7 @@ func writeDoctorJSON(w io.Writer, findings []doctor.Finding) error {
 	out := doc{Findings: make([]wireFinding, 0, len(findings))}
 	for _, f := range findings {
 		out.Findings = append(out.Findings, wireFinding{
-			Severity:  f.Severity.String(),
+			Severity:  f.Severity,
 			CheckName: f.CheckName,
 			Path:      f.Path,
 			Message:   f.Message,
@@ -145,7 +149,7 @@ func writeDoctorJSON(w io.Writer, findings []doctor.Finding) error {
 		switch f.Severity {
 		case doctor.SeverityError:
 			out.Errors++
-		case doctor.SeverityWarn:
+		case doctor.SeverityWarning:
 			out.Warnings++
 		}
 	}
@@ -154,6 +158,10 @@ func writeDoctorJSON(w io.Writer, findings []doctor.Finding) error {
 	return enc.Encode(out)
 }
 
+// hasDoctorErrors reports whether any finding is error-severity.
+// All current built-in checks emit SeverityError; when a warning-
+// only check ships, add a `--strict` flag mirroring validate to let
+// callers fail closed on warnings too.
 func hasDoctorErrors(findings []doctor.Finding) bool {
 	for _, f := range findings {
 		if f.Severity == doctor.SeverityError {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"monorel.disaresta.com/internal/git/testutil"
+)
+
+// doctorFixture builds an on-disk repo with monorel.toml + an
+// arbitrary changeset state and a recorded chore(release) commit
+// that deleted some files. Returns the absolute path to monorel.toml
+// for runCmd.
+func doctorFixture(
+	t *testing.T,
+	preReleaseChangesets []string, // committed before the release commit
+	releasedChangesets []string, // deleted by the release commit
+	currentChangesets []string, // present at HEAD
+) string {
+	t.Helper()
+	r := testutil.NewRepo(t)
+	r.WriteFile("monorel.toml", singlePackageTOML)
+
+	// Initial commit: add monorel.toml plus all "before-release" files.
+	files := []string{"monorel.toml"}
+	for _, name := range preReleaseChangesets {
+		path := ".changeset/" + name + ".md"
+		r.WriteFile(path, "---\n\"foo\": minor\n---\n\nseed.\n")
+		files = append(files, path)
+	}
+	r.AddCommit("seed", files...)
+
+	// The release commit: delete `releasedChangesets`.
+	for _, name := range releasedChangesets {
+		path := ".changeset/" + name + ".md"
+		// Remove via git rm so the commit records a deletion.
+		if err := r.Repo.Remove(path); err != nil {
+			t.Fatalf("remove %s: %v", path, err)
+		}
+	}
+	if len(releasedChangesets) > 0 {
+		if err := r.Repo.Commit("chore(release): pkg v1.0.0\n\nmonorel-Release: pkg v1.0.0\n"); err != nil {
+			t.Fatalf("release commit: %v", err)
+		}
+	}
+
+	// Final state: write the "current" set of changesets. Any name
+	// shared with releasedChangesets simulates a revival; any new
+	// name is a fresh changeset that should NOT be flagged.
+	for _, name := range currentChangesets {
+		path := ".changeset/" + name + ".md"
+		r.WriteFile(path, "---\n\"foo\": minor\n---\n\nrevived or new.\n")
+	}
+
+	return r.Dir + "/monorel.toml"
+}
+
+func TestDoctorCmd_Clean(t *testing.T) {
+	configPath := doctorFixture(t,
+		[]string{"shipped"},   // pre-release: present
+		[]string{"shipped"},   // released: deleted
+		[]string{"new-thing"}, // current: only fresh content
+	)
+	stdout, _, err := runCmd(t, "doctor", "--config", configPath)
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	if !strings.Contains(stdout, "No findings") {
+		t.Errorf("expected clean output; got: %s", stdout)
+	}
+}
+
+func TestDoctorCmd_FlagsRevival(t *testing.T) {
+	configPath := doctorFixture(t,
+		[]string{"shipped"},
+		[]string{"shipped"},
+		[]string{"shipped", "fresh"}, // shipped is back on disk: revival
+	)
+	stdout, _, err := runCmd(t, "doctor", "--config", configPath)
+	if err == nil {
+		t.Fatal("doctor should have returned a non-zero exit on revival")
+	}
+	var ee ErrExit
+	if !errors.As(err, &ee) || int(ee) != 1 {
+		t.Fatalf("err = %v, want ErrExit(1)", err)
+	}
+	for _, want := range []string{
+		"revived-changeset",
+		".changeset/shipped.md",
+		"1 error(s)",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("doctor output missing %q\nfull:\n%s", want, stdout)
+		}
+	}
+	// "fresh" shouldn't be flagged.
+	if strings.Contains(stdout, "fresh.md") {
+		t.Errorf("doctor flagged a fresh changeset; output:\n%s", stdout)
+	}
+}
+
+func TestDoctorCmd_JSONShape(t *testing.T) {
+	configPath := doctorFixture(t,
+		[]string{"a", "b"},
+		[]string{"a", "b"},
+		[]string{"a", "b"},
+	)
+	stdout, _, err := runCmd(t, "doctor", "--config", configPath, "--json")
+	if err == nil {
+		t.Fatal("doctor should have returned a non-zero exit on revival")
+	}
+
+	var got struct {
+		Findings []struct {
+			Severity  string `json:"severity"`
+			CheckName string `json:"check_name"`
+			Path      string `json:"path"`
+			Message   string `json:"message"`
+		} `json:"findings"`
+		Errors   int `json:"errors"`
+		Warnings int `json:"warnings"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("unmarshal: %v\noutput:\n%s", err, stdout)
+	}
+	if got.Errors != 2 || got.Warnings != 0 || len(got.Findings) != 2 {
+		t.Fatalf("counts wrong: %+v", got)
+	}
+	// Findings are sorted by Path.
+	if got.Findings[0].Path != ".changeset/a.md" || got.Findings[1].Path != ".changeset/b.md" {
+		t.Errorf("paths in wrong order: %+v", got.Findings)
+	}
+	for _, f := range got.Findings {
+		if f.Severity != "error" || f.CheckName != "revived-changeset" {
+			t.Errorf("unexpected finding: %+v", f)
+		}
+	}
+}
+
+func TestDoctorCmd_NoChangesetDir(t *testing.T) {
+	// A repo without a .changeset directory at all should report
+	// no findings rather than crash.
+	r := testutil.NewRepo(t)
+	r.WriteFile("monorel.toml", singlePackageTOML)
+	r.AddCommit("seed", "monorel.toml")
+
+	stdout, _, err := runCmd(t, "doctor", "--config", r.Dir+"/monorel.toml")
+	if err != nil {
+		t.Fatalf("doctor: %v", err)
+	}
+	if !strings.Contains(stdout, "No findings") {
+		t.Errorf("expected clean output; got: %s", stdout)
+	}
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"monorel.disaresta.com/doctor"
 	"monorel.disaresta.com/internal/git/testutil"
 )
 
@@ -136,6 +137,12 @@ func TestDoctorCmd_JSONShape(t *testing.T) {
 		if f.Severity != "error" || f.CheckName != "revived-changeset" {
 			t.Errorf("unexpected finding: %+v", f)
 		}
+	}
+	// `warning` (not `warn`) must be the wire form for symmetry
+	// with validate's schema. No findings produce warnings today,
+	// but the type alias guarantees the spelling.
+	if string(doctor.SeverityWarning) != "warning" {
+		t.Errorf("SeverityWarning wire = %q, want %q", doctor.SeverityWarning, "warning")
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -88,7 +88,7 @@ func TestDoctorCmd_FlagsRevival(t *testing.T) {
 		t.Fatalf("err = %v, want ErrExit(1)", err)
 	}
 	for _, want := range []string{
-		"revived-changeset",
+		doctor.CheckNameRevivedChangeset,
 		".changeset/shipped.md",
 		"1 error(s)",
 	} {
@@ -134,7 +134,7 @@ func TestDoctorCmd_JSONShape(t *testing.T) {
 		t.Errorf("paths in wrong order: %+v", got.Findings)
 	}
 	for _, f := range got.Findings {
-		if f.Severity != "error" || f.CheckName != "revived-changeset" {
+		if f.Severity != "error" || f.CheckName != doctor.CheckNameRevivedChangeset {
 			t.Errorf("unexpected finding: %+v", f)
 		}
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -44,6 +44,7 @@ Reference docs: https://monorel.disaresta.com`,
 		newPreviewCmd(),
 		newPreCmd(),
 		newInitCmd(),
+		newDoctorCmd(),
 	)
 	return cmd
 }

--- a/internal/git/exec.go
+++ b/internal/git/exec.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 )
 
@@ -174,6 +175,42 @@ func (e *Exec) IsClean() (bool, error) {
 		return false, err
 	}
 	return strings.TrimSpace(out) == "", nil
+}
+
+// DeletedFilesInCommitsMatching implements
+// [Repo.DeletedFilesInCommitsMatching].
+//
+// Shells out to `git log --diff-filter=D --name-only --format=
+// --fixed-strings --grep=<messageGrep>`, then dedupes/sorts the
+// result. --fixed-strings makes the grep a literal substring match;
+// --format= suppresses the commit header so stdout is just deleted
+// paths.
+func (e *Exec) DeletedFilesInCommitsMatching(messageGrep string) ([]string, error) {
+	if messageGrep == "" {
+		return nil, errors.New("messageGrep is empty")
+	}
+	out, err := e.run("log",
+		"--diff-filter=D",
+		"--name-only",
+		"--format=",
+		"--fixed-strings",
+		"--grep="+messageGrep,
+	)
+	if err != nil {
+		return nil, err
+	}
+	lines := splitLines(out)
+	seen := make(map[string]struct{}, len(lines))
+	uniq := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if _, ok := seen[l]; ok {
+			continue
+		}
+		seen[l] = struct{}{}
+		uniq = append(uniq, l)
+	}
+	sort.Strings(uniq)
+	return uniq, nil
 }
 
 // splitLines splits raw on '\n', trimming carriage returns, and drops

--- a/internal/git/exec.go
+++ b/internal/git/exec.go
@@ -199,18 +199,23 @@ func (e *Exec) DeletedFilesInCommitsMatching(messageGrep string) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	lines := splitLines(out)
-	seen := make(map[string]struct{}, len(lines))
-	uniq := make([]string, 0, len(lines))
-	for _, l := range lines {
-		if _, ok := seen[l]; ok {
+	return dedupSorted(splitLines(out)), nil
+}
+
+// dedupSorted returns a copy of in with duplicates removed and the
+// remaining elements sorted lexicographically.
+func dedupSorted(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
 			continue
 		}
-		seen[l] = struct{}{}
-		uniq = append(uniq, l)
+		seen[s] = struct{}{}
+		out = append(out, s)
 	}
-	sort.Strings(uniq)
-	return uniq, nil
+	sort.Strings(out)
+	return out
 }
 
 // splitLines splits raw on '\n', trimming carriage returns, and drops

--- a/internal/git/fake.go
+++ b/internal/git/fake.go
@@ -281,20 +281,12 @@ func (f *Fake) DeletedFilesInCommitsMatching(messageGrep string) ([]string, erro
 	if messageGrep == "" {
 		return nil, errors.New("messageGrep is empty")
 	}
-	seen := make(map[string]struct{})
-	var out []string
+	var paths []string
 	for _, c := range f.Commits {
 		if !strings.Contains(c.Message, messageGrep) {
 			continue
 		}
-		for _, p := range c.Deletions {
-			if _, ok := seen[p]; ok {
-				continue
-			}
-			seen[p] = struct{}{}
-			out = append(out, p)
-		}
+		paths = append(paths, c.Deletions...)
 	}
-	sort.Strings(out)
-	return out, nil
+	return dedupSorted(paths), nil
 }

--- a/internal/git/fake.go
+++ b/internal/git/fake.go
@@ -64,6 +64,12 @@ type Fake struct {
 type FakeCommit struct {
 	Message string
 	Files   []string
+
+	// Deletions are the paths Remove(...) recorded for this commit.
+	// Subset of Files. Tracked separately so
+	// DeletedFilesInCommitsMatching can answer accurately without
+	// the fake needing to know each path's add-vs-delete state.
+	Deletions []string
 }
 
 // NewFake returns an empty in-memory repo with the given initial
@@ -182,7 +188,12 @@ func (f *Fake) Commit(message string) error {
 	}
 	files := append([]string{}, f.Staged...)
 	files = append(files, f.Removed...)
-	f.Commits = append(f.Commits, FakeCommit{Message: message, Files: files})
+	deletions := append([]string{}, f.Removed...)
+	f.Commits = append(f.Commits, FakeCommit{
+		Message:   message,
+		Files:     files,
+		Deletions: deletions,
+	})
 	f.Staged = nil
 	f.Removed = nil
 	return nil
@@ -255,4 +266,35 @@ func (f *Fake) IsClean() (bool, error) {
 		return false, err
 	}
 	return !f.Dirty, nil
+}
+
+// DeletedFilesInCommitsMatching implements
+// [Repo.DeletedFilesInCommitsMatching]. Walks the recorded Commits,
+// collecting Deletions from any commit whose Message contains
+// messageGrep as a literal substring.
+func (f *Fake) DeletedFilesInCommitsMatching(messageGrep string) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return nil, err
+	}
+	if messageGrep == "" {
+		return nil, errors.New("messageGrep is empty")
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, c := range f.Commits {
+		if !strings.Contains(c.Message, messageGrep) {
+			continue
+		}
+		for _, p := range c.Deletions {
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -78,4 +78,18 @@ type Repo interface {
 	// Pre-release safety check: monorel refuses to run release on
 	// a dirty tree.
 	IsClean() (bool, error)
+
+	// DeletedFilesInCommitsMatching returns the union of every file
+	// path deleted (`--diff-filter=D`) by a commit whose subject or
+	// body literally contains messageGrep. The substring match is
+	// case-sensitive and does NOT use regex.
+	//
+	// Used by `monorel doctor` to scan past `chore(release):`
+	// commits for the changeset filenames they consumed, so a
+	// stale-branch + squash-merge revival can be detected.
+	//
+	// Order: deduplicated, sorted lexicographically. Includes paths
+	// that were re-added by later commits — callers intersect
+	// against the live tree to flag that case.
+	DeletedFilesInCommitsMatching(messageGrep string) ([]string, error)
 }

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -14,6 +14,104 @@ import (
 // Tests target both the Exec impl (via testutil.NewRepo) and the
 // Fake impl, since they must satisfy the same Repo contract.
 
+func TestExec_DeletedFilesInCommitsMatching(t *testing.T) {
+	r := testutil.NewRepo(t)
+	r.WriteFile(".changeset/a.md", "a")
+	r.WriteFile(".changeset/b.md", "b")
+	r.WriteFile(".changeset/keep.md", "keep")
+	r.WriteFile("README.md", "readme")
+	r.AddCommit("seed", ".changeset/a.md", ".changeset/b.md", ".changeset/keep.md", "README.md")
+
+	if err := r.Repo.Remove(".changeset/a.md", ".changeset/b.md"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := r.Repo.Commit("chore(release): pkg v1.0.0\n\nmonorel-Release: pkg v1.0.0\n"); err != nil {
+		t.Fatalf("release commit: %v", err)
+	}
+
+	// An unrelated commit that also deletes a file should NOT be
+	// surfaced (its message doesn't match the grep).
+	if err := r.Repo.Remove("README.md"); err != nil {
+		t.Fatalf("remove README: %v", err)
+	}
+	if err := r.Repo.Commit("chore: drop the readme"); err != nil {
+		t.Fatalf("readme commit: %v", err)
+	}
+
+	got, err := r.Repo.DeletedFilesInCommitsMatching("chore(release):")
+	if err != nil {
+		t.Fatalf("DeletedFilesInCommitsMatching: %v", err)
+	}
+	want := []string{".changeset/a.md", ".changeset/b.md"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("[%d]: got %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestExec_DeletedFilesInCommitsMatching_RejectsEmptyGrep(t *testing.T) {
+	r := testutil.NewRepo(t)
+	if _, err := r.Repo.DeletedFilesInCommitsMatching(""); err == nil {
+		t.Error("expected error for empty grep")
+	}
+}
+
+func TestFake_DeletedFilesInCommitsMatching(t *testing.T) {
+	f := git.NewFake()
+
+	// Commit 1: matching message, two deletions.
+	if err := f.Remove(".changeset/x.md", ".changeset/y.md"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := f.Commit("chore(release): pkg v1.0.0"); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Commit 2: non-matching message, deletion that should be excluded.
+	if err := f.Remove("README.md"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := f.Commit("chore: cleanup"); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Commit 3: matching message, one further deletion (dedup test
+	// when combined with commit 1).
+	if err := f.Remove(".changeset/x.md", ".changeset/z.md"); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if err := f.Commit("chore(release): pkg v1.1.0"); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	got, err := f.DeletedFilesInCommitsMatching("chore(release):")
+	if err != nil {
+		t.Fatalf("DeletedFilesInCommitsMatching: %v", err)
+	}
+	want := []string{".changeset/x.md", ".changeset/y.md", ".changeset/z.md"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("[%d]: got %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestFake_DeletedFilesInCommitsMatching_FailNext(t *testing.T) {
+	f := git.NewFake()
+	want := errors.New("boom")
+	f.FailNext = want
+	if _, err := f.DeletedFilesInCommitsMatching("anything"); !errors.Is(err, want) {
+		t.Fatalf("err = %v, want %v", err, want)
+	}
+}
+
 func TestExec_ListTagsAndHead(t *testing.T) {
 	r := testutil.NewRepo(t)
 	r.Tag("v1.0.0", "")


### PR DESCRIPTION
## Summary

Adds the `monorel doctor` command and a public `monorel.disaresta.com/doctor` Go package that catches a real failure mode: stale-branch + squash-merge revival of a previously-consumed `.changeset/*.md` file.

## Motivation

Concrete incident on this repo (PRs #29-#33): the `gitlab-provider` changeset was correctly deleted by the v0.7.0 `chore(release):` commit (PR #30). PR #31 was created from a stale local main that still had the file; GitHub's squash-merge re-introduced it as a side-effect, and PR #32 inherited the revived state. The release-pr workflow then opened PR #33 (`v0.8.0`) with the same content as the already-shipped v0.7.0. The fix was a hand-cleanup PR (#34).

monorel's planner does what its spec says: changesets on main = stuff to release. The bug was the input. JS changesets has the same exposure ([changesets/changesets#1647](https://github.com/changesets/changesets/issues/1647)) and explicitly does not detect it (the maintainer's stance is "rebase your branch"). monorel does better.

## What ships

**CLI:**
```sh
monorel doctor          # text
monorel doctor --json   # machine-readable
```
Exits non-zero on any error-severity finding so CI can gate on it.

**Library:** `monorel.disaresta.com/doctor`
- `doctor.Run(Options) ([]Finding, error)` — runs every built-in check
- `doctor.Finding`, `doctor.Severity`, `doctor.GitLog` — public types
- `doctor.GitLog` is a function value (not an interface), so callers can adapt any git library without conforming to a struct shape

**Mechanism:** `git log --diff-filter=D --grep='chore(release):'` builds the set of changeset filenames previous releases consumed; the live `.changeset/` set is intersected against it. Match = revived file = `SeverityError` finding.

**Internally:** check-runner shape, ready to grow. Today the only check is `revived-changeset`; future checks (orphan changesets, malformed frontmatter, etc.) drop in without re-architecting.

## Coverage

- `doctor/doctor_test.go`: 9 cases — empty, single revival, multi sorted, ignores non-changeset deletions, missing dir, GitLog error propagation, options validation, custom grep, severity stringer.
- `internal/cli/doctor_test.go`: 4 end-to-end cases through a real on-disk git repo via `testutil.NewRepo`.
- `internal/git/repo_test.go`: contract tests for the new `Repo.DeletedFilesInCommitsMatching` method against both `Exec` and `Fake`.

## Test plan

- [x] `go test ./...` passes.
- [x] `bun run docs:build` clean.
- [x] Live smoke test: `go run ./cmd/monorel doctor` against this repo prints "No findings."
- [x] Live smoke test: synthetic revival reproducer in `internal/cli/doctor_test.go::TestDoctorCmd_FlagsRevival` confirms exit 1 + correct message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)