### PR TITLE
fix(orchestrator): auto-truncate release PR body when it exceeds provider limit

### DIFF
--- a/.changeset/release-pr-body-limit.md
+++ b/.changeset/release-pr-body-limit.md
@@ -1,0 +1,7 @@
+---
+"monorel.disaresta.com": patch
+---
+
+Auto-truncate the always-open release PR body when it would exceed the provider's body limit. The orchestrator now falls back through three forms: full rendering with per-package release notes (default), compact rendering with the version table only (when the full body exceeds 65,536 chars), or hard byte-truncation with a trailing marker (last-resort safety net for releases with hundreds of packages where even the table blows past the limit).
+
+Fixes [#37](https://github.com/disaresta-org/monorel/issues/37): the loglayer-go v2 cascade triggered GitHub's `422 Validation Failed: body is too long` because 27 packages × a single multi-package changeset body × table overhead pushed the rendered PR body past 65,536 chars.

--- a/internal/orchestrator/export_test.go
+++ b/internal/orchestrator/export_test.go
@@ -1,0 +1,10 @@
+package orchestrator
+
+// TruncateWithMarker re-exports the package-private
+// truncateWithMarker helper so the external test package can
+// exercise the tier-3 (hard-truncation) path directly without
+// building a synthetic release plan large enough to drive the
+// orchestrator there organically.
+//
+// Tests only; the canonical name stays unexported in production.
+var TruncateWithMarker = truncateWithMarker

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"unicode/utf8"
 
 	"monorel.disaresta.com/internal/provider"
 	"monorel.disaresta.com/internal/release"
@@ -188,7 +189,7 @@ func renderBodyWithinLimit(p *plan.ReleasePlan, today string) string {
 	if len(body) <= MaxPRBodyBytes {
 		return body
 	}
-	body = release.RenderPreviewCompact(p, today)
+	body = release.RenderPreviewCompact(p)
 	if len(body) <= MaxPRBodyBytes {
 		return body
 	}
@@ -196,13 +197,30 @@ func renderBodyWithinLimit(p *plan.ReleasePlan, today string) string {
 	// packages). Hard-truncate at a byte boundary, leaving room
 	// for a trailing marker so the body remains valid markdown
 	// and the reader knows content was dropped.
+	return truncateWithMarker(body, MaxPRBodyBytes)
+}
+
+// truncateWithMarker cuts body to at most max bytes (including the
+// trailing marker) on a UTF-8 codepoint boundary so a multi-byte
+// rune doesn't render as a replacement character. Exposed at
+// package scope so the test suite can exercise the tier-3 branch
+// directly without building a release plan large enough to drive
+// the orchestrator there organically.
+func truncateWithMarker(body string, max int) string {
 	const marker = "\n\n_…(release-PR body truncated by monorel; see each package's CHANGELOG.md for the full content)._\n"
-	cut := MaxPRBodyBytes - len(marker)
+	cut := max - len(marker)
 	if cut < 0 {
 		cut = 0
 	}
 	if cut > len(body) {
 		cut = len(body)
+	}
+	// Walk back to the nearest UTF-8 codepoint boundary so the
+	// truncation never splits a multi-byte rune. RuneStart
+	// returns true for ASCII bytes too, so single-byte truncations
+	// are unaffected.
+	for cut > 0 && !utf8.RuneStart(body[cut]) {
+		cut--
 	}
 	return body[:cut] + marker
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -126,7 +126,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 
 	title := titleFor(opts.Plan)
-	body := release.RenderPreview(opts.Plan, opts.Today)
+	body := renderBodyWithinLimit(opts.Plan, opts.Today)
 
 	if existing == nil {
 		pr, err := opts.Provider.CreatePR(ctx, provider.CreatePROptions{
@@ -159,4 +159,50 @@ func titleFor(p *plan.ReleasePlan) string {
 		return fmt.Sprintf("chore(release): %s %s", r.Name, r.To)
 	}
 	return fmt.Sprintf("chore(release): %d packages", len(p.Releases))
+}
+
+// MaxPRBodyBytes is the conservative upper bound used for PR / MR
+// body content across providers. GitHub caps PR descriptions at
+// 65,536 bytes and Gitea matches; GitLab's MR description allows
+// ~1 MiB but we use the same conservative bound so a release plan
+// that fits one provider fits all.
+const MaxPRBodyBytes = 65536
+
+// renderBodyWithinLimit returns the rendered release-PR body, falling
+// back through three steps when the rendering would exceed
+// [MaxPRBodyBytes]:
+//
+//  1. Full [release.RenderPreview] (header + per-package sections).
+//  2. [release.RenderPreviewCompact] (header + version table only;
+//     per-package release notes elided with a pointer to each
+//     package's CHANGELOG).
+//  3. Hard byte-truncation with a trailing marker, for the rare
+//     case where even the compact form is too large (e.g. hundreds
+//     of packages where the table itself exceeds the limit).
+//
+// Step 1 succeeds for the vast majority of release plans; step 2
+// kicks in only when a changeset body × package-count blows past
+// the limit; step 3 is a last-resort safety net.
+func renderBodyWithinLimit(p *plan.ReleasePlan, today string) string {
+	body := release.RenderPreview(p, today)
+	if len(body) <= MaxPRBodyBytes {
+		return body
+	}
+	body = release.RenderPreviewCompact(p, today)
+	if len(body) <= MaxPRBodyBytes {
+		return body
+	}
+	// Compact still doesn't fit (huge release with hundreds of
+	// packages). Hard-truncate at a byte boundary, leaving room
+	// for a trailing marker so the body remains valid markdown
+	// and the reader knows content was dropped.
+	const marker = "\n\n_…(release-PR body truncated by monorel; see each package's CHANGELOG.md for the full content)._\n"
+	cut := MaxPRBodyBytes - len(marker)
+	if cut < 0 {
+		cut = 0
+	}
+	if cut > len(body) {
+		cut = len(body)
+	}
+	return body[:cut] + marker
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -184,3 +184,55 @@ func TestRun_MultiPackageTitle(t *testing.T) {
 		t.Errorf("multi-package title = %q, want '2 packages'", res.PR.Title)
 	}
 }
+
+// TestRun_LongBodyFallsBackToCompact builds a plan whose full
+// rendering would exceed MaxPRBodyBytes (a single huge changeset
+// body fanned across 30 packages) and verifies the orchestrator
+// falls back to the compact form so the provider call still
+// succeeds.
+func TestRun_LongBodyFallsBackToCompact(t *testing.T) {
+	f := provider.NewFake()
+
+	// 5 KiB of body × 30 packages = ~150 KiB, well over the 64 KiB
+	// limit. Each package has its own changeset with the same body.
+	body := strings.Repeat("This is a long changeset body. ", 160) // ~5 KB
+	p := &plan.ReleasePlan{}
+	for i := 0; i < 30; i++ {
+		name := "pkg" + string(rune('a'+i))
+		cs := &changeset.Changeset{
+			Name:  name,
+			Bumps: map[string]semver.BumpLevel{name: semver.Major},
+			Body:  body,
+		}
+		p.Releases = append(p.Releases, plan.PackageRelease{
+			Name:       name,
+			From:       "v1.0.0",
+			To:         "v2.0.0",
+			Bump:       semver.Major,
+			Tag:        "transports/" + name + "/v2.0.0",
+			Changesets: []*changeset.Changeset{cs},
+		})
+		p.Consumed = append(p.Consumed, cs)
+	}
+
+	res, err := orchestrator.Run(context.Background(), orchestrator.Options{
+		Plan:     p,
+		Provider: f,
+		Today:    "2026-05-02",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := len(res.PR.Body); got > orchestrator.MaxPRBodyBytes {
+		t.Errorf("body size %d exceeds limit %d; orchestrator should have fallen back", got, orchestrator.MaxPRBodyBytes)
+	}
+	if !strings.Contains(res.PR.Body, "Per-package release notes were elided") {
+		t.Errorf("compact-form marker missing; body:\n%s", res.PR.Body)
+	}
+	// Sanity: the table is still present (so the reader sees
+	// what's shipping at what versions).
+	if !strings.Contains(res.PR.Body, "| Package | Bump | From | To |") {
+		t.Errorf("version table missing from compact rendering")
+	}
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -236,3 +236,24 @@ func TestRun_LongBodyFallsBackToCompact(t *testing.T) {
 		t.Errorf("version table missing from compact rendering")
 	}
 }
+
+// TestTruncateWithMarker_Tier3 directly tests the hard-truncation
+// helper with a small max so we don't have to build a release plan
+// large enough to drive the orchestrator there organically. Covers:
+//   - body fits within max: marker is appended unconditionally; this test only asserts the multi-byte rune case below.
+//   - body exceeds max → cut + marker, total length <= max + len(marker).
+//   - body contains a multi-byte rune at the cut point → walks back to a UTF-8 boundary.
+func TestTruncateWithMarker_Tier3(t *testing.T) {
+	// Build a body that would split a 3-byte UTF-8 rune (€ = U+20AC,
+	// 0xE2 0x82 0xAC) at byte 2 if we naively cut at len(body) - 1.
+	// Place the rune so that the cut lands inside it.
+	body := strings.Repeat("a", 600) + "€" + strings.Repeat("b", 600)
+	// max chosen so the cut would land mid-rune without UTF-8 walk-back.
+	got := orchestrator.TruncateWithMarker(body, 700)
+	if strings.Contains(got, "�") {
+		t.Errorf("truncation produced a UTF-8 replacement character: %q", got[:60])
+	}
+	if !strings.Contains(got, "release-PR body truncated by monorel") {
+		t.Errorf("truncated body missing trailing marker: %q", got[len(got)-200:])
+	}
+}

--- a/internal/release/render.go
+++ b/internal/release/render.go
@@ -83,6 +83,57 @@ func RenderPreview(p *plan.ReleasePlan, today string) string {
 	return b.String()
 }
 
+// RenderPreviewCompact is a slimmer variant of [RenderPreview] for
+// release plans whose full rendering would exceed a provider's PR
+// body limit. The output keeps the header, the per-package version
+// table, and any pre-release / consumed-changesets footer; it omits
+// the `## Released changes` per-package sections. A reader sees
+// what's shipping at what version and is pointed at the CHANGELOGs
+// for the full prose.
+//
+// The orchestrator falls back to this when the full rendering
+// exceeds [MaxPRBodyBytes]; callers don't normally invoke it
+// directly.
+func RenderPreviewCompact(p *plan.ReleasePlan, today string) string {
+	if p == nil || p.IsEmpty() {
+		return "_No pending changesets. The release PR will be closed._\n"
+	}
+
+	var b strings.Builder
+	fmt.Fprintln(&b, "This PR was opened by [monorel](https://monorel.disaresta.com). Merge it to release the following packages:")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| Package | Bump | From | To |")
+	fmt.Fprintln(&b, "|---|---|---|---|")
+	for _, r := range p.Releases {
+		from := r.From
+		if from == "" {
+			from = "_(initial)_"
+		}
+		fmt.Fprintf(&b, "| `%s` | %s | %s | **%s** |\n", r.Name, r.Bump, from, r.To)
+	}
+	fmt.Fprintln(&b)
+
+	if anyPrerelease(p) {
+		fmt.Fprintln(&b, "> **Pre-release**: this release is part of a pre-release window. CHANGELOGs and changeset files are preserved; merging this PR ships pre-release tags.")
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintln(&b, "_Per-package release notes were elided to fit the provider's PR body limit. Each package's `CHANGELOG.md` will receive the full content when this PR merges._")
+
+	if len(p.Consumed) > 0 {
+		fmt.Fprintln(&b)
+		fmt.Fprintf(&b, "_Consumed %d changeset(s): ", len(p.Consumed))
+		names := make([]string, len(p.Consumed))
+		for i, cs := range p.Consumed {
+			names[i] = "`" + cs.Name + "`"
+		}
+		fmt.Fprint(&b, strings.Join(names, ", "))
+		fmt.Fprintln(&b, "._")
+	}
+
+	return b.String()
+}
+
 func anyPrerelease(p *plan.ReleasePlan) bool {
 	for _, r := range p.Releases {
 		if r.Prerelease {

--- a/internal/release/render.go
+++ b/internal/release/render.go
@@ -83,6 +83,13 @@ func RenderPreview(p *plan.ReleasePlan, today string) string {
 	return b.String()
 }
 
+// CompactElidedNotesMarker is the line the compact-form rendering
+// emits in place of the per-package "Released changes" sections.
+// Exported so downstream tooling that scrapes release-PR bodies has
+// a stable substring to detect "this PR's body was rendered in the
+// compact form because the full content didn't fit".
+const CompactElidedNotesMarker = "_Per-package release notes were elided to fit the provider's PR body limit. Each package's `CHANGELOG.md` will receive the full content when this PR merges._"
+
 // RenderPreviewCompact is a slimmer variant of [RenderPreview] for
 // release plans whose full rendering would exceed a provider's PR
 // body limit. The output keeps the header, the per-package version
@@ -94,7 +101,11 @@ func RenderPreview(p *plan.ReleasePlan, today string) string {
 // The orchestrator falls back to this when the full rendering
 // exceeds [MaxPRBodyBytes]; callers don't normally invoke it
 // directly.
-func RenderPreviewCompact(p *plan.ReleasePlan, today string) string {
+//
+// Unlike [RenderPreview], this function takes no `today` parameter:
+// the compact form has no per-package date-stamped CHANGELOG
+// content, so the date is not needed.
+func RenderPreviewCompact(p *plan.ReleasePlan) string {
 	if p == nil || p.IsEmpty() {
 		return "_No pending changesets. The release PR will be closed._\n"
 	}
@@ -118,7 +129,7 @@ func RenderPreviewCompact(p *plan.ReleasePlan, today string) string {
 		fmt.Fprintln(&b)
 	}
 
-	fmt.Fprintln(&b, "_Per-package release notes were elided to fit the provider's PR body limit. Each package's `CHANGELOG.md` will receive the full content when this PR merges._")
+	fmt.Fprintln(&b, CompactElidedNotesMarker)
 
 	if len(p.Consumed) > 0 {
 		fmt.Fprintln(&b)

--- a/internal/release/render_test.go
+++ b/internal/release/render_test.go
@@ -96,3 +96,55 @@ func TestRenderPreview_PrereleaseNote(t *testing.T) {
 		t.Errorf("pre-release plan should call out the channel state:\n%s", got)
 	}
 }
+
+func TestRenderPreviewCompact(t *testing.T) {
+	cs := &changeset.Changeset{
+		Name:  "first",
+		Bumps: map[string]semver.BumpLevel{"foo": semver.Minor},
+		Body:  "Adds Lazy() helper.",
+	}
+	p := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{{
+			Name:       "foo",
+			From:       "v1.6.1",
+			To:         "v1.7.0",
+			Bump:       semver.Minor,
+			Tag:        "transports/foo/v1.7.0",
+			Changesets: []*changeset.Changeset{cs},
+		}},
+		Consumed: []*changeset.Changeset{cs},
+	}
+	got := release.RenderPreviewCompact(p, "2026-04-30")
+
+	// The version table is the load-bearing content of the
+	// compact form; make sure it survives.
+	for _, want := range []string{
+		"opened by [monorel]",
+		"`foo`",
+		"v1.6.1",
+		"**v1.7.0**",
+		"Per-package release notes were elided",
+		"`first`", // Consumed footer
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("compact form missing %q\nfull:\n%s", want, got)
+		}
+	}
+	// The per-package "Released changes" section should NOT
+	// render in the compact form; that's the whole point.
+	if strings.Contains(got, "Released changes") {
+		t.Errorf("compact form should drop the Released changes section:\n%s", got)
+	}
+	if strings.Contains(got, "Adds Lazy() helper.") {
+		t.Errorf("compact form should drop the changeset body:\n%s", got)
+	}
+}
+
+func TestRenderPreviewCompact_EmptyPlan(t *testing.T) {
+	if got := release.RenderPreviewCompact(nil, ""); !strings.Contains(got, "No pending changesets") {
+		t.Errorf("nil plan should render empty-state message; got %q", got)
+	}
+	if got := release.RenderPreviewCompact(&plan.ReleasePlan{}, ""); !strings.Contains(got, "No pending changesets") {
+		t.Errorf("empty plan should render empty-state message; got %q", got)
+	}
+}

--- a/internal/release/render_test.go
+++ b/internal/release/render_test.go
@@ -114,7 +114,7 @@ func TestRenderPreviewCompact(t *testing.T) {
 		}},
 		Consumed: []*changeset.Changeset{cs},
 	}
-	got := release.RenderPreviewCompact(p, "2026-04-30")
+	got := release.RenderPreviewCompact(p)
 
 	// The version table is the load-bearing content of the
 	// compact form; make sure it survives.
@@ -141,10 +141,32 @@ func TestRenderPreviewCompact(t *testing.T) {
 }
 
 func TestRenderPreviewCompact_EmptyPlan(t *testing.T) {
-	if got := release.RenderPreviewCompact(nil, ""); !strings.Contains(got, "No pending changesets") {
+	if got := release.RenderPreviewCompact(nil); !strings.Contains(got, "No pending changesets") {
 		t.Errorf("nil plan should render empty-state message; got %q", got)
 	}
-	if got := release.RenderPreviewCompact(&plan.ReleasePlan{}, ""); !strings.Contains(got, "No pending changesets") {
+	if got := release.RenderPreviewCompact(&plan.ReleasePlan{}); !strings.Contains(got, "No pending changesets") {
 		t.Errorf("empty plan should render empty-state message; got %q", got)
+	}
+}
+
+func TestCompactElidedNotesMarker_StableContract(t *testing.T) {
+	// CompactElidedNotesMarker is the stable substring downstream
+	// scrapers can detect to know the body was rendered compact.
+	// Verify the constant matches what RenderPreviewCompact emits
+	// so a future rewrite of one without the other can't drift.
+	cs := &changeset.Changeset{
+		Name:  "x",
+		Bumps: map[string]semver.BumpLevel{"foo": semver.Patch},
+		Body:  "x",
+	}
+	p := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{{
+			Name: "foo", From: "v1.0.0", To: "v1.0.1", Bump: semver.Patch,
+			Tag: "foo/v1.0.1", Changesets: []*changeset.Changeset{cs},
+		}},
+	}
+	got := release.RenderPreviewCompact(p)
+	if !strings.Contains(got, release.CompactElidedNotesMarker) {
+		t.Errorf("compact rendering doesn't contain the public marker constant")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #37. The always-open release PR's body now auto-truncates when its rendered length would exceed the provider's PR-body limit (65,536 chars on GitHub / Gitea, conservative bound on GitLab). Replaces a hard `422 Validation Failed: body is too long` with a graceful fallback to a compact form.

## What changed

- `internal/release/render.go`: new `RenderPreviewCompact` function. Same header + version table + consumed footer as `RenderPreview`, but the per-package "Released changes" sections are elided with a pointer to each package's `CHANGELOG.md`.
- `internal/orchestrator/orchestrator.go`: new `MaxPRBodyBytes` constant (`65536`) and `renderBodyWithinLimit` helper. Three-tier fallback: full → compact → hard byte-truncation with a trailing marker.

## Repro

The loglayer-go v2 cascade (loglayer/loglayer-go#61) shipped 27 packages at `:major` from a single multi-package changeset whose body was ~3.4 KB. 27 × 3.4 KB + table overhead = ~92 KB rendered, well over GitHub's 65,536-char cap. The release-pr workflow failed with the 422 error.

After this PR, the same plan would render compact (~2 KB) and the workflow would succeed.

## Test plan

- [x] `go test -count=1 ./...` passes.
- [x] New `TestRenderPreviewCompact` (verifies compact form preserves the table + footer, drops the per-package sections + changeset body).
- [x] New `TestRenderPreviewCompact_EmptyPlan` (empty / nil plans still render the no-pending-changesets message).
- [x] New `TestRun_LongBodyFallsBackToCompact` (synthetic 30-package × 5 KB body plan; verifies orchestrator falls back to compact and resulting body fits within `MaxPRBodyBytes`).
- [ ] After merge, the loglayer-go v2 release-pr workflow re-runs against the now-compact-friendly orchestrator and opens the always-open PR successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)