### PR TITLE
feat(apply): rewrite released sub-modules' go.mod before tagging

### DIFF
--- a/.changeset/strip-dev-replaces.md
+++ b/.changeset/strip-dev-replaces.md
@@ -1,0 +1,12 @@
+---
+"monorel.disaresta.com": minor
+---
+
+`monorel apply` now rewrites each released sub-module's `go.mod` before staging the release commit:
+
+1. Drops dev-only `replace` directives whose target is a sibling package in the same release plan AND whose source is a relative filesystem path (the `replace go.loglayer.dev/<sibling> => ../<sibling>` convention from monorel's monorepo template). External replaces (forking a third-party dep, etc.) are preserved.
+2. Pins each sibling `require` line to the planned release version, replacing the placeholder pseudo-version (`v0.0.0-00010101000000-000000000000`) sub-modules carry during development.
+
+Without this rewrite, the dev-only state shipped to the module proxy and downstream consumers' `go mod tidy` returned 404 on the placeholder pseudo-version.
+
+Fixes [#41](https://github.com/disaresta-org/monorel/issues/41).

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -23,7 +23,7 @@ The off-the-shelf options each have a sharp edge for this layout.
 | Local CLI (works off-CI) | ⚠️ via npm package | ✅ | ✅ | ✅ |
 | Bare-tag root (`vX.Y.Z`) | ✅ | n/a (JS layout) | ❌ prefixes mandatory | ✅ |
 | Path-prefixed sub-module tags | ✅ | n/a (JS layout) | ✅ | ✅ |
-| Strips dev `replace` + pins sibling `require` versions in `go.mod` at release time | ❌ | n/a (JS) | ❌ | ✅ |
+| Cleans `go.mod` for proxy publish | ❌ | n/a (JS) | ❌ | ✅ |
 | Source of truth | commit footers (`Release-As:`) | `.changeset/*.md` | configurable (commits or files) | `.changeset/*.md` |
 | Native to | TypeScript | TypeScript | Rust | Go |
 | Multi-provider | GitHub | GitHub (bot); CLI host-agnostic | GitHub / GitLab / Gitea | GitHub + Gitea / Forgejo + GitLab |
@@ -60,7 +60,7 @@ monorel takes the changesets *idea* (per-PR intent files, named affected package
 - **Always-open release PR.** The bot orchestrator force-pushes a speculative-version branch and upserts a PR. Merging the PR runs `monorel release` on the merge commit, pushes tags, and publishes per-tag releases.
 - **Pre-release support.** `monorel pre enter rc` switches the repo to release-candidate mode; subsequent releases append `-rc.N` to the next stable version and increment a per-package counter. `pre exit` returns to stable.
 - **Provider-neutral.** GitHub, Gitea / Forgejo, and GitLab today; Bitbucket by adding a subpackage. The orchestrator never sees provider-specific types.
-- **Clean `go.mod` at release time.** Go monorepo sub-modules conventionally carry `replace go.example.com/<sibling> => ../<sibling>` for local development plus a placeholder pseudo-version (`v0.0.0-00010101000000-000000000000`) on the matching `require` line. Both are correct in the local checkout; both are wrong on the module proxy. Without intervention they ship verbatim to the proxy and downstream consumers' `go mod tidy` returns 404 on the placeholder version. monorel's `apply` rewrites every released sub-module's `go.mod` before staging the release commit: drops the dev-only `replace` directives whose target is a sibling in the same release plan, and pins each sibling's `require` line to its planned tag. External (non-sibling) `replace` directives are preserved. This is monorel-specific: `release-please`, `Knope`, and `changesets` don't model the Go-monorepo proxy contract, so every adopter solves it hand-rolled (kubernetes' staging-publishing-bot, hashicorp's modulemodifier, etc.).
+- **Clean `go.mod` at release time.** Sub-modules carry dev `replace` directives and placeholder `require` versions for local cross-module work; monorel strips and pins them in the release commit so downstream consumers' `go mod tidy` doesn't 404 on the placeholder. The other tools don't model the Go-monorepo proxy contract; every adopter who hits this hand-rolls a publishing script.
 
 ## When monorel is overkill
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -23,6 +23,7 @@ The off-the-shelf options each have a sharp edge for this layout.
 | Local CLI (works off-CI) | ⚠️ via npm package | ✅ | ✅ | ✅ |
 | Bare-tag root (`vX.Y.Z`) | ✅ | n/a (JS layout) | ❌ prefixes mandatory | ✅ |
 | Path-prefixed sub-module tags | ✅ | n/a (JS layout) | ✅ | ✅ |
+| Strips dev `replace` + pins sibling `require` versions in `go.mod` at release time | ❌ | n/a (JS) | ❌ | ✅ |
 | Source of truth | commit footers (`Release-As:`) | `.changeset/*.md` | configurable (commits or files) | `.changeset/*.md` |
 | Native to | TypeScript | TypeScript | Rust | Go |
 | Multi-provider | GitHub | GitHub (bot); CLI host-agnostic | GitHub / GitLab / Gitea | GitHub + Gitea / Forgejo + GitLab |
@@ -59,6 +60,7 @@ monorel takes the changesets *idea* (per-PR intent files, named affected package
 - **Always-open release PR.** The bot orchestrator force-pushes a speculative-version branch and upserts a PR. Merging the PR runs `monorel release` on the merge commit, pushes tags, and publishes per-tag releases.
 - **Pre-release support.** `monorel pre enter rc` switches the repo to release-candidate mode; subsequent releases append `-rc.N` to the next stable version and increment a per-package counter. `pre exit` returns to stable.
 - **Provider-neutral.** GitHub, Gitea / Forgejo, and GitLab today; Bitbucket by adding a subpackage. The orchestrator never sees provider-specific types.
+- **Clean `go.mod` at release time.** Go monorepo sub-modules conventionally carry `replace go.example.com/<sibling> => ../<sibling>` for local development plus a placeholder pseudo-version (`v0.0.0-00010101000000-000000000000`) on the matching `require` line. Both are correct in the local checkout; both are wrong on the module proxy. Without intervention they ship verbatim to the proxy and downstream consumers' `go mod tidy` returns 404 on the placeholder version. monorel's `apply` rewrites every released sub-module's `go.mod` before staging the release commit: drops the dev-only `replace` directives whose target is a sibling in the same release plan, and pins each sibling's `require` line to its planned tag. External (non-sibling) `replace` directives are preserved. This is monorel-specific: `release-please`, `Knope`, and `changesets` don't model the Go-monorepo proxy contract, so every adopter solves it hand-rolled (kubernetes' staging-publishing-bot, hashicorp's modulemodifier, etc.).
 
 ## When monorel is overkill
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -60,7 +60,7 @@ monorel takes the changesets *idea* (per-PR intent files, named affected package
 - **Always-open release PR.** The bot orchestrator force-pushes a speculative-version branch and upserts a PR. Merging the PR runs `monorel release` on the merge commit, pushes tags, and publishes per-tag releases.
 - **Pre-release support.** `monorel pre enter rc` switches the repo to release-candidate mode; subsequent releases append `-rc.N` to the next stable version and increment a per-package counter. `pre exit` returns to stable.
 - **Provider-neutral.** GitHub, Gitea / Forgejo, and GitLab today; Bitbucket by adding a subpackage. The orchestrator never sees provider-specific types.
-- **Clean `go.mod` at release time.** Sub-modules carry dev `replace` directives and placeholder `require` versions for local cross-module work; monorel strips and pins them in the release commit so downstream consumers' `go mod tidy` doesn't 404 on the placeholder. The other tools don't model the Go-monorepo proxy contract; every adopter who hits this hand-rolls a publishing script.
+- **Clean `go.mod` at release time.** Sub-modules carry dev `replace` directives and placeholder `require` versions for local cross-module work; monorel strips and pins them in the release commit so downstream consumers' `go mod tidy` resolves the published versions.
 
 ## When monorel is overkill
 

--- a/internal/release/gomod.go
+++ b/internal/release/gomod.go
@@ -20,8 +20,9 @@ import (
 //     left intact.
 //  2. Rewrite require lines for sibling packages to the planned
 //     release version. Sub-modules hold each other's require version
-//     at a placeholder pseudo-version (e.g. v0.0.0-00010101000000-
-//  000000000000. during development; without the rewrite, the
+//     at a placeholder pseudo-version (e.g.
+//     v0.0.0-00010101000000-000000000000) during development;
+//     without the rewrite, the
 //     placeholder ships to the proxy and downstream consumers'
 //     `go mod tidy` returns 404 on the placeholder.
 //

--- a/internal/release/gomod.go
+++ b/internal/release/gomod.go
@@ -1,0 +1,155 @@
+package release
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/modfile"
+)
+
+// rewriteSubmoduleGoMods walks the released packages and cleans each
+// one's go.mod for the published-tag state:
+//
+//  1. Drop replace directives whose target is a sibling package (one
+//     of the others in the same release plan) AND whose source is a
+//     relative filesystem path. These are dev-only "use the local
+//     checkout instead of the proxy" directives that should never
+//     ship to the module proxy. External (non-sibling) replaces are
+//     left intact.
+//  2. Rewrite require lines for sibling packages to the planned
+//     release version. Sub-modules hold each other's require version
+//     at a placeholder pseudo-version (e.g. v0.0.0-00010101000000-
+//  000000000000. during development; without the rewrite, the
+//     placeholder ships to the proxy and downstream consumers'
+//     `go mod tidy` returns 404 on the placeholder.
+//
+// Stages each modified file via opts.Repo.Add. Idempotent: a go.mod
+// that doesn't need changes isn't touched.
+//
+// Packages whose Path doesn't contain a go.mod (e.g. the main module
+// rooted at the repo root, or a pure-changelog package) are skipped.
+//
+// Called from applyStable AFTER CHANGELOG writes and BEFORE the
+// consumed-changesets deletion so all the file changes land in the
+// same release commit.
+func rewriteSubmoduleGoMods(opts Options) error {
+	// First pass: read every released package's go.mod and build a
+	// map from import path (module directive) to planned release
+	// version. The planned version is the version part of the
+	// release tag (e.g. tag "transports/foo/v2.0.0" -> "v2.0.0").
+	// Packages without a go.mod (no sibling-deps to rewrite) get
+	// an empty entry, which is skipped on the rewrite pass.
+	type releasedPkg struct {
+		importPath string
+		version    string
+		modPath    string // absolute filesystem path
+		modFile    *modfile.File
+	}
+	pkgs := make([]releasedPkg, len(opts.Plan.Releases))
+	siblings := make(map[string]string, len(opts.Plan.Releases))
+	for i, r := range opts.Plan.Releases {
+		modPath := filepath.Join(opts.RepoDir, r.Config.Path, "go.mod")
+		data, err := os.ReadFile(modPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("release: read %s: %w", modPath, err)
+		}
+		mf, err := modfile.Parse(modPath, data, nil)
+		if err != nil {
+			return fmt.Errorf("release: parse %s: %w", modPath, err)
+		}
+		if mf.Module == nil {
+			return fmt.Errorf("release: %s has no module directive", modPath)
+		}
+		// Extract the version part of the tag (strip the prefix).
+		// Tag shape: "<tag_prefix>/v<X.Y.Z>" or "v<X.Y.Z>" for the
+		// root module.
+		ver := r.Tag
+		if idx := strings.LastIndex(ver, "/v"); idx >= 0 {
+			ver = ver[idx+1:]
+		}
+		pkgs[i] = releasedPkg{
+			importPath: mf.Module.Mod.Path,
+			version:    ver,
+			modPath:    modPath,
+			modFile:    mf,
+		}
+		siblings[mf.Module.Mod.Path] = ver
+	}
+
+	// Second pass: rewrite each released package's go.mod using the
+	// sibling map. Self-references are skipped explicitly so a
+	// package's own import path can't shadow a sibling rewrite.
+	for i, p := range pkgs {
+		if p.modFile == nil {
+			continue
+		}
+		mf := p.modFile
+		changed := false
+
+		// Strip dev-only replace directives.
+		for _, rep := range mf.Replace {
+			if rep.Old.Path == p.importPath {
+				continue // self-replace; weird but leave alone
+			}
+			if _, ok := siblings[rep.Old.Path]; !ok {
+				continue
+			}
+			if !isRelativePath(rep.New.Path) {
+				continue
+			}
+			if err := mf.DropReplace(rep.Old.Path, rep.Old.Version); err != nil {
+				return fmt.Errorf("release: drop replace %s in %s: %w", rep.Old.Path, p.modPath, err)
+			}
+			changed = true
+		}
+
+		// Pin sibling require versions.
+		for _, req := range mf.Require {
+			newVer, isSibling := siblings[req.Mod.Path]
+			if !isSibling {
+				continue
+			}
+			if req.Mod.Path == p.importPath {
+				continue
+			}
+			if req.Mod.Version == newVer {
+				continue
+			}
+			if err := mf.AddRequire(req.Mod.Path, newVer); err != nil {
+				return fmt.Errorf("release: pin require %s in %s: %w", req.Mod.Path, p.modPath, err)
+			}
+			changed = true
+		}
+
+		if !changed {
+			continue
+		}
+
+		mf.Cleanup()
+		out, err := mf.Format()
+		if err != nil {
+			return fmt.Errorf("release: format %s: %w", p.modPath, err)
+		}
+		if err := os.WriteFile(p.modPath, out, 0o644); err != nil {
+			return fmt.Errorf("release: write %s: %w", p.modPath, err)
+		}
+		rel := filepath.Join(opts.Plan.Releases[i].Config.Path, "go.mod")
+		if err := opts.Repo.Add(rel); err != nil {
+			return fmt.Errorf("release: stage %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+
+// isRelativePath reports whether s names a filesystem path relative
+// to the package's go.mod directory. A target that doesn't start with
+// "." or ".." is treated as a non-relative location (an absolute
+// path, a remote module path, etc.) and is left alone.
+func isRelativePath(s string) bool {
+	return strings.HasPrefix(s, ".") || strings.HasPrefix(s, "..")
+}

--- a/internal/release/gomod.go
+++ b/internal/release/gomod.go
@@ -147,9 +147,10 @@ func rewriteSubmoduleGoMods(opts Options) error {
 }
 
 // isRelativePath reports whether s names a filesystem path relative
-// to the package's go.mod directory. A target that doesn't start with
-// "." or ".." is treated as a non-relative location (an absolute
-// path, a remote module path, etc.) and is left alone.
+// to the package's go.mod directory. modfile's grammar says any
+// replace target starting with "." (so ".", "./x", "..", "../x") is
+// a filesystem path; absolute paths, remote module paths, etc. are
+// left alone.
 func isRelativePath(s string) bool {
-	return strings.HasPrefix(s, ".") || strings.HasPrefix(s, "..")
+	return strings.HasPrefix(s, ".")
 }

--- a/internal/release/gomod_test.go
+++ b/internal/release/gomod_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"monorel.disaresta.com/changeset"
 	"monorel.disaresta.com/config"
 	"monorel.disaresta.com/internal/git"
 	"monorel.disaresta.com/plan"
@@ -140,6 +139,114 @@ require github.com/some/dep v1.0.0
 	}
 }
 
+// TestRewriteSubmoduleGoMods_MultiSiblingRequirePin verifies that a
+// go.mod with multiple sibling require lines gets every sibling
+// pinned, not just the first one.
+func TestRewriteSubmoduleGoMods_MultiSiblingRequirePin(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "transports/baz/go.mod"), `module example.com/transports/baz/v2
+
+go 1.25.0
+
+replace example.com/transports/foo/v2 => ../foo
+replace example.com/transports/bar/v2 => ../bar
+
+require (
+	example.com/transports/bar/v2 v2.0.0-00010101000000-000000000000
+	example.com/transports/foo/v2 v2.0.0-00010101000000-000000000000
+)
+`)
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+`)
+	mustWrite(t, filepath.Join(dir, "transports/bar/go.mod"), `module example.com/transports/bar/v2
+
+go 1.25.0
+`)
+
+	repo := git.NewFake()
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{
+				{
+					Name: "transports/baz", Tag: "transports/baz/v2.0.1", To: "v2.0.1", Bump: semver.Patch,
+					Config: config.PackageConfig{TagPrefix: "transports/baz", Path: "transports/baz"},
+				},
+				{
+					Name: "transports/foo", Tag: "transports/foo/v2.0.1", To: "v2.0.1", Bump: semver.Patch,
+					Config: config.PackageConfig{TagPrefix: "transports/foo", Path: "transports/foo"},
+				},
+				{
+					Name: "transports/bar", Tag: "transports/bar/v2.0.1", To: "v2.0.1", Bump: semver.Patch,
+					Config: config.PackageConfig{TagPrefix: "transports/bar", Path: "transports/bar"},
+				},
+			},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/baz/go.mod"))
+	for _, want := range []string{
+		"example.com/transports/foo/v2 v2.0.1",
+		"example.com/transports/bar/v2 v2.0.1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing pinned require %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "v2.0.0-00010101000000-000000000000") {
+		t.Errorf("placeholder version still present:\n%s", got)
+	}
+	if strings.Contains(got, "replace example.com/transports/") {
+		t.Errorf("dev replace directives should be stripped:\n%s", got)
+	}
+}
+
+// TestRewriteSubmoduleGoMods_OutOfPlanSiblingLeftAlone verifies
+// that a require for a package that ISN'T in the current release
+// plan (even if it shares the same naming pattern) is not touched.
+// The contract is "rewrite siblings IN the plan"; out-of-plan
+// siblings stay at whatever version the go.mod already specifies.
+func TestRewriteSubmoduleGoMods_OutOfPlanSiblingLeftAlone(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+
+require example.com/transports/external/v2 v2.5.0
+`)
+
+	repo := git.NewFake()
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{{
+				Name: "transports/foo", Tag: "transports/foo/v2.0.1", To: "v2.0.1", Bump: semver.Patch,
+				Config: config.PackageConfig{TagPrefix: "transports/foo", Path: "transports/foo"},
+			}},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/foo/go.mod"))
+	if !strings.Contains(got, "example.com/transports/external/v2 v2.5.0") {
+		t.Errorf("out-of-plan sibling require should be preserved:\n%s", got)
+	}
+	if len(repo.Staged) != 0 {
+		t.Errorf("nothing should be staged when no rewrite occurs; staged = %v", repo.Staged)
+	}
+}
+
 // TestRewriteSubmoduleGoMods_NoGoModSkipsSilently confirms a
 // release whose Path doesn't contain a go.mod (e.g. a pure-changelog
 // package) doesn't error out.
@@ -183,6 +290,3 @@ func mustRead(t *testing.T, path string) string {
 	}
 	return string(data)
 }
-
-// Ensure changeset import is exercised so the linter is happy.
-var _ = changeset.Changeset{}

--- a/internal/release/gomod_test.go
+++ b/internal/release/gomod_test.go
@@ -1,0 +1,188 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"monorel.disaresta.com/changeset"
+	"monorel.disaresta.com/config"
+	"monorel.disaresta.com/internal/git"
+	"monorel.disaresta.com/plan"
+	"monorel.disaresta.com/semver"
+)
+
+// TestRewriteSubmoduleGoMods_StripsDevReplacesAndPinsRequires
+// constructs a synthetic two-sub-module monorepo on disk:
+//
+//	root/
+//	  transports/foo/go.mod   (module = example.com/transports/foo/v2,
+//	                            replace example.com/transports/bar/v2 => ../bar,
+//	                            require example.com/transports/bar/v2 v2.0.0-placeholder)
+//	  transports/bar/go.mod   (module = example.com/transports/bar/v2)
+//
+// and verifies that after rewriteSubmoduleGoMods runs against a
+// release plan that includes both packages at v2.0.1:
+//
+//   - transports/foo/go.mod no longer contains the `replace ../bar`
+//     directive.
+//   - transports/foo/go.mod's require for transports/bar/v2 reads
+//     v2.0.1 instead of the placeholder.
+//   - both go.mod files are staged via repo.Add.
+func TestRewriteSubmoduleGoMods_StripsDevReplacesAndPinsRequires(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+
+replace example.com/transports/bar/v2 => ../bar
+
+require example.com/transports/bar/v2 v2.0.0-00010101000000-000000000000
+`)
+	mustWrite(t, filepath.Join(dir, "transports/bar/go.mod"), `module example.com/transports/bar/v2
+
+go 1.25.0
+`)
+
+	repo := git.NewFake()
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{
+				{
+					Name:   "transports/foo",
+					Tag:    "transports/foo/v2.0.1",
+					Bump:   semver.Patch,
+					From:   "v2.0.0",
+					To:     "v2.0.1",
+					Config: config.PackageConfig{TagPrefix: "transports/foo", Path: "transports/foo"},
+				},
+				{
+					Name:   "transports/bar",
+					Tag:    "transports/bar/v2.0.1",
+					Bump:   semver.Patch,
+					From:   "v2.0.0",
+					To:     "v2.0.1",
+					Config: config.PackageConfig{TagPrefix: "transports/bar", Path: "transports/bar"},
+				},
+			},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/foo/go.mod"))
+	if strings.Contains(got, "replace") {
+		t.Errorf("dev replace directive should be stripped:\n%s", got)
+	}
+	if !strings.Contains(got, "v2.0.1") {
+		t.Errorf("require version should be pinned to v2.0.1:\n%s", got)
+	}
+	if strings.Contains(got, "v2.0.0-00010101000000-000000000000") {
+		t.Errorf("placeholder require version should be gone:\n%s", got)
+	}
+
+	// Both go.mod files should be staged. transports/foo got
+	// edited; transports/bar didn't change (no sibling deps), so
+	// only foo should be staged.
+	staged := strings.Join(repo.Staged, " ")
+	if !strings.Contains(staged, filepath.Join("transports", "foo", "go.mod")) {
+		t.Errorf("foo/go.mod should be staged; staged = %v", repo.Staged)
+	}
+	if strings.Contains(staged, filepath.Join("transports", "bar", "go.mod")) {
+		t.Errorf("bar/go.mod was not modified, should not be staged; staged = %v", repo.Staged)
+	}
+}
+
+// TestRewriteSubmoduleGoMods_KeepsExternalReplaces verifies that a
+// replace directive whose target ISN'T a sibling package is left
+// alone.
+func TestRewriteSubmoduleGoMods_KeepsExternalReplaces(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+
+replace github.com/some/dep => github.com/forks/dep v1.2.3
+
+require github.com/some/dep v1.0.0
+`)
+
+	repo := git.NewFake()
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{{
+				Name:   "transports/foo",
+				Tag:    "transports/foo/v2.0.1",
+				To:     "v2.0.1",
+				Config: config.PackageConfig{TagPrefix: "transports/foo", Path: "transports/foo"},
+			}},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/foo/go.mod"))
+	if !strings.Contains(got, "replace github.com/some/dep => github.com/forks/dep v1.2.3") {
+		t.Errorf("external replace should be preserved:\n%s", got)
+	}
+	// No sibling rewrite happened, no changes staged.
+	if len(repo.Staged) != 0 {
+		t.Errorf("nothing should be staged when no rewrite occurs; staged = %v", repo.Staged)
+	}
+}
+
+// TestRewriteSubmoduleGoMods_NoGoModSkipsSilently confirms a
+// release whose Path doesn't contain a go.mod (e.g. a pure-changelog
+// package) doesn't error out.
+func TestRewriteSubmoduleGoMods_NoGoModSkipsSilently(t *testing.T) {
+	dir := t.TempDir()
+
+	repo := git.NewFake()
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{{
+				Name:   "no-gomod",
+				Tag:    "no-gomod/v1.0.0",
+				To:     "v1.0.0",
+				Config: config.PackageConfig{TagPrefix: "no-gomod", Path: "no-gomod"},
+			}},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods on no-go.mod path should succeed: %v", err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+// Ensure changeset import is exercised so the linter is happy.
+var _ = changeset.Changeset{}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -367,8 +367,9 @@ func configFromPlan(p *plan.ReleasePlan) *config.Config {
 	return &config.Config{Packages: pkgs}
 }
 
-// applyStable writes CHANGELOG entries, deletes consumed changesets,
-// and stages everything. Caller does the commit.
+// applyStable writes CHANGELOG entries, rewrites go.mod files for
+// the released sub-modules, deletes consumed changesets, and stages
+// everything. Caller does the commit.
 func applyStable(opts Options, today string) error {
 	for _, r := range opts.Plan.Releases {
 		entry := buildEntry(r, today)
@@ -385,6 +386,13 @@ func applyStable(opts Options, today string) error {
 		if err := opts.Repo.Add(r.Config.Changelog); err != nil {
 			return fmt.Errorf("release: stage %s: %w", r.Config.Changelog, err)
 		}
+	}
+
+	// Strip dev-only sibling replaces and pin sibling require
+	// versions in each released package's go.mod, so the published
+	// modules are clean for downstream consumers.
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		return err
 	}
 
 	// Delete the consumed changesets. The planner's Consumed list


### PR DESCRIPTION
## Summary

Closes [#41](https://github.com/disaresta-org/monorel/issues/41). monorel's `apply` now rewrites each released sub-module's `go.mod` before staging the release commit:

1. **Drops dev-only `replace` directives** whose target is a sibling package in the same release plan AND whose source is a relative filesystem path. This is the `replace go.loglayer.dev/<sibling> => ../<sibling>` convention from monorel's monorepo template — local-checkout-only, never meaningful on the proxy.
2. **Pins sibling `require` lines** to the planned release version, replacing the placeholder pseudo-version (`v0.0.0-00010101000000-000000000000`) that sub-modules carry during development.

External (non-sibling) replaces are preserved. Modules with no sibling deps are unchanged. Packages without a go.mod under their `Path` (e.g. main module rooted at the repo root, pure-changelog packages) are skipped silently.

## Why

Without the rewrite, the dev-only state shipped to the module proxy and downstream consumers' `go mod tidy` returned 404 on the placeholder version. The loglayer-go v2 cascade was the trigger that surfaced this — every published v2.0.0 sub-module has the broken shape; consumers like [disaresta-org/monorel#39](https://github.com/disaresta-org/monorel/pull/39) couldn't tidy.

## Implementation notes

- Two-pass design: pass 1 reads each released package's go.mod, parses with `golang.org/x/mod/modfile`, builds a `{importPath -> plannedVersion}` map. Pass 2 rewrites each go.mod using that map.
- `modfile.AddRequire(path, version)` updates an existing require line for that path; `modfile.DropReplace(oldPath, oldVersion)` removes the directive. Format is preserved via `mf.Format()` after `mf.Cleanup()`.
- The version part of each tag is extracted via `strings.LastIndex(tag, "/v")` to handle both `<prefix>/vX.Y.Z` and bare `vX.Y.Z` tag shapes.
- Idempotent: a go.mod that doesn't need changes isn't touched and isn't staged.

## Recovery for already-broken published modules

The existing v2.0.0 tags are immutable on the proxy. Recovery path: re-release with this change, cutting `v2.0.1` (or higher) of every affected sub-module. monorel itself can do that once this lands by adding `:patch` changesets for each affected package.

## Test plan

- [x] `go test -count=1 ./...` passes.
- [x] New `TestRewriteSubmoduleGoMods_StripsDevReplacesAndPinsRequires` (synthetic two-sub-module repo; verifies replace dropped, require pinned, only modified go.mod staged).
- [x] New `TestRewriteSubmoduleGoMods_KeepsExternalReplaces` (third-party replace preserved; nothing staged when no rewrite occurs).
- [x] New `TestRewriteSubmoduleGoMods_NoGoModSkipsSilently` (package with no go.mod doesn't error).
- [ ] Smoke against loglayer-go: trigger a release plan that exercises the rewrite end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)