### PR TITLE
feat(apply): pin sibling requires for out-of-plan managed packages

### DIFF
--- a/.changeset/smarter-gomod-rewriter.md
+++ b/.changeset/smarter-gomod-rewriter.md
@@ -1,0 +1,11 @@
+---
+"monorel.disaresta.com": minor
+---
+
+The release-time `go.mod` rewriter now pins sibling requires for managed packages outside the current release plan, not just packages being released.
+
+Before: releasing a single sub-module that required another monorel-managed sibling would leave the sibling's require at whatever the dev `go.mod` specified (typically a placeholder pseudo-version), because the rewriter only built its sibling map from packages in the current plan. This forced contributors to include the root module in every recovery release just to seed the sibling map (see [loglayer/loglayer-go#70](https://github.com/loglayer/loglayer-go/pull/70)).
+
+After: the rewriter walks every package declared in `monorel.toml`. In-plan packages pin to their planned version; out-of-plan packages pin to their latest existing stable tag (resolved through `plan.LatestStableTagVersion`, newly exported). Out-of-plan siblings with no existing tag (or only pre-release tags) leave the require alone instead of failing the release.
+
+Closes #43.

--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -61,6 +61,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 
 	res, err := release.Apply(release.Options{
 		Plan:         p,
+		Config:       rt.Config,
 		Repo:         rt.Repo,
 		RepoDir:      rt.RepoDir,
 		ChangesetDir: rt.ChangesetDir,

--- a/internal/cli/release.go
+++ b/internal/cli/release.go
@@ -61,6 +61,7 @@ func runRelease(cmd *cobra.Command, _ []string) error {
 
 	res, err := release.ApplyAndTag(release.Options{
 		Plan:         p,
+		Config:       rt.Config,
 		Repo:         rt.Repo,
 		RepoDir:      rt.RepoDir,
 		ChangesetDir: rt.ChangesetDir,

--- a/internal/release/gomod.go
+++ b/internal/release/gomod.go
@@ -7,95 +7,75 @@ import (
 	"strings"
 
 	"golang.org/x/mod/modfile"
+
+	"monorel.disaresta.com/plan"
 )
 
 // rewriteSubmoduleGoMods walks the released packages and cleans each
 // one's go.mod for the published-tag state:
 //
-//  1. Drop replace directives whose target is a sibling package (one
-//     of the others in the same release plan) AND whose source is a
-//     relative filesystem path. These are dev-only "use the local
-//     checkout instead of the proxy" directives that should never
-//     ship to the module proxy. External (non-sibling) replaces are
-//     left intact.
-//  2. Rewrite require lines for sibling packages to the planned
-//     release version. Sub-modules hold each other's require version
-//     at a placeholder pseudo-version (e.g.
-//     v0.0.0-00010101000000-000000000000) during development;
-//     without the rewrite, the
-//     placeholder ships to the proxy and downstream consumers'
-//     `go mod tidy` returns 404 on the placeholder.
+//  1. Drop replace directives whose target is a managed sibling
+//     package AND whose source is a relative filesystem path. These
+//     are dev-only "use the local checkout instead of the proxy"
+//     directives that should never ship to the module proxy. External
+//     (non-sibling) replaces are left intact.
+//  2. Rewrite require lines for managed sibling packages to a real
+//     version. Sub-modules hold each other's require version at a
+//     placeholder pseudo-version (e.g.
+//     v0.0.0-00010101000000-000000000000) during development; without
+//     the rewrite, the placeholder ships to the proxy and downstream
+//     consumers' `go mod tidy` returns 404 on the placeholder.
+//
+// "Managed sibling" means any package declared in monorel.toml. The
+// version each sibling resolves to depends on whether it is part of
+// the current release plan:
+//
+//   - In-plan siblings pin to the planned release version (the
+//     version part of opts.Plan.Releases[i].Tag).
+//   - Out-of-plan siblings (declared in opts.Config but not being
+//     released right now) pin to their latest existing stable tag.
+//     This lets a single-package release fix its own go.mod without
+//     forcing the rest of the repo into the same release.
+//
+// Out-of-plan siblings with no existing tag (a freshly-registered
+// package about to ship its first release elsewhere) are silently
+// skipped: the rewriter has nothing to pin to, so the existing
+// require line stays put.
 //
 // Stages each modified file via opts.Repo.Add. Idempotent: a go.mod
 // that doesn't need changes isn't touched.
 //
-// Packages whose Path doesn't contain a go.mod (e.g. the main module
-// rooted at the repo root, or a pure-changelog package) are skipped.
+// Packages whose Path doesn't contain a go.mod (e.g. a pure-changelog
+// package) are skipped.
 //
 // Called from applyStable AFTER CHANGELOG writes and BEFORE the
 // consumed-changesets deletion so all the file changes land in the
 // same release commit.
 func rewriteSubmoduleGoMods(opts Options) error {
-	// First pass: read every released package's go.mod and build a
-	// map from import path (module directive) to planned release
-	// version. The planned version is the version part of the
-	// release tag (e.g. tag "transports/foo/v2.0.0" -> "v2.0.0").
-	// Packages without a go.mod (no sibling-deps to rewrite) get
-	// an empty entry, which is skipped on the rewrite pass.
-	type releasedPkg struct {
-		importPath string
-		version    string
-		modPath    string // absolute filesystem path
-		modFile    *modfile.File
-	}
-	pkgs := make([]releasedPkg, len(opts.Plan.Releases))
-	siblings := make(map[string]string, len(opts.Plan.Releases))
-	for i, r := range opts.Plan.Releases {
-		modPath := filepath.Join(opts.RepoDir, r.Config.Path, "go.mod")
-		data, err := os.ReadFile(modPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return fmt.Errorf("release: read %s: %w", modPath, err)
-		}
-		mf, err := modfile.Parse(modPath, data, nil)
-		if err != nil {
-			return fmt.Errorf("release: parse %s: %w", modPath, err)
-		}
-		if mf.Module == nil {
-			return fmt.Errorf("release: %s has no module directive", modPath)
-		}
-		// Extract the version part of the tag (strip the prefix).
-		// Tag shape: "<tag_prefix>/v<X.Y.Z>" or "v<X.Y.Z>" for the
-		// root module.
-		ver := r.Tag
-		if idx := strings.LastIndex(ver, "/v"); idx >= 0 {
-			ver = ver[idx+1:]
-		}
-		pkgs[i] = releasedPkg{
-			importPath: mf.Module.Mod.Path,
-			version:    ver,
-			modPath:    modPath,
-			modFile:    mf,
-		}
-		siblings[mf.Module.Mod.Path] = ver
+	siblings, err := buildSiblingMap(opts)
+	if err != nil {
+		return err
 	}
 
-	// Second pass: rewrite each released package's go.mod using the
-	// sibling map. Self-references are skipped explicitly so a
-	// package's own import path can't shadow a sibling rewrite.
-	for i, p := range pkgs {
-		if p.modFile == nil {
-			continue
+	// Walk released packages' go.mod files and rewrite each one
+	// using the combined sibling map. Self-references are skipped
+	// explicitly so a package's own import path can't shadow a
+	// sibling rewrite.
+	for _, r := range opts.Plan.Releases {
+		modPath := filepath.Join(opts.RepoDir, r.Config.Path, "go.mod")
+		mf, err := readModFile(modPath)
+		if err != nil {
+			return err
 		}
-		mf := p.modFile
+		if mf == nil {
+			continue // no go.mod (pure-changelog package)
+		}
+		ownPath := mf.Module.Mod.Path
 		changed := false
 
-		// Strip dev-only replace directives.
 		for _, rep := range mf.Replace {
-			if rep.Old.Path == p.importPath {
-				continue // self-replace; weird but leave alone
+			if rep.Old.Path == ownPath {
+				continue
 			}
 			if _, ok := siblings[rep.Old.Path]; !ok {
 				continue
@@ -104,25 +84,24 @@ func rewriteSubmoduleGoMods(opts Options) error {
 				continue
 			}
 			if err := mf.DropReplace(rep.Old.Path, rep.Old.Version); err != nil {
-				return fmt.Errorf("release: drop replace %s in %s: %w", rep.Old.Path, p.modPath, err)
+				return fmt.Errorf("release: drop replace %s in %s: %w", rep.Old.Path, modPath, err)
 			}
 			changed = true
 		}
 
-		// Pin sibling require versions.
 		for _, req := range mf.Require {
 			newVer, isSibling := siblings[req.Mod.Path]
-			if !isSibling {
+			if !isSibling || newVer == "" {
 				continue
 			}
-			if req.Mod.Path == p.importPath {
+			if req.Mod.Path == ownPath {
 				continue
 			}
 			if req.Mod.Version == newVer {
 				continue
 			}
 			if err := mf.AddRequire(req.Mod.Path, newVer); err != nil {
-				return fmt.Errorf("release: pin require %s in %s: %w", req.Mod.Path, p.modPath, err)
+				return fmt.Errorf("release: pin require %s in %s: %w", req.Mod.Path, modPath, err)
 			}
 			changed = true
 		}
@@ -134,17 +113,113 @@ func rewriteSubmoduleGoMods(opts Options) error {
 		mf.Cleanup()
 		out, err := mf.Format()
 		if err != nil {
-			return fmt.Errorf("release: format %s: %w", p.modPath, err)
+			return fmt.Errorf("release: format %s: %w", modPath, err)
 		}
-		if err := os.WriteFile(p.modPath, out, 0o644); err != nil {
-			return fmt.Errorf("release: write %s: %w", p.modPath, err)
+		if err := os.WriteFile(modPath, out, 0o644); err != nil {
+			return fmt.Errorf("release: write %s: %w", modPath, err)
 		}
-		rel := filepath.Join(opts.Plan.Releases[i].Config.Path, "go.mod")
+		rel := filepath.Join(r.Config.Path, "go.mod")
 		if err := opts.Repo.Add(rel); err != nil {
 			return fmt.Errorf("release: stage %s: %w", rel, err)
 		}
 	}
 	return nil
+}
+
+// buildSiblingMap constructs the import-path → version map the
+// rewriter consults. Every monorel-managed package contributes one
+// entry; in-plan packages map to their planned version, out-of-plan
+// packages map to their latest existing stable tag (or "" if none).
+//
+// Falls back to a plan-only map when opts.Config is nil — preserves
+// behavior for callers that haven't been updated to thread the
+// config through.
+func buildSiblingMap(opts Options) (map[string]string, error) {
+	planned := make(map[string]string, len(opts.Plan.Releases))
+	for _, r := range opts.Plan.Releases {
+		ver := r.Tag
+		if idx := strings.LastIndex(ver, "/v"); idx >= 0 {
+			ver = ver[idx+1:]
+		}
+		planned[r.Name] = ver
+	}
+
+	siblings := make(map[string]string)
+
+	// In-plan packages first.
+	for _, r := range opts.Plan.Releases {
+		modPath := filepath.Join(opts.RepoDir, r.Config.Path, "go.mod")
+		mf, err := readModFile(modPath)
+		if err != nil {
+			return nil, err
+		}
+		if mf == nil {
+			continue
+		}
+		siblings[mf.Module.Mod.Path] = planned[r.Name]
+	}
+
+	if opts.Config == nil {
+		return siblings, nil
+	}
+
+	// Out-of-plan managed packages: read their go.mod for the
+	// import path, look up their latest existing stable tag.
+	var allTags []string
+	var tagsLoaded bool
+	for name, pkg := range opts.Config.Packages {
+		if _, inPlan := planned[name]; inPlan {
+			continue
+		}
+		modPath := filepath.Join(opts.RepoDir, pkg.Path, "go.mod")
+		mf, err := readModFile(modPath)
+		if err != nil {
+			return nil, err
+		}
+		if mf == nil {
+			continue
+		}
+		if !tagsLoaded {
+			allTags, err = opts.Repo.ListTags("")
+			if err != nil {
+				return nil, fmt.Errorf("release: list tags for sibling lookup: %w", err)
+			}
+			tagsLoaded = true
+		}
+		ver, ok := plan.LatestStableTagVersion(allTags, pkg)
+		if !ok {
+			// No existing tag for this managed package; record
+			// the import path with an empty version so the
+			// rewriter recognizes it as a managed sibling
+			// (replace dropping still applies) but skips the
+			// require pinning.
+			siblings[mf.Module.Mod.Path] = ""
+			continue
+		}
+		siblings[mf.Module.Mod.Path] = ver
+	}
+	return siblings, nil
+}
+
+// readModFile reads and parses the go.mod at path. Returns (nil, nil)
+// if the file doesn't exist (the package has no go.mod, e.g. a
+// pure-changelog package).
+func readModFile(path string) (*modfile.File, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("release: read %s: %w", path, err)
+	}
+	mf, err := modfile.Parse(path, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("release: parse %s: %w", path, err)
+	}
+	if mf.Module == nil {
+		return nil, fmt.Errorf("release: %s has no module directive", path)
+	}
+	return mf, nil
 }
 
 // isRelativePath reports whether s names a filesystem path relative

--- a/internal/release/gomod.go
+++ b/internal/release/gomod.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/mod/modfile"
 
+	"monorel.disaresta.com/config"
 	"monorel.disaresta.com/plan"
 )
 
@@ -131,7 +132,7 @@ func rewriteSubmoduleGoMods(opts Options) error {
 // entry; in-plan packages map to their planned version, out-of-plan
 // packages map to their latest existing stable tag (or "" if none).
 //
-// Falls back to a plan-only map when opts.Config is nil — preserves
+// Falls back to a plan-only map when opts.Config is nil. Preserves
 // behavior for callers that haven't been updated to thread the
 // config through.
 func buildSiblingMap(opts Options) (map[string]string, error) {
@@ -163,10 +164,16 @@ func buildSiblingMap(opts Options) (map[string]string, error) {
 		return siblings, nil
 	}
 
-	// Out-of-plan managed packages: read their go.mod for the
-	// import path, look up their latest existing stable tag.
-	var allTags []string
-	var tagsLoaded bool
+	// Out-of-plan managed packages: load tags once, then walk every
+	// managed package not in the plan, read its go.mod for the
+	// import path, and look up its latest existing stable tag.
+	if !hasOutOfPlanPackages(opts.Config.Packages, planned) {
+		return siblings, nil
+	}
+	allTags, err := opts.Repo.ListTags("")
+	if err != nil {
+		return nil, fmt.Errorf("release: list tags for sibling lookup: %w", err)
+	}
 	for name, pkg := range opts.Config.Packages {
 		if _, inPlan := planned[name]; inPlan {
 			continue
@@ -178,13 +185,6 @@ func buildSiblingMap(opts Options) (map[string]string, error) {
 		}
 		if mf == nil {
 			continue
-		}
-		if !tagsLoaded {
-			allTags, err = opts.Repo.ListTags("")
-			if err != nil {
-				return nil, fmt.Errorf("release: list tags for sibling lookup: %w", err)
-			}
-			tagsLoaded = true
 		}
 		ver, ok := plan.LatestStableTagVersion(allTags, pkg)
 		if !ok {
@@ -203,7 +203,8 @@ func buildSiblingMap(opts Options) (map[string]string, error) {
 
 // readModFile reads and parses the go.mod at path. Returns (nil, nil)
 // if the file doesn't exist (the package has no go.mod, e.g. a
-// pure-changelog package).
+// pure-changelog package). On success the returned File is guaranteed
+// to have a non-nil Module directive (parse errors out otherwise).
 func readModFile(path string) (*modfile.File, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -220,6 +221,18 @@ func readModFile(path string) (*modfile.File, error) {
 		return nil, fmt.Errorf("release: %s has no module directive", path)
 	}
 	return mf, nil
+}
+
+// hasOutOfPlanPackages reports whether any package in pkgs is not
+// listed in planned. Used to skip the ListTags call when every
+// managed package is part of the current plan.
+func hasOutOfPlanPackages(pkgs map[string]config.PackageConfig, planned map[string]string) bool {
+	for name := range pkgs {
+		if _, inPlan := planned[name]; !inPlan {
+			return true
+		}
+	}
+	return false
 }
 
 // isRelativePath reports whether s names a filesystem path relative

--- a/internal/release/gomod.go
+++ b/internal/release/gomod.go
@@ -32,7 +32,8 @@ import (
 // the current release plan:
 //
 //   - In-plan siblings pin to the planned release version (the
-//     version part of opts.Plan.Releases[i].Tag).
+//     version part of each release's Tag, e.g. "v2.0.1" from
+//     "transports/foo/v2.0.1").
 //   - Out-of-plan siblings (declared in opts.Config but not being
 //     released right now) pin to their latest existing stable tag.
 //     This lets a single-package release fix its own go.mod without
@@ -127,7 +128,7 @@ func rewriteSubmoduleGoMods(opts Options) error {
 	return nil
 }
 
-// buildSiblingMap constructs the import-path → version map the
+// buildSiblingMap constructs the import-path-to-version map the
 // rewriter consults. Every monorel-managed package contributes one
 // entry; in-plan packages map to their planned version, out-of-plan
 // packages map to their latest existing stable tag (or "" if none).

--- a/internal/release/gomod_test.go
+++ b/internal/release/gomod_test.go
@@ -247,6 +247,179 @@ require example.com/transports/external/v2 v2.5.0
 	}
 }
 
+// TestRewriteSubmoduleGoMods_PinsOutOfPlanSiblingFromExistingTag
+// covers the headline win of the smarter rewriter: package A is
+// being released, package B (a managed sibling) is NOT in the
+// current plan, but B already has a tag at v1.2.0. A's go.mod
+// requires B at the placeholder pseudo-version. After the rewrite,
+// A's require pins to v1.2.0 (from B's existing tag) without B
+// needing to be in the release plan.
+func TestRewriteSubmoduleGoMods_PinsOutOfPlanSiblingFromExistingTag(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+
+replace example.com/transports/bar/v2 => ../bar
+
+require example.com/transports/bar/v2 v2.0.0-00010101000000-000000000000
+`)
+	mustWrite(t, filepath.Join(dir, "transports/bar/go.mod"), `module example.com/transports/bar/v2
+
+go 1.25.0
+`)
+
+	repo := git.NewFake("transports/bar/v1.2.0", "transports/foo/v2.0.0")
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"transports/foo": {TagPrefix: "transports/foo", Path: "transports/foo"},
+			"transports/bar": {TagPrefix: "transports/bar", Path: "transports/bar"},
+		},
+	}
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Config:  cfg,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{{
+				Name:   "transports/foo",
+				Tag:    "transports/foo/v2.0.1",
+				Bump:   semver.Patch,
+				From:   "v2.0.0",
+				To:     "v2.0.1",
+				Config: cfg.Packages["transports/foo"],
+			}},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/foo/go.mod"))
+	if strings.Contains(got, "replace example.com/transports/bar/v2") {
+		t.Errorf("dev replace for out-of-plan sibling should be stripped:\n%s", got)
+	}
+	if !strings.Contains(got, "example.com/transports/bar/v2 v1.2.0") {
+		t.Errorf("require should pin to existing-tag version v1.2.0:\n%s", got)
+	}
+	if strings.Contains(got, "v2.0.0-00010101000000-000000000000") {
+		t.Errorf("placeholder require version should be gone:\n%s", got)
+	}
+}
+
+// TestRewriteSubmoduleGoMods_OutOfPlanSiblingNoExistingTag verifies
+// that an out-of-plan managed sibling with no existing tag (e.g. a
+// freshly-registered package that hasn't shipped its first release)
+// doesn't fail the rewrite. The dev replace still gets dropped (the
+// package IS managed); the require simply stays at whatever the
+// go.mod already had, since there's no real version to pin to.
+func TestRewriteSubmoduleGoMods_OutOfPlanSiblingNoExistingTag(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+
+replace example.com/transports/bar/v2 => ../bar
+
+require example.com/transports/bar/v2 v2.0.0-00010101000000-000000000000
+`)
+	mustWrite(t, filepath.Join(dir, "transports/bar/go.mod"), `module example.com/transports/bar/v2
+
+go 1.25.0
+`)
+
+	repo := git.NewFake("transports/foo/v2.0.0") // no tag for bar
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"transports/foo": {TagPrefix: "transports/foo", Path: "transports/foo"},
+			"transports/bar": {TagPrefix: "transports/bar", Path: "transports/bar"},
+		},
+	}
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Config:  cfg,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{{
+				Name:   "transports/foo",
+				Tag:    "transports/foo/v2.0.1",
+				Bump:   semver.Patch,
+				From:   "v2.0.0",
+				To:     "v2.0.1",
+				Config: cfg.Packages["transports/foo"],
+			}},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/foo/go.mod"))
+	if strings.Contains(got, "replace example.com/transports/bar/v2") {
+		t.Errorf("dev replace for managed sibling should be stripped even when no tag exists:\n%s", got)
+	}
+	if !strings.Contains(got, "v2.0.0-00010101000000-000000000000") {
+		t.Errorf("placeholder require should be preserved when no real version is available:\n%s", got)
+	}
+}
+
+// TestRewriteSubmoduleGoMods_PreReleaseTagsIgnored verifies that an
+// out-of-plan sibling whose only existing tags are pre-releases
+// behaves the same as having no tag at all: the placeholder require
+// is preserved (the rewriter only pins to stable tags, since
+// pinning sub-modules to a pre-release of a sibling is rarely the
+// intended publish-time state).
+func TestRewriteSubmoduleGoMods_PreReleaseTagsIgnored(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+
+require example.com/transports/bar/v2 v2.0.0-00010101000000-000000000000
+`)
+	mustWrite(t, filepath.Join(dir, "transports/bar/go.mod"), `module example.com/transports/bar/v2
+
+go 1.25.0
+`)
+
+	repo := git.NewFake("transports/bar/v1.0.0-rc.1", "transports/bar/v1.0.0-rc.2")
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"transports/foo": {TagPrefix: "transports/foo", Path: "transports/foo"},
+			"transports/bar": {TagPrefix: "transports/bar", Path: "transports/bar"},
+		},
+	}
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Config:  cfg,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{{
+				Name:   "transports/foo",
+				Tag:    "transports/foo/v2.0.1",
+				Bump:   semver.Patch,
+				From:   "v2.0.0",
+				To:     "v2.0.1",
+				Config: cfg.Packages["transports/foo"],
+			}},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/foo/go.mod"))
+	if !strings.Contains(got, "v2.0.0-00010101000000-000000000000") {
+		t.Errorf("placeholder require should be preserved when only pre-release tags exist:\n%s", got)
+	}
+	if strings.Contains(got, "v1.0.0-rc") {
+		t.Errorf("pre-release tag should not be pinned as a sibling version:\n%s", got)
+	}
+}
+
 // TestRewriteSubmoduleGoMods_NoGoModSkipsSilently confirms a
 // release whose Path doesn't contain a go.mod (e.g. a pure-changelog
 // package) doesn't error out.

--- a/internal/release/gomod_test.go
+++ b/internal/release/gomod_test.go
@@ -420,6 +420,73 @@ go 1.25.0
 	}
 }
 
+// TestRewriteSubmoduleGoMods_ConfigMatchesPlanNoOutOfPlanWalk
+// covers the code path where opts.Config is set but every package
+// declared in it is also in the current plan. The
+// hasOutOfPlanPackages short-circuit should fire so ListTags isn't
+// consulted, and the rewrite should produce the same output as the
+// nil-Config case for the same plan.
+func TestRewriteSubmoduleGoMods_ConfigMatchesPlanNoOutOfPlanWalk(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+
+replace example.com/transports/bar/v2 => ../bar
+
+require example.com/transports/bar/v2 v2.0.0-00010101000000-000000000000
+`)
+	mustWrite(t, filepath.Join(dir, "transports/bar/go.mod"), `module example.com/transports/bar/v2
+
+go 1.25.0
+`)
+
+	repo := git.NewFake() // no tags seeded; should never be consulted
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"transports/foo": {TagPrefix: "transports/foo", Path: "transports/foo"},
+			"transports/bar": {TagPrefix: "transports/bar", Path: "transports/bar"},
+		},
+	}
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Config:  cfg,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{
+				{
+					Name:   "transports/foo",
+					Tag:    "transports/foo/v2.0.1",
+					Bump:   semver.Patch,
+					From:   "v2.0.0",
+					To:     "v2.0.1",
+					Config: cfg.Packages["transports/foo"],
+				},
+				{
+					Name:   "transports/bar",
+					Tag:    "transports/bar/v2.0.1",
+					Bump:   semver.Patch,
+					From:   "v2.0.0",
+					To:     "v2.0.1",
+					Config: cfg.Packages["transports/bar"],
+				},
+			},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/foo/go.mod"))
+	if strings.Contains(got, "replace") {
+		t.Errorf("dev replace should be stripped:\n%s", got)
+	}
+	if !strings.Contains(got, "example.com/transports/bar/v2 v2.0.1") {
+		t.Errorf("require should pin to planned v2.0.1:\n%s", got)
+	}
+}
+
 // TestRewriteSubmoduleGoMods_KeyedByImportPathNotPackageName
 // verifies that the sibling-pin lookup uses the go.mod's `module`
 // directive (the import path), not the monorel.toml package name.

--- a/internal/release/gomod_test.go
+++ b/internal/release/gomod_test.go
@@ -365,13 +365,13 @@ go 1.25.0
 	}
 }
 
-// TestRewriteSubmoduleGoMods_PreReleaseTagsIgnored verifies that an
-// out-of-plan sibling whose only existing tags are pre-releases
-// behaves the same as having no tag at all: the placeholder require
-// is preserved (the rewriter only pins to stable tags, since
-// pinning sub-modules to a pre-release of a sibling is rarely the
-// intended publish-time state).
-func TestRewriteSubmoduleGoMods_PreReleaseTagsIgnored(t *testing.T) {
+// TestRewriteSubmoduleGoMods_OutOfPlanSiblingPreReleaseTagsIgnored
+// verifies that an out-of-plan sibling whose only existing tags are
+// pre-releases behaves the same as having no tag at all: the
+// placeholder require is preserved (the rewriter only pins to
+// stable tags, since pinning sub-modules to a pre-release of a
+// sibling is rarely the intended publish-time state).
+func TestRewriteSubmoduleGoMods_OutOfPlanSiblingPreReleaseTagsIgnored(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
 
@@ -417,6 +417,61 @@ go 1.25.0
 	}
 	if strings.Contains(got, "v1.0.0-rc") {
 		t.Errorf("pre-release tag should not be pinned as a sibling version:\n%s", got)
+	}
+}
+
+// TestRewriteSubmoduleGoMods_KeyedByImportPathNotPackageName
+// verifies that the sibling-pin lookup uses the go.mod's `module`
+// directive (the import path), not the monorel.toml package name.
+// Two managed packages that share a similar package-name shape but
+// publish under different import paths must be distinguished by
+// their module directive.
+func TestRewriteSubmoduleGoMods_KeyedByImportPathNotPackageName(t *testing.T) {
+	dir := t.TempDir()
+	// foo (in plan) requires bar (out of plan) by import path.
+	// Note bar's go.mod publishes under example.com/transports/bar/v2
+	// while its monorel.toml package-name key is "transports/bar".
+	mustWrite(t, filepath.Join(dir, "transports/foo/go.mod"), `module example.com/transports/foo/v2
+
+go 1.25.0
+
+require example.com/transports/bar/v2 v2.0.0-00010101000000-000000000000
+`)
+	mustWrite(t, filepath.Join(dir, "transports/bar/go.mod"), `module example.com/transports/bar/v2
+
+go 1.25.0
+`)
+
+	repo := git.NewFake("transports/bar/v2.0.5")
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"transports/foo": {TagPrefix: "transports/foo", Path: "transports/foo"},
+			"transports/bar": {TagPrefix: "transports/bar", Path: "transports/bar"},
+		},
+	}
+	opts := Options{
+		Repo:    repo,
+		RepoDir: dir,
+		Config:  cfg,
+		Plan: &plan.ReleasePlan{
+			Releases: []plan.PackageRelease{{
+				Name:   "transports/foo",
+				Tag:    "transports/foo/v2.0.1",
+				Bump:   semver.Patch,
+				From:   "v2.0.0",
+				To:     "v2.0.1",
+				Config: cfg.Packages["transports/foo"],
+			}},
+		},
+	}
+
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		t.Fatalf("rewriteSubmoduleGoMods: %v", err)
+	}
+
+	got := mustRead(t, filepath.Join(dir, "transports/foo/go.mod"))
+	if !strings.Contains(got, "example.com/transports/bar/v2 v2.0.5") {
+		t.Errorf("require should pin to v2.0.5 (the bar import path's latest tag):\n%s", got)
 	}
 }
 

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -35,11 +35,20 @@ import (
 	"monorel.disaresta.com/plan"
 )
 
-// Options bundles the inputs to [Apply]. All fields except Today are
-// required.
+// Options bundles the inputs to [Apply]. All fields except Today and
+// Config are required; Config is required for the go.mod rewriter to
+// see managed packages outside the current release plan (without it,
+// out-of-plan sibling requires aren't pinned).
 type Options struct {
 	// Plan is the release plan to apply. Must be non-empty.
 	Plan *plan.ReleasePlan
+
+	// Config is the parsed monorel.toml. The go.mod rewriter walks
+	// every managed package's go.mod (not just those in Plan) so
+	// sibling requires for packages outside the current plan get
+	// pinned to their latest existing tag. Optional; if nil, only
+	// in-plan siblings get pinned.
+	Config *config.Config
 
 	// Repo is the git interface bound to RepoDir. Apply uses
 	// ListTags (conflict check), Add/Remove (staging), Commit, and

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -173,7 +173,7 @@ func Plan(cfg *config.Config, changesets []*changeset.Changeset, tags []string, 
 			}
 		}
 
-		from, fromOK := latestStableTagVersion(tags, pkgCfg)
+		from, fromOK := LatestStableTagVersion(tags, pkgCfg)
 		var stableTo string
 		var initial bool
 		if fromOK {
@@ -224,14 +224,14 @@ func Plan(cfg *config.Config, changesets []*changeset.Changeset, tags []string, 
 	return &ReleasePlan{Releases: releases, Consumed: consumed}, nil
 }
 
-// latestStableTagVersion finds the highest semver-valid, non-pre-release
+// LatestStableTagVersion finds the highest semver-valid, non-pre-release
 // tag for pkg's configured tag_prefix and returns its version part
 // (e.g. "v1.6.2"). The bool reports whether any qualifying tag existed.
 //
 // Tags that don't parse as semver are silently ignored; pre-release
 // tags are ignored at this layer (pre-release-mode handling lives in
 // a layer above the planner).
-func latestStableTagVersion(tags []string, pkg config.PackageConfig) (string, bool) {
+func LatestStableTagVersion(tags []string, pkg config.PackageConfig) (string, bool) {
 	prefix := pkg.FullTagPrefix()
 	var best string
 	for _, tag := range tags {


### PR DESCRIPTION
## Summary

The release-time `go.mod` rewriter now considers every monorel-managed package, not just packages in the current release plan. Out-of-plan siblings pin to their latest existing stable tag.

Closes #43.

## Why

#42 shipped a rewriter that strips dev-only `replace` directives and pins sibling requires. Its sibling map was built only from the current release plan, so a sub-module's require for a managed sibling that wasn't being released would still ship with the placeholder pseudo-version (`v0.0.0-00010101000000-000000000000`).

Concrete fallout: [loglayer/loglayer-go#70](https://github.com/loglayer/loglayer-go/pull/70) had to include the root `go.loglayer.dev` package in the recovery release plan even though the root itself didn't need a re-publish, just so its `v2.0.1` would land in the sibling map. With this change, future single-package releases pin requires correctly without forcing a cascade.

## What changes

- `plan.LatestStableTagVersion` is now exported (was `latestStableTagVersion`); the rewriter reuses it for the existing-tag lookup.
- `release.Options` gains an optional `Config *config.Config` field. Callers (`internal/cli/{apply,release}.go`) thread it through. Nil falls back to the original plan-only behavior — fully backward-compatible.
- `internal/release/gomod.go`: extracted `buildSiblingMap` and `readModFile` helpers. `buildSiblingMap` walks every managed package: in-plan packages map to their planned version, out-of-plan packages map to their latest existing stable tag (or empty if no qualifying tag, in which case the require is left alone but dev replaces still strip).

## Tests

Four new tests in `internal/release/gomod_test.go`:

- `PinsOutOfPlanSiblingFromExistingTag` — the headline win.
- `OutOfPlanSiblingNoExistingTag` — graceful fallback for freshly-registered managed packages.
- `OutOfPlanSiblingPreReleaseTagsIgnored` — pre-release-only siblings preserve the placeholder.
- `KeyedByImportPathNotPackageName` — locks in that the sibling-pin lookup keys on the go.mod's module directive, not the monorel.toml package-name key.

All existing tests pass unchanged (the `Config == nil` fallback preserves prior behavior).

## Test plan

- [ ] CI passes (`go test -race ./...`, `go vet ./...`, `staticcheck ./...`).
- [ ] After merge, a downstream sub-module-only release (no root in plan) successfully pins its `go.loglayer.dev/v2` require to the latest existing tag rather than the placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)