### PR TITLE
feat(changeset): add schemaVersion field to .changeset/pre.json

### DIFF
--- a/.changeset/prestate-schema-version.md
+++ b/.changeset/prestate-schema-version.md
@@ -1,0 +1,11 @@
+---
+"monorel.disaresta.com": minor
+---
+
+`.changeset/pre.json` now carries a `schemaVersion` field (currently `1`). Files written by older monorel builds omit the field and load as version 1, so existing pre-release windows are unaffected. A file whose `schemaVersion` is higher than the current build supports is rejected with a clear `"upgrade monorel"` error rather than being silently misread.
+
+The on-disk shape is otherwise unchanged. Library callers that construct `*changeset.PreState` directly don't need to set the field; `PreState.Write` stamps `schemaVersion: 1` automatically when the field is zero.
+
+Constants exposed: `changeset.PreStateCurrentSchemaVersion`. Bump it (and add a migration in `LoadPreState`) the next time the on-disk shape changes incompatibly.
+
+Pre-v1.0 housekeeping: future-proofs the pre-release-state file format ahead of the v1.0 stability commitment.

--- a/changeset/changeset_test.go
+++ b/changeset/changeset_test.go
@@ -403,6 +403,82 @@ func TestPreState_RejectsInvalid(t *testing.T) {
 	}
 }
 
+func TestPreState_LegacyFileWithoutSchemaVersionLoadsAsV1(t *testing.T) {
+	// pre.json files written by monorel before SchemaVersion existed
+	// have no `schemaVersion` field. They should load fine, with
+	// SchemaVersion treated as 1 (the original on-disk shape).
+	dir := t.TempDir()
+	path := filepath.Join(dir, PreStateFilename)
+	legacy := `{"mode":"pre","channel":"rc","counters":{"foo":2}}`
+	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadPreState(dir)
+	if err != nil {
+		t.Fatalf("LoadPreState on legacy file: %v", err)
+	}
+	if got.SchemaVersion != 1 {
+		t.Errorf("legacy file should load as SchemaVersion 1; got %d", got.SchemaVersion)
+	}
+	if got.Channel != "rc" || got.Counters["foo"] != 2 {
+		t.Errorf("legacy fields not preserved: %+v", got)
+	}
+}
+
+func TestPreState_RejectsFutureSchemaVersion(t *testing.T) {
+	// A pre.json written by a NEWER monorel (schemaVersion bumped
+	// past what this build understands) is rejected hard, so the
+	// stale binary can't silently misread the future format.
+	dir := t.TempDir()
+	path := filepath.Join(dir, PreStateFilename)
+	future := `{"schemaVersion":99,"mode":"pre","channel":"rc"}`
+	if err := os.WriteFile(path, []byte(future), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadPreState(dir)
+	if err == nil {
+		t.Fatal("expected error for future schemaVersion")
+	}
+	if !strings.Contains(err.Error(), "schemaVersion 99") {
+		t.Errorf("error should name the offending version; got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "upgrade monorel") {
+		t.Errorf("error should hint at the fix; got: %v", err)
+	}
+}
+
+func TestPreState_WriteStampsCurrentSchemaVersion(t *testing.T) {
+	// Calling Write on a PreState with SchemaVersion zero stamps
+	// the current version. Round-trips back through Load.
+	dir := t.TempDir()
+	original := &PreState{Mode: "pre", Channel: "rc"}
+	if err := original.Write(dir); err != nil {
+		t.Fatal(err)
+	}
+	if original.SchemaVersion != PreStateCurrentSchemaVersion {
+		t.Errorf("Write should stamp SchemaVersion; got %d, want %d",
+			original.SchemaVersion, PreStateCurrentSchemaVersion)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, PreStateFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"schemaVersion": 1`) {
+		t.Errorf("on-disk file should include schemaVersion field; got:\n%s", raw)
+	}
+
+	got, err := LoadPreState(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SchemaVersion != 1 {
+		t.Errorf("round-tripped SchemaVersion = %d, want 1", got.SchemaVersion)
+	}
+}
+
 func TestPreState_RemoveIdempotent(t *testing.T) {
 	dir := t.TempDir()
 	if err := RemovePreState(dir); err != nil {

--- a/changeset/prerelease.go
+++ b/changeset/prerelease.go
@@ -17,6 +17,14 @@ import (
 // file; the next stable release bumps from the last *stable* tag,
 // applying every changeset accumulated since.
 type PreState struct {
+	// SchemaVersion identifies the on-disk format. Currently 1.
+	// Older files written before this field existed deserialize as
+	// 0 and are treated as version 1 (backward-compatible). Newer
+	// versions (greater than [PreStateCurrentSchemaVersion]) are
+	// rejected with a clear error so a stale monorel binary can't
+	// silently misread a future format.
+	SchemaVersion int `json:"schemaVersion,omitempty"`
+
 	// Mode is always "pre" while the state file exists. Reserved
 	// for forward-compatibility with future modes (e.g. "exit"
 	// rendering the file inert without deleting it).
@@ -35,6 +43,11 @@ type PreState struct {
 // PreStateFilename is the basename of the on-disk state file.
 const PreStateFilename = "pre.json"
 
+// PreStateCurrentSchemaVersion is the version this build of monorel
+// writes to .changeset/pre.json. Bump (and add a migration in
+// LoadPreState) when the on-disk shape changes incompatibly.
+const PreStateCurrentSchemaVersion = 1
+
 // LoadPreState reads .changeset/pre.json. Returns (nil, nil) if the
 // file does not exist (the common, "not in pre-release mode" case).
 func LoadPreState(dir string) (*PreState, error) {
@@ -49,6 +62,18 @@ func LoadPreState(dir string) (*PreState, error) {
 	var s PreState
 	if err := json.Unmarshal(data, &s); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	// Schema-version gate. 0 means "written by a monorel before the
+	// field existed"; treat as version 1 (the original shape). A
+	// version higher than this build understands is a hard error
+	// because we can't safely interpret unknown fields or migrated
+	// semantics.
+	if s.SchemaVersion == 0 {
+		s.SchemaVersion = 1
+	}
+	if s.SchemaVersion > PreStateCurrentSchemaVersion {
+		return nil, fmt.Errorf("parse %s: schemaVersion %d is newer than this build supports (max %d); upgrade monorel",
+			path, s.SchemaVersion, PreStateCurrentSchemaVersion)
 	}
 	if s.Mode != "pre" {
 		return nil, fmt.Errorf("parse %s: unknown mode %q (expected \"pre\")", path, s.Mode)
@@ -68,6 +93,9 @@ func (s *PreState) Write(dir string) error {
 	}
 	if s.Counters == nil {
 		s.Counters = map[string]int{}
+	}
+	if s.SchemaVersion == 0 {
+		s.SchemaVersion = PreStateCurrentSchemaVersion
 	}
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {

--- a/docs/src/changesets.md
+++ b/docs/src/changesets.md
@@ -60,7 +60,7 @@ When multiple changesets target the same package, monorel uses the **strongest**
 
 ## Pre-release mode
 
-`monorel pre enter <channel>` writes `.changeset/pre.json` with the channel name and an empty per-package counter map. While pre-release mode is active:
+`monorel pre enter <channel>` writes `.changeset/pre.json` with the channel name, an empty per-package counter map, and a `schemaVersion` (currently `1`) so future on-disk format changes are detected rather than silently misread. While pre-release mode is active:
 
 - `monorel release` appends `-<channel>.N` to each released version (e.g. `v1.7.0-rc.0`).
 - `.changeset/*.md` files are NOT deleted between releases.

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -278,6 +278,17 @@ list, err := changeset.LoadAll(".changeset/")  // every *.md file in the dir
 
 name := changeset.RandomName()       // "<adj>-<noun>"
 ok := changeset.IsValidName("name")  // [a-z0-9]+(-[a-z0-9]+)*
+
+// Pre-release-mode state.
+pre, err := changeset.LoadPreState(".changeset/")  // nil if not in pre mode
+// pre.SchemaVersion (currently 1; missing-field files load as 1)
+// pre.Mode = "pre", pre.Channel = "rc", pre.Counters map[string]int
+pre.Write(".changeset/")    // stamps schemaVersion automatically
+changeset.RemovePreState(".changeset/")  // idempotent
+
+// Constants:
+// changeset.PreStateFilename             = "pre.json"
+// changeset.PreStateCurrentSchemaVersion = 1
 ```
 
 ### `monorel.disaresta.com/plan` (the load-bearing logic)

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -117,6 +117,7 @@ Reserved filenames in `.changeset/` (NOT changesets): `pre.json`, `README.md`, `
 
 ```json
 {
+  "schemaVersion": 1,
   "mode": "pre",
   "channel": "rc",
   "counters": {
@@ -125,6 +126,8 @@ Reserved filenames in `.changeset/` (NOT changesets): `pre.json`, `README.md`, `
   }
 }
 ```
+
+`schemaVersion` identifies the on-disk format. Files written by older monorel versions omit the field; they load as version 1 (backward-compatible). A file with `schemaVersion` higher than this monorel build supports is rejected with a clear error.
 
 Created by `monorel pre enter <channel>`; deleted by `monorel pre exit`. While the file exists:
 


### PR DESCRIPTION
## Summary

Pre-v1.0 housekeeping. Stamps a \`schemaVersion\` field on the pre-release-state file so future on-disk shape changes are detected explicitly rather than silently misread by stale binaries.

## Changes

- \`changeset.PreState\` gains a \`SchemaVersion int\` field (json \`schemaVersion,omitempty\`).
- New constant \`changeset.PreStateCurrentSchemaVersion = 1\`.
- \`PreState.Write\` stamps the current version when the field is zero. Library callers don't need to set it.
- \`LoadPreState\` treats a missing/zero field as version 1 (backward-compat for files written before this change). A file with a higher version is rejected with a clear \`"upgrade monorel"\` hint.

## Tests

Three new tests in \`changeset/changeset_test.go\`:

- \`TestPreState_LegacyFileWithoutSchemaVersionLoadsAsV1\`
- \`TestPreState_RejectsFutureSchemaVersion\`
- \`TestPreState_WriteStampsCurrentSchemaVersion\`

## Docs

- \`docs/src/changesets.md\`: notes the new field on the pre.json description.
- \`docs/src/public/llms-full.txt\`: the pre.json snippet now shows \`schemaVersion: 1\` at the top + a note about the version-gate semantics; the changeset package's library API block now lists the PreState helpers and the new constant.

## Library-API last-look (recommendation #2 from the v1.0 prep set)

Surveyed the 7 public packages (\`config\`, \`changeset\`, \`changelog\`, \`plan\`, \`semver\`, \`validate\`, \`doctor\`). All clean and v1.0-shippable as-is. Notable signals:

- \`config.KnownProviders\` is already documented as \"should not mutate\" (immutable-by-convention is fine).
- \`Severity\` types in \`validate\` and \`doctor\` are intentionally distinct so they can evolve independently.
- \`semver.BumpLevel\` is a clean iota-based enum with a stable \`String()\`.
- \`plan.PackageRelease\` field exposure is documented; struct mutation by callers is a standard Go pattern, no defensive copying needed.

No actionable changes from the last-look beyond the schemaVersion addition above.

## Test plan

- [ ] CI passes (build, lint, vet, staticcheck, race tests).
- [ ] Manually: write an old-style pre.json (no \`schemaVersion\` field), \`go run ./cmd/monorel plan\` succeeds. Write one with \`schemaVersion: 99\`, \`monorel plan\` fails with the upgrade hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)