### PR TITLE
refactor(cli): use loglayer.Multiline for init's completion report

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/spf13/cobra v1.10.2
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	go.loglayer.dev/plugins/fmtlog/v2 v2.0.1
-	go.loglayer.dev/transports/cli/v2 v2.1.1
-	go.loglayer.dev/v2 v2.0.1
+	go.loglayer.dev/transports/cli/v2 v2.2.0
+	go.loglayer.dev/v2 v2.1.0
 	golang.org/x/mod v0.35.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -118,12 +118,12 @@ gitlab.com/gitlab-org/api/client-go v1.46.0 h1:YxBWFZIFYKcGESCb9fpkwzouo+apyB9pr
 gitlab.com/gitlab-org/api/client-go v1.46.0/go.mod h1:FtgyU6g2HS5+fMhw6nLK96GBEEBx5MzntOiJWfIaiN8=
 go.loglayer.dev/plugins/fmtlog/v2 v2.0.1 h1:Lrj4ne53PihwNDuMJCwjVw+5hE4lpZbI64cOX5/ZA4Q=
 go.loglayer.dev/plugins/fmtlog/v2 v2.0.1/go.mod h1:X3e0Abx1+Sg/1E+YZx3dYHPgChUTQX6HOlOVq3OtQ0s=
-go.loglayer.dev/transports/cli/v2 v2.1.1 h1:aFJE1uA6xFMPVMa1s48dGAXd/xsmbv7eYcb5Rj1o74Q=
-go.loglayer.dev/transports/cli/v2 v2.1.1/go.mod h1:cuhl2sbZcg1trVBg9qeIpEruaDu/rMKzBUy0n38vb1g=
+go.loglayer.dev/transports/cli/v2 v2.2.0 h1:iTdx5DlSt/5gru1x2OFy6s5bmtEvkAoPfAMVaaZGytA=
+go.loglayer.dev/transports/cli/v2 v2.2.0/go.mod h1:CO/IML0g98TSzmK+Fmf83c9zaaAgLkRsbQuh9FBdRQY=
 go.loglayer.dev/transports/testing/v2 v2.0.1 h1:+xjONuRjjP2Z+CNa+wzfwoTCAn0VexRtd/d48DHCb/Q=
 go.loglayer.dev/transports/testing/v2 v2.0.1/go.mod h1:12kl35hwKAZctpUrkGiV67O2ZF41Drh21Rhad4lul6M=
-go.loglayer.dev/v2 v2.0.1 h1:B7oYpkfMky0UG/N8IdKeIiiTi6h7eyj5NvRyEth9DHI=
-go.loglayer.dev/v2 v2.0.1/go.mod h1:+BWhs5AyICvCLBz07qHnCE12W34tArUWfXOba0Ct/QI=
+go.loglayer.dev/v2 v2.1.0 h1:8/fq8Z1NNLtjfKgaPn6S0Hy7zWPnkjn9Gj3YgEDFk4w=
+go.loglayer.dev/v2 v2.1.0/go.mod h1:+BWhs5AyICvCLBz07qHnCE12W34tArUWfXOba0Ct/QI=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -167,14 +167,18 @@ func doInit(log *loglayer.LogLayer, opts initOptions) error {
 		// else: file present, leave it alone.
 	}
 
-	log.Info("Wrote monorel.toml with %d package(s):", len(pkgs))
+	lines := make([]any, 0, len(pkgs)+5)
+	lines = append(lines, fmt.Sprintf("Wrote monorel.toml with %d package(s):", len(pkgs)))
 	for _, p := range pkgs {
-		log.Info("  %s (path: %s, tag prefix: %q)", p.Name, p.Path, p.TagPrefix)
+		lines = append(lines, fmt.Sprintf("  %s (path: %s, tag prefix: %q)", p.Name, p.Path, p.TagPrefix))
 	}
-	log.Info("Created .changeset/ with a README.")
-	log.Info("Next steps:")
-	log.Info("  monorel validate     # confirm the config")
-	log.Info("  monorel add          # write your first changeset")
+	lines = append(lines,
+		"Created .changeset/ with a README.",
+		"Next steps:",
+		"  monorel validate     # confirm the config",
+		"  monorel add          # write your first changeset",
+	)
+	log.Info(loglayer.Multiline(lines...))
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Dogfoods [`loglayer.Multiline`](https://go.loglayer.dev/logging-api/multiline) (shipped in `go.loglayer.dev/v2 v2.1.0`) to render `monorel init`'s six-line completion report as a single log entry instead of six adjacent `log.Info` calls.

**Output bytes on stdout are unchanged.** `cli`'s `transport.AssembleMessage` joins the authored lines with `\n` and `Fprintln` adds the trailing `\n`, matching what six separate `log.Info` → `Fprintln` calls produced before. The semantic improvement is on the JSON-sink side: if a structured wrapper transport is wired up downstream, the entire init report becomes one entry with a multi-line `msg` field instead of six unrelated entries.

## fmtlog interaction

Lines are pre-formatted with `fmt.Sprintf` before being passed into `loglayer.Multiline`. This is required because the project's `fmtlog` plugin runs Sprintf on `(string, ...args)` call shapes, and a `*MultilineMessage` passed as a Sprintf arg collapses via `Stringer` (the trust signal is lost; the inner `\n` gets stripped by terminal-renderer sanitization). Documented at https://go.loglayer.dev/plugins/fmtlog#interaction-with-multiline.

Calling `Multiline(...)` as the sole positional arg keeps fmtlog's `len(messages) < 2` guard from firing, so the wrapper survives end-to-end through the dispatch path.

## Dep bumps

- `go.loglayer.dev/v2`: v2.0.1 → v2.1.0 (Multiline ships here)
- `go.loglayer.dev/transports/cli/v2`: v2.1.1 → v2.2.0 (cli's `AssembleMessage` Multiline branch ships here)

Both `:minor` bumps. v2.1.0 also fixes a pre-existing `transport.JoinPrefixAndMessages` bug where `WithPrefix` was silently dropped when `Messages[0]` wasn't a string; this codebase doesn't use `WithPrefix`, so the behavior change has zero blast radius here.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (33 packages, no regressions)
- [x] Manually verified `monorel init` output renders the six-line report identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)