### PR TITLE
feat: Bitbucket Cloud provider + universal PR-body trailers fallback

### DIFF
--- a/.changeset/bitbucket-provider.md
+++ b/.changeset/bitbucket-provider.md
@@ -1,0 +1,13 @@
+---
+"monorel.disaresta.com": minor
+---
+
+monorel now supports Bitbucket Cloud (`provider.name = "bitbucket"`) alongside GitHub, Gitea / Forgejo, and GitLab. The `internal/provider/bitbucket/` package implements the `provider.Client` interface against Bitbucket's REST API v2 (hand-rolled `net/http`; no new direct deps).
+
+Auth uses two environment variables: `BITBUCKET_EMAIL` (Atlassian account email) and `BITBUCKET_TOKEN` (Atlassian API token with Bitbucket scopes). The Bitbucket username for git over HTTPS is probed from `/2.0/user` and cached on the client.
+
+Bitbucket Cloud has no first-class Release concept, so `monorel publish` is a no-op on Bitbucket; per-package `CHANGELOG.md` is the canonical release-notes source.
+
+Plus a defensive recovery mechanism that benefits every provider: `monorel preview` now appends a `<!-- monorel-trailers ... -->` HTML comment to the PR body. `monorel tag` falls back to that block when the merge commit body lacks `monorel-Release:` trailers (e.g. because of a squash-merge that rewrote the body). The fallback uses the new `provider.Client.FindPRByMergeCommit` method, implemented by every provider.
+
+See [Bitbucket integration](/integrations/bitbucket).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 A changesets-style release tool for multi-module Go monorepos.
 
-`monorel` manages per-package versions, tags, and CHANGELOG entries in a Go monorepo using explicit `.changeset/*.md` files instead of inferring releases from commit messages. Pair it with CI on your provider (GitHub, Gitea / Forgejo, or GitLab) to drive an always-open release PR whose diff IS the actual file changes the next release will produce.
+`monorel` manages per-package versions, tags, and CHANGELOG entries in a Go monorepo using explicit `.changeset/*.md` files instead of inferring releases from commit messages. Pair it with CI on your provider (GitHub, Gitea / Forgejo, GitLab, or Bitbucket Cloud) to drive an always-open release PR whose diff IS the actual file changes the next release will produce.
 
 ## Why monorel?
 
@@ -47,7 +47,7 @@ git commit && gh pr create
 #    always-open release PR. Merge it when ready to ship.
 ```
 
-Reference setups for each provider live in [`examples/`](examples/) (GitHub, Gitea / Forgejo, GitLab). Copy the files you need; the [Getting Started](https://monorel.disaresta.com/getting-started) walkthrough explains the full lifecycle.
+Reference setups for each provider live in [`examples/`](examples/) (GitHub, Gitea / Forgejo, GitLab, Bitbucket). Copy the files you need; the [Getting Started](https://monorel.disaresta.com/getting-started) walkthrough explains the full lifecycle.
 
 ## Documentation
 
@@ -58,7 +58,7 @@ Reference setups for each provider live in [`examples/`](examples/) (GitHub, Git
 - [Configuration](https://monorel.disaresta.com/configuration): `monorel.toml` reference.
 - [CLI](https://monorel.disaresta.com/cli-reference): every command and flag.
 - [Changesets](https://monorel.disaresta.com/changesets): file format and authoring conventions.
-- Integration guides: [GitHub](https://monorel.disaresta.com/integrations/github), [Gitea / Forgejo](https://monorel.disaresta.com/integrations/gitea), [GitLab](https://monorel.disaresta.com/integrations/gitlab).
+- Integration guides: [GitHub](https://monorel.disaresta.com/integrations/github), [Gitea / Forgejo](https://monorel.disaresta.com/integrations/gitea), [GitLab](https://monorel.disaresta.com/integrations/gitlab), [Bitbucket](https://monorel.disaresta.com/integrations/bitbucket).
 - [FAQ](https://monorel.disaresta.com/faq): the questions that come up after the first release.
 - [Use with AI / LLMs](https://monorel.disaresta.com/llms): paste-ready `llms.txt` and `llms-full.txt` for coding assistants.
 - [Glossary](https://monorel.disaresta.com/glossary): canonical definitions of monorel terminology.
@@ -66,13 +66,14 @@ Reference setups for each provider live in [`examples/`](examples/) (GitHub, Git
 
 ## CI integration
 
-monorel ships a composite GitHub Action wrapper plus first-class support for Gitea / Forgejo and GitLab CI. Each provider has a working reference setup under [`examples/`](examples/):
+monorel ships a composite GitHub Action wrapper plus first-class support for Gitea / Forgejo, GitLab CI, and Bitbucket Pipelines. Each provider has a working reference setup under [`examples/`](examples/):
 
 | Provider | Example | Notes |
 |---|---|---|
 | GitHub | [`examples/github/`](examples/github/) | Composite action wrapper + two workflow files. |
 | Gitea / Forgejo | [`examples/gitea/`](examples/gitea/) | Same wrapper on Gitea Actions; `provider.host` set; covers Forgejo via API compatibility. |
 | GitLab | [`examples/gitlab/`](examples/gitlab/) | Single `.gitlab-ci.yml` using `ghcr.io/disaresta-org/monorel`. Project must use fast-forward merge. |
+| Bitbucket Cloud | [`examples/bitbucket/`](examples/bitbucket/) | Single `bitbucket-pipelines.yml` using `ghcr.io/disaresta-org/monorel`. Cloud-only; needs the [workspace plan acceptance](https://monorel.disaresta.com/integrations/bitbucket#workspace-plan-acceptance) step. |
 
 The GitHub flow looks like this:
 

--- a/config/provider.go
+++ b/config/provider.go
@@ -5,9 +5,10 @@ package config
 // new provider: append to KnownProviders and wire up a provider
 // implementation under internal/provider/<name>/.
 const (
-	ProviderGitHub = "github"
-	ProviderGitea  = "gitea"
-	ProviderGitLab = "gitlab"
+	ProviderGitHub    = "github"
+	ProviderGitea     = "gitea"
+	ProviderGitLab    = "gitlab"
+	ProviderBitbucket = "bitbucket"
 )
 
 // DefaultProvider is the value [ResolveProvider] returns for an
@@ -19,6 +20,7 @@ const DefaultProvider = ProviderGitHub
 // in alphabetical order. The slice is shared and read-only; callers
 // should not mutate it.
 var KnownProviders = []string{
+	ProviderBitbucket,
 	ProviderGitea,
 	ProviderGitHub,
 	ProviderGitLab,

--- a/config/provider_test.go
+++ b/config/provider_test.go
@@ -2,17 +2,25 @@ package config
 
 import "testing"
 
-func TestProviderBitbucket_IsKnown(t *testing.T) {
-	if !IsKnownProvider(ProviderBitbucket) {
-		t.Error("ProviderBitbucket should be recognized")
+func TestKnownProviders(t *testing.T) {
+	for _, p := range []string{ProviderBitbucket, ProviderGitea, ProviderGitHub, ProviderGitLab} {
+		t.Run(p, func(t *testing.T) {
+			if !IsKnownProvider(p) {
+				t.Errorf("%q should be a known provider", p)
+			}
+			// Also assert it appears in the slice directly (defends
+			// against an IsKnownProvider regression that decouples
+			// the predicate from the canonical list).
+			found := false
+			for _, k := range KnownProviders {
+				if k == p {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%q missing from KnownProviders slice", p)
+			}
+		})
 	}
-}
-
-func TestKnownProviders_IncludesBitbucket(t *testing.T) {
-	for _, p := range KnownProviders {
-		if p == ProviderBitbucket {
-			return
-		}
-	}
-	t.Error("KnownProviders should include ProviderBitbucket")
 }

--- a/config/provider_test.go
+++ b/config/provider_test.go
@@ -1,0 +1,18 @@
+package config
+
+import "testing"
+
+func TestProviderBitbucket_IsKnown(t *testing.T) {
+	if !IsKnownProvider(ProviderBitbucket) {
+		t.Error("ProviderBitbucket should be recognized")
+	}
+}
+
+func TestKnownProviders_IncludesBitbucket(t *testing.T) {
+	for _, p := range KnownProviders {
+		if p == ProviderBitbucket {
+			return
+		}
+	}
+	t.Error("KnownProviders should include ProviderBitbucket")
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -124,6 +124,7 @@ gtag('config', '${gaMeasurementId}');`,
       {
         text: 'Integrations',
         items: [
+          { text: 'Bitbucket', link: '/integrations/bitbucket' },
           { text: 'GitHub', link: '/integrations/github' },
           { text: 'Gitea / Forgejo', link: '/integrations/gitea' },
           { text: 'GitLab', link: '/integrations/gitlab' },

--- a/docs/src/_partials/bitbucket-pipelines-yml.md
+++ b/docs/src/_partials/bitbucket-pipelines-yml.md
@@ -1,0 +1,28 @@
+```yaml
+# bitbucket-pipelines.yml
+image: ghcr.io/disaresta-org/monorel:0.13.0
+
+pipelines:
+  branches:
+    main:
+      - step:
+          name: monorel
+          script:
+            - export GIT_AUTHOR_NAME="monorel-bot[automation]"
+            - export GIT_AUTHOR_EMAIL="monorel-bot@users.noreply.example.com"
+            - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+            - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+            - if echo "$BITBUCKET_COMMIT_MESSAGE" | grep -q "^chore(release):"; then
+                monorel tag &&
+                git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
+                monorel publish;
+              else
+                git fetch origin "$BITBUCKET_BRANCH" &&
+                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH" &&
+                apply_out=$(monorel apply); echo "$apply_out";
+                if ! echo "$apply_out" | grep -qF "Nothing to apply."; then
+                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release &&
+                  monorel preview --upsert;
+                fi;
+              fi
+```

--- a/docs/src/_partials/bitbucket-pipelines-yml.md
+++ b/docs/src/_partials/bitbucket-pipelines-yml.md
@@ -12,17 +12,25 @@ pipelines:
             - export GIT_AUTHOR_EMAIL="monorel-bot@users.noreply.example.com"
             - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
             - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
-            - if echo "$BITBUCKET_COMMIT_MESSAGE" | grep -q "^chore(release):"; then
+            # Detect release-merge commits by scanning the FULL commit
+            # message (subject + body) for the chore(release): trailer
+            # marker. Bitbucket's merge strategies replace the source
+            # subject with `Merged in <branch> (pull request #N)`, so a
+            # subject-only check would never match. Both squash and
+            # merge_commit preserve the source subject as a body line.
+            - HEAD_MSG=$(git log -1 --format=%B)
+            - if echo "$HEAD_MSG" | grep -qE '(^|\n)chore\(release\):'; then
                 monorel tag &&
                 git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
                 monorel publish;
               else
                 git fetch origin "$BITBUCKET_BRANCH" &&
-                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH" &&
+                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH";
                 apply_out=$(monorel apply); echo "$apply_out";
                 if ! echo "$apply_out" | grep -qF "Nothing to apply."; then
-                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release &&
-                  monorel preview --upsert;
+                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release;
                 fi;
+                git checkout "$BITBUCKET_BRANCH" &&
+                monorel preview --upsert;
               fi
 ```

--- a/docs/src/_partials/bitbucket-pipelines-yml.md
+++ b/docs/src/_partials/bitbucket-pipelines-yml.md
@@ -1,6 +1,6 @@
 ```yaml
 # bitbucket-pipelines.yml
-image: ghcr.io/disaresta-org/monorel:0.13.0
+image: ghcr.io/disaresta-org/monorel:0.14.0
 
 pipelines:
   branches:

--- a/docs/src/cheat-sheet.md
+++ b/docs/src/cheat-sheet.md
@@ -90,5 +90,6 @@ monorel pre exit            # the following release is stable
 | `GITHUB_TOKEN` / `GH_TOKEN` | `preview`, `publish` | Auth for the GitHub provider. |
 | `GITEA_TOKEN` | `preview`, `publish` | Auth for the Gitea / Forgejo provider. |
 | `GITLAB_TOKEN` | `preview`, `publish` | Auth for the GitLab provider. |
+| `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN` | `preview`, `publish` | Auth for the Bitbucket Cloud provider. Email is the Atlassian-account email; token is an API token with Bitbucket scopes. |
 | `VISUAL` / `EDITOR` | `monorel add --editor` | Editor to launch for the body. Falls back to `vi` / `nano` (Unix) or `notepad` (Windows). |
 | `GOMODCACHE`, `GOCACHE` | `monorel apply` | Inherited by the offline `go mod tidy` invocation; pre-populated by your normal dev / `go test ./...` runs. |

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -145,7 +145,7 @@ No. The planner reads tags from git history to determine the current version per
 
 ### Does monorel require GitHub?
 
-No. As of v0.7, `provider.name` accepts `"github"`, `"gitea"`, and `"gitlab"`. The Gitea implementation also covers Forgejo via API compatibility (set `host` to your Forgejo instance). Bitbucket isn't implemented yet but the provider seam is ready; the path is documented in `internal/provider/factory/factory.go`.
+No. `provider.name` accepts `"github"`, `"gitea"`, `"gitlab"`, and `"bitbucket"` (Bitbucket Cloud added in v0.14). The Gitea implementation also covers Forgejo via API compatibility (set `host` to your Forgejo instance). The provider seam is documented in `internal/provider/factory/factory.go` for users who need a different forge.
 
 ### Can monorel coordinate releases across multiple repos?
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -106,7 +106,11 @@ Re-run it. `CreateRelease` is idempotent on the tag name: each tag the prior run
 
 ### A release PR merged without `monorel-Release:` body trailers, and `monorel tag` returned `ErrNoReleaseCommit`. What now?
 
-The merge stripped the trailer block. Most likely cause: a squash-merge setting that drops the commit body (see [Branch protection](/integrations/github#branch-protection)). Recovery: manually create the tags pointing at the merge commit:
+The merge stripped the trailer block. Most likely cause: a squash-merge setting that drops the commit body (see [Branch protection](/integrations/github#branch-protection)).
+
+**First, the universal trailers fallback usually recovers automatically.** Since v0.13, `monorel preview` writes a `<!-- monorel-trailers ... -->` HTML comment into the PR body whenever it opens or updates the always-open release PR. When `monorel tag` finds no `monorel-Release:` trailers on HEAD, it walks back to the merged PR via the provider's `FindPRByMergeCommit` lookup and parses trailers from that comment block. So even a force-applied squash-merge that rewrote the body still completes the release. Fixing the squash-merge setting is still recommended (one fewer round-trip, one fewer failure mode), but not urgent.
+
+The fallback fails only when **both** the commit body AND the PR body's comment block are absent. The latter happens when a contributor edited the PR body and removed the comment block before merge, or when an older `monorel preview` (pre-v0.13) wrote the body without the comment. In that case, hand-create the tags pointing at the merge commit:
 
 ```sh
 git tag -a <prefix>/v<X.Y.Z> <merge-sha> -m "Release <prefix> v<X.Y.Z>"

--- a/docs/src/integrations/bitbucket.md
+++ b/docs/src/integrations/bitbucket.md
@@ -1,0 +1,161 @@
+---
+title: Bitbucket
+description: "Wire up monorel against a Bitbucket Cloud repository: configuration, two-env-var auth, workspace plan acceptance, Bitbucket Pipelines workflow."
+---
+
+# Bitbucket
+
+monorel's Bitbucket provider talks to [Bitbucket Cloud](https://bitbucket.org) via the standard Bitbucket REST API v2. The implementation is hand-rolled against `net/http` (no SDK), so the provider has no extra direct dependencies and works on any platform Go does.
+
+::: info Available in v0.13+
+The Bitbucket provider landed in monorel v0.13.0. Earlier versions support `github`, `gitea`, and `gitlab` only.
+:::
+
+::: warning Bitbucket Cloud only
+Only Bitbucket Cloud (`bitbucket.org`) is supported. Bitbucket Data Center / Server (the self-hosted product) uses a different REST surface and is not covered. The package layout is namespace-ready for a future `bitbucket/datacenter/` sibling, but that work is not on the roadmap.
+:::
+
+::: tip Example
+Working reference setup at [`examples/bitbucket/`](https://github.com/disaresta-org/monorel/tree/main/examples/bitbucket). Copy the files you need.
+:::
+
+## Configuration
+
+`monorel.toml`:
+
+```toml
+[provider]
+name  = "bitbucket"
+owner = "your-workspace"   # bitbucket workspace slug
+repo  = "your-repo"
+```
+
+| Field | Notes |
+|-------|-------|
+| `name` | Must be `"bitbucket"`. The default (`"github"`) won't work against Bitbucket. |
+| `owner` | The Bitbucket workspace slug. The provider treats `owner` as the workspace and joins it with `repo` to form the `{workspace}/{repo_slug}` path the REST API expects. |
+| `repo` | The repository slug (the URL component, not the display name). |
+| `host` | Not used. Bitbucket Cloud is the only host. The package layout is namespace-ready for a future Data Center variant; today the field is ignored. |
+
+Run `monorel validate` to confirm the config loads cleanly.
+
+## Auth: two environment variables
+
+Bitbucket Cloud no longer accepts username + app-password as a long-term auth scheme; the supported path is an Atlassian API token bound to your Atlassian account. monorel reads two env vars:
+
+| Env var | Meaning |
+|---------|---------|
+| `BITBUCKET_EMAIL` | The email address on the Atlassian account that owns the token. Used as the username on the Basic-auth pair. |
+| `BITBUCKET_TOKEN` | The Atlassian API token string itself. |
+
+Both must be set; missing either fails the constructor with a clear error.
+
+### Creating an API token with Bitbucket scopes
+
+1. Go to [`id.atlassian.com/manage-profile/security/api-tokens`](https://id.atlassian.com/manage-profile/security/api-tokens) (the Atlassian-account API tokens page; works for any user with a Bitbucket workspace).
+2. Click **Create API token with scopes**. The plain "Create API token" button generates a token without Bitbucket scopes; that token will return HTTP 401 against every Bitbucket REST call. The scoped flow is the one you want.
+3. Pick **Bitbucket** as the app, then select the workspace.
+4. Grant at minimum:
+   - `read:repository:bitbucket` and `write:repository:bitbucket` (for tag creation and metadata reads)
+   - `read:pullrequest:bitbucket` and `write:pullrequest:bitbucket` (for the always-open release PR)
+   - `read:account` (so monorel can probe the username on `/2.0/user`; see below)
+5. Copy the token and store it as a secret in your CI provider (`BITBUCKET_TOKEN`). The token is shown once.
+
+::: warning Tokens without Bitbucket scopes return HTTP 401
+The "Create API token" button (no scopes) at `id.atlassian.com` produces a token that the rest of Atlassian Cloud accepts but Bitbucket rejects. If your first push or `monorel preview --upsert` returns `401 Unauthorized` despite the token being non-empty, regenerate the token via "Create API token with scopes" and pick the Bitbucket app explicitly.
+:::
+
+### Username probing
+
+Bitbucket's git-over-HTTPS push expects the workspace's Bitbucket username, not the email on the API token. monorel probes `GET /2.0/user` once at constructor time with the email + token, reads the `username` field, and caches it on the client. You don't supply a username; it's resolved automatically from the token's identity.
+
+This is why the API token MUST have `read:account`: without it, the probe fails and the provider can't construct.
+
+## Workspace plan acceptance
+
+Bitbucket Cloud workspaces created (or upgraded) since the September 2024 plan migration require an explicit workspace-plan acceptance step before push, MR, and release-tag operations succeed. The symptom is HTTP 402 (`Payment Required`) on the first push from CI, even on free-tier workspaces, even when billing is current.
+
+Resolution: a workspace admin visits `https://bitbucket.org/<workspace>/workspace/settings/plans` and clicks the plan-acceptance button (the page presents it the first time the workspace is loaded after migration). It's a one-time action per workspace and unrelated to billing.
+
+If you see `402 Payment Required` from a `monorel preview --upsert` or `monorel tag` step, hit that URL first and re-run the workflow. monorel surfaces the upstream HTTP status verbatim so the error is easy to recognize.
+
+## Workflows
+
+monorel doesn't ship a Bitbucket-specific CI wrapper. The simplest setup uses Bitbucket Pipelines with the published Docker image (`ghcr.io/disaresta-org/monorel`). One pipeline that branches on whether the just-landed commit is a `chore(release):` merge: non-release commits run `monorel apply` + `monorel preview --upsert`; release commits run `monorel tag` + `git push --follow-tags` + `monorel publish`.
+
+`bitbucket-pipelines.yml`:
+
+<!--@include: ../_partials/bitbucket-pipelines-yml.md-->
+
+Setup:
+
+1. **Add `BITBUCKET_TOKEN` and `BB_USER` as repository secrets** under Repository settings → Repository variables. `BITBUCKET_TOKEN` is the Atlassian API token; `BB_USER` is the Bitbucket username (the same one monorel probes from `/2.0/user`; you can copy it from your Bitbucket profile URL). The pipeline uses both to authenticate the git push over HTTPS.
+2. **Pick a merge strategy that preserves the release commit body.** Fast-forward and merge-commit both work; squash-merge rewrites the body but the universal trailers fallback recovers (see below). Configure under Repository settings → Branch restrictions / Merge strategies.
+3. **Push the `bitbucket-pipelines.yml` to the default branch.** The pipeline fires on every push to `main`; it runs `monorel apply` + `monorel preview --upsert` and opens the always-open release PR once you have a `.changeset/<name>.md`.
+
+::: info Token revocation
+To revoke or rotate, return to `id.atlassian.com/manage-profile/security/api-tokens` and delete the token. Update `BITBUCKET_TOKEN` in the repo's pipeline variables and re-run.
+:::
+
+### Local CLI (no CI)
+
+Same shape as the [Working without CI](/getting-started#working-without-ci) section of Getting Started, with the two Bitbucket env vars:
+
+```sh
+BITBUCKET_EMAIL=... BITBUCKET_TOKEN=... monorel release
+git push --follow-tags
+BITBUCKET_EMAIL=... BITBUCKET_TOKEN=... monorel publish
+```
+
+`monorel publish` is effectively a no-op on Bitbucket (see below); the command exits cleanly without making any API calls. The release commit and tags still land via `monorel release` + `git push --follow-tags`.
+
+### External CI
+
+monorel is a single static binary. Any CI that can run a shell command can run it. Pattern is the same as the local flow: download the binary (or use the Docker image), set `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN`, run `monorel release` + `git push --follow-tags` + `monorel publish`.
+
+## Merge strategy: any of the three works
+
+The release PR's commit body carries `monorel-Release:` trailers that `monorel tag` reads post-merge. Three Bitbucket merge strategies are available:
+
+- **Fast-forward**: preserves the head commit verbatim. Trailers reach `main` unchanged. Recommended.
+- **Merge commit**: creates a merge commit with the head commit as a parent. `monorel tag` reads the parent's body trailers. Works.
+- **Squash merge**: rewrites the body, dropping the trailers from the merge commit. The universal trailers fallback recovers: monorel walks back to the merged PR (via `FindPRByMergeCommit`) and reads the trailers from a `<!-- monorel-trailers ... -->` HTML comment that `monorel preview` writes into the PR body. The release still completes.
+
+Squash merge is supported but not preferred; the fallback adds an extra round-trip to the API and a small risk that a contributor edited the PR body and removed the comment block. Pick fast-forward or merge-commit when you have the choice.
+
+## No native releases: CHANGELOG.md is canonical
+
+Bitbucket Cloud has no first-class "Release" concept analogous to GitHub Releases or GitLab Releases (a tag-attached object with a body, assets, and a pre-release flag). The closest equivalent is the tag itself plus the per-package `CHANGELOG.md` entry that `monorel apply` writes alongside.
+
+Consequence: `monorel publish` does nothing on Bitbucket. It's safe to run (the command exits successfully without making any API calls), but the canonical record of what changed in each release is the `CHANGELOG.md` entry. The pipeline above includes `monorel publish` for symmetry with the other providers; you can omit it without loss.
+
+If you need release notes shown in a UI, link the per-package CHANGELOG file from the repo's README or your project's docs site.
+
+## Branch protection
+
+Bitbucket calls these "branch restrictions." Two points:
+
+- **`monorel/release` should NOT have a `Prevent rewriting branch history` restriction.** The pipeline force-pushes to that branch on every release-pr run. Either don't add a restriction covering `monorel/release`, or exempt the bot user / token.
+- **The default branch's merge strategy should preserve the trailers** (fast-forward or merge-commit; see above). Squash-merge works via the fallback but adds a network hop and one failure mode (edited PR body).
+
+## Troubleshooting
+
+### `provider: unknown provider "bitbucket"`
+
+monorel binary is older than v0.13.0 (when the Bitbucket provider landed). Upgrade with `go install monorel.disaresta.com/cmd/monorel@latest` or use a newer Docker image tag.
+
+### `bitbucket: probe username: 401 Unauthorized`
+
+The API token doesn't have Bitbucket scopes (or doesn't have `read:account`). Regenerate via the **Create API token with scopes** flow at `id.atlassian.com/manage-profile/security/api-tokens` and grant the scopes listed under [Auth](#auth-two-environment-variables).
+
+### `bitbucket: ...: 402 Payment Required`
+
+The workspace plan hasn't been accepted yet. Visit `https://bitbucket.org/<workspace>/workspace/settings/plans` as a workspace admin and click through the plan-acceptance prompt. See [Workspace plan acceptance](#workspace-plan-acceptance).
+
+### `bitbucket: ...: 403 Forbidden`
+
+The token's scopes are insufficient for the operation. The most common gap is `write:pullrequest:bitbucket` (needed to open / update the always-open release PR). Regenerate the token with all scopes listed under [Auth](#auth-two-environment-variables).
+
+### `monorel tag` returns `ErrNoReleaseCommit` despite the merge happening
+
+HEAD's commit body has no `monorel-Release:` trailers AND the merged PR's body has no `<!-- monorel-trailers ... -->` comment block (so the universal fallback also missed). The fallback fails when both sources are gone, which typically means a contributor manually edited the release-PR body and removed the comment block before merge. Recovery: hand-create the tags pointing at the merge commit, push, then re-run. See the [tag-recovery FAQ](/faq#a-release-pr-merged-without-monorel-release-body-trailers-and-monorel-tag-returned-errnoreleasecommit-what-now) for the exact commands.

--- a/docs/src/integrations/bitbucket.md
+++ b/docs/src/integrations/bitbucket.md
@@ -7,8 +7,8 @@ description: "Wire up monorel against a Bitbucket Cloud repository: configuratio
 
 monorel's Bitbucket provider talks to [Bitbucket Cloud](https://bitbucket.org) via the standard Bitbucket REST API v2. The implementation is hand-rolled against `net/http` (no SDK), so the provider has no extra direct dependencies and works on any platform Go does.
 
-::: info Available in v0.13+
-The Bitbucket provider landed in monorel v0.13.0. Earlier versions support `github`, `gitea`, and `gitlab` only.
+::: info Available in v0.14+
+The Bitbucket provider landed in monorel v0.14.0. Earlier versions support `github`, `gitea`, and `gitlab` only.
 :::
 
 ::: warning Bitbucket Cloud only
@@ -129,6 +129,10 @@ Bitbucket Cloud has no first-class "Release" concept analogous to GitHub Release
 
 Consequence: `monorel publish` does nothing on Bitbucket. It's safe to run (the command exits successfully without making any API calls), but the canonical record of what changed in each release is the `CHANGELOG.md` entry. The pipeline above includes `monorel publish` for symmetry with the other providers; you can omit it without loss.
 
+::: warning `monorel publish` still requires the auth env vars
+The publish command constructs the provider client before noticing it has nothing to do, so `BITBUCKET_EMAIL` and `BITBUCKET_TOKEN` must still be set in the environment when it runs. Constructor validation (including the `/2.0/user` username probe) fires before the no-op check; missing or invalid credentials surface as a constructor error, not a clean exit.
+:::
+
 If you need release notes shown in a UI, link the per-package CHANGELOG file from the repo's README or your project's docs site.
 
 ## Branch protection
@@ -142,7 +146,7 @@ Bitbucket calls these "branch restrictions." Two points:
 
 ### `provider: unknown provider "bitbucket"`
 
-monorel binary is older than v0.13.0 (when the Bitbucket provider landed). Upgrade with `go install monorel.disaresta.com/cmd/monorel@latest` or use a newer Docker image tag.
+monorel binary is older than v0.14.0 (when the Bitbucket provider landed). Upgrade with `go install monorel.disaresta.com/cmd/monorel@latest` or use a newer Docker image tag.
 
 ### `bitbucket: probe username: 401 Unauthorized`
 

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -486,25 +486,39 @@ GitLab requires the project's merge method set to **Fast-forward** (Settings →
 Bitbucket Cloud-only (`bitbucket.org`); Bitbucket Data Center / Server is not supported. Use the Docker image. One pipeline that branches on whether the just-landed commit is a `chore(release):` merge:
 
 ```yaml
-image: ghcr.io/disaresta-org/monorel:0.13.0
+# bitbucket-pipelines.yml
+image: ghcr.io/disaresta-org/monorel:0.14.0
 
 pipelines:
   branches:
     main:
       - step:
+          name: monorel
           script:
-            - if echo "$BITBUCKET_COMMIT_MESSAGE" | grep -q "^chore(release):"; then
+            - export GIT_AUTHOR_NAME="monorel-bot[automation]"
+            - export GIT_AUTHOR_EMAIL="monorel-bot@users.noreply.example.com"
+            - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+            - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+            # Detect release-merge commits by scanning the FULL commit
+            # message (subject + body) for the chore(release): trailer
+            # marker. Bitbucket's merge strategies replace the source
+            # subject with `Merged in <branch> (pull request #N)`, so a
+            # subject-only check would never match. Both squash and
+            # merge_commit preserve the source subject as a body line.
+            - HEAD_MSG=$(git log -1 --format=%B)
+            - if echo "$HEAD_MSG" | grep -qE '(^|\n)chore\(release\):'; then
                 monorel tag &&
                 git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
                 monorel publish;
               else
                 git fetch origin "$BITBUCKET_BRANCH" &&
-                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH" &&
+                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH";
                 apply_out=$(monorel apply); echo "$apply_out";
                 if ! echo "$apply_out" | grep -qF "Nothing to apply."; then
-                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release &&
-                  monorel preview --upsert;
+                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release;
                 fi;
+                git checkout "$BITBUCKET_BRANCH" &&
+                monorel preview --upsert;
               fi
 ```
 

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -57,7 +57,7 @@ The configuration file at the repo root. Top-level provider info plus one `[pack
 # Layout: bare vX.Y.Z tags for the root, <path>/vX.Y.Z for sub-modules.
 
 [provider]
-name  = "github"             # one of "github" / "gitea" / "gitlab"
+name  = "github"             # one of "github" / "gitea" / "gitlab" / "bitbucket"
 owner = "acme"
 repo  = "widget"
 host  = ""                   # set for self-hosted Gitea / Forgejo / GitLab Enterprise
@@ -79,7 +79,7 @@ Field reference:
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `provider.name` | string | yes | `github` / `gitea` / `gitlab`. |
+| `provider.name` | string | yes | `github` / `gitea` / `gitlab` / `bitbucket`. |
 | `provider.owner` | string | yes | Repository owner (org or user). |
 | `provider.repo` | string | yes | Repository name (no `.git` suffix). |
 | `provider.host` | string | no | For self-hosted instances; defaults to the provider's public host. |
@@ -481,6 +481,40 @@ release:
 
 GitLab requires the project's merge method set to **Fast-forward** (Settings → Merge requests) so the `monorel-Release:` body trailers reach `main` post-merge.
 
+### Bitbucket Pipelines
+
+Bitbucket Cloud-only (`bitbucket.org`); Bitbucket Data Center / Server is not supported. Use the Docker image. One pipeline that branches on whether the just-landed commit is a `chore(release):` merge:
+
+```yaml
+image: ghcr.io/disaresta-org/monorel:0.13.0
+
+pipelines:
+  branches:
+    main:
+      - step:
+          script:
+            - if echo "$BITBUCKET_COMMIT_MESSAGE" | grep -q "^chore(release):"; then
+                monorel tag &&
+                git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
+                monorel publish;
+              else
+                git fetch origin "$BITBUCKET_BRANCH" &&
+                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH" &&
+                apply_out=$(monorel apply); echo "$apply_out";
+                if ! echo "$apply_out" | grep -qF "Nothing to apply."; then
+                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release &&
+                  monorel preview --upsert;
+                fi;
+              fi
+```
+
+Bitbucket-specific notes:
+
+- Auth uses two env vars (`BITBUCKET_EMAIL` + `BITBUCKET_TOKEN`); both must be set for the provider to construct. The provider probes `GET /2.0/user` once at construction and caches the Bitbucket username; `read:account` is required for that probe.
+- A one-time **workspace plan acceptance** at `bitbucket.org/<workspace>/workspace/settings/plans` is required before any push or REST call succeeds; the symptom is HTTP 402 Payment Required even on free-tier workspaces.
+- Bitbucket Cloud has no first-class Release concept, so `monorel publish` is a no-op (exits cleanly without making API calls). Per-package `CHANGELOG.md` is the canonical release-notes source.
+- All three Bitbucket merge strategies work: fast-forward and merge-commit preserve the `monorel-Release:` body trailers; squash-merge rewrites the body but the universal trailers fallback (a `<!-- monorel-trailers ... -->` comment that `monorel preview` writes into the PR body, retrieved post-merge via `FindPRByMergeCommit`) recovers.
+
 ### Composite-action commands
 
 The `disaresta-org/monorel/ci/github` action wraps the multi-step sequences into single inputs:
@@ -499,6 +533,7 @@ The `disaresta-org/monorel/ci/github` action wraps the multi-step sequences into
 | GitHub (with branch protection) | Personal Access Token or App token | PRs created by the auto token don't trigger required-status-check workflows (anti-recursion). | Same scopes. |
 | Gitea / Forgejo | `GITEA_TOKEN` | PAT generated at `/-/user/settings/applications`. | `repository: write`, `user: read`. |
 | GitLab | `GITLAB_TOKEN` | Personal or project access token. | `api`. |
+| Bitbucket Cloud | `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN` | Atlassian API token created via "Create API token with scopes" at `id.atlassian.com/manage-profile/security/api-tokens`. The plain "Create API token" button produces a token without Bitbucket scopes (returns 401). | `read:repository:bitbucket`, `write:repository:bitbucket`, `read:pullrequest:bitbucket`, `write:pullrequest:bitbucket`, `read:account` (for the username probe). |
 
 The `doctor` command needs no token; `contents: read` alone is sufficient.
 
@@ -600,7 +635,7 @@ If a release commit produced bad state (wrong version, missing go.sum tidy, etc.
 - `monorel.disaresta.com/workflows`: ASCII diagrams of the lifecycles.
 - `monorel.disaresta.com/changesets`: changeset file format reference.
 - `monorel.disaresta.com/configuration`: `monorel.toml` field reference.
-- `monorel.disaresta.com/integrations/{github,gitea,gitlab}`: per-provider setup.
+- `monorel.disaresta.com/integrations/{github,gitea,gitlab,bitbucket}`: per-provider setup.
 - `monorel.disaresta.com/api`: library API reference.
 - `monorel.disaresta.com/design`: design principles + tradeoffs.
 - `monorel.disaresta.com/docker`: running monorel via container.

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -39,7 +39,7 @@ Top-level provider info plus one `[packages."<name>"]` block per managed module.
 
 ```toml
 [provider]
-name  = "github"             # or "gitea" / "gitlab"
+name  = "github"             # or "gitea" / "gitlab" / "bitbucket"
 owner = "acme"
 repo  = "widget"
 # host = "git.example.com"   # for self-hosted Gitea / Forgejo / GitLab
@@ -188,6 +188,7 @@ release:
 | GitHub | `GITHUB_TOKEN` or `GH_TOKEN` | Default `secrets.GITHUB_TOKEN` works; PAT or App token needed if branch protection requires status checks. |
 | Gitea / Forgejo | `GITEA_TOKEN` | PAT with `repository: write` + `user: read`. |
 | GitLab | `GITLAB_TOKEN` | PAT or project access token with `api` scope. |
+| Bitbucket Cloud | `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN` | API token with `read/write:repository:bitbucket` + `read/write:pullrequest:bitbucket` scopes. |
 
 ## Documentation
 
@@ -198,7 +199,7 @@ release:
 - `monorel.disaresta.com/workflows`: ASCII diagrams of the lifecycles.
 - `monorel.disaresta.com/changesets`: changeset file format reference.
 - `monorel.disaresta.com/configuration`: `monorel.toml` field reference.
-- `monorel.disaresta.com/integrations/{github,gitea,gitlab}`: per-provider setup.
+- `monorel.disaresta.com/integrations/{github,gitea,gitlab,bitbucket}`: per-provider setup.
 - `monorel.disaresta.com/api`: library API reference.
 - `monorel.disaresta.com/design`: design principles + tradeoffs.
 - `monorel.disaresta.com/faq`: frequently asked questions.

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -188,7 +188,7 @@ release:
 | GitHub | `GITHUB_TOKEN` or `GH_TOKEN` | Default `secrets.GITHUB_TOKEN` works; PAT or App token needed if branch protection requires status checks. |
 | Gitea / Forgejo | `GITEA_TOKEN` | PAT with `repository: write` + `user: read`. |
 | GitLab | `GITLAB_TOKEN` | PAT or project access token with `api` scope. |
-| Bitbucket Cloud | `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN` | API token with `read/write:repository:bitbucket` + `read/write:pullrequest:bitbucket` scopes. |
+| Bitbucket Cloud | `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN` | API token with `read/write:repository:bitbucket` + `read/write:pullrequest:bitbucket` + `read:account` scopes. |
 
 ## Documentation
 

--- a/docs/superpowers/plans/2026-05-03-bitbucket-provider.md
+++ b/docs/superpowers/plans/2026-05-03-bitbucket-provider.md
@@ -1,0 +1,2607 @@
+# Bitbucket Cloud Provider + Universal PR-Body Trailers Fallback
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `bitbucket` provider implementation for Bitbucket Cloud, plus a defensive PR-body trailers fallback that lets `monorel tag` recover when the merge commit body is rewritten (e.g. by squash-merge).
+
+**Architecture:** New hand-rolled HTTP package at `internal/provider/bitbucket/` mirroring the gitlab package's shape (no SDK; ~7 endpoints over `net/http`). The provider interface gains `FindPRByMergeCommit(sha)` implemented by every provider; `monorel preview` writes a `<!-- monorel-trailers ... -->` HTML comment into the PR body; `monorel tag` falls back to fetching the merged PR's body when HEAD's commit message has no trailers.
+
+**Tech Stack:** Go 1.26.x, `net/http`, `encoding/json`, existing project deps (no new direct deps). Bitbucket Cloud REST API v2 at `api.bitbucket.org/2.0/`. HTTP Basic auth (email + API token) for REST; `<username>:<token>` for git over HTTPS (username probed from `/2.0/user` and cached on the client).
+
+**Spec:** `docs/superpowers/specs/2026-05-03-bitbucket-provider-design.md`
+
+**Branch:** `feat/bitbucket-provider` (already exists; spec doc is already committed there as the first commit).
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `internal/provider/provider.go` | modify | Add `FindPRByMergeCommit` to `Client` interface; add `EmailEnvVars`; extend `TokenEnvVars` for bitbucket |
+| `internal/provider/fake.go` | modify | Add `FindPRByMergeCommit` to `Fake` (in-memory implementation) |
+| `internal/provider/github/github.go` | modify | Implement `FindPRByMergeCommit` |
+| `internal/provider/gitlab/gitlab.go` | modify | Implement `FindPRByMergeCommit` |
+| `internal/provider/gitea/gitea.go` | modify | Implement `FindPRByMergeCommit` |
+| `internal/provider/factory/factory.go` | modify | Add `case ProviderBitbucket` arm |
+| `config/provider.go` | modify | Add `ProviderBitbucket` constant; append to `KnownProviders` |
+| `internal/provider/bitbucket/doc.go` | create | Package overview |
+| `internal/provider/bitbucket/bitbucket.go` | create | `Options` + `New()` constructor |
+| `internal/provider/bitbucket/client.go` | create | `*client` type, HTTP transport, auth header, JSON helpers |
+| `internal/provider/bitbucket/errors.go` | create | `ErrPlanGate`, `ErrRateLimited` sentinels + status-code mapper |
+| `internal/provider/bitbucket/identity.go` | create | `/2.0/user` probe with `sync.Once` |
+| `internal/provider/bitbucket/repo.go` | create | `GetDefaultBranch` |
+| `internal/provider/bitbucket/pulls.go` | create | `FindOpenReleasePR`, `CreatePR`, `UpdatePR`, `ClosePR` |
+| `internal/provider/bitbucket/release.go` | create | `CreateRelease` (no-op + log line) |
+| `internal/provider/bitbucket/trailers.go` | create | `FindPRByMergeCommit` |
+| `internal/provider/bitbucket/bitbucket_test.go` | create | Unit tests against `httptest.NewServer` |
+| `internal/provider/bitbucket/integration_test.go` | create | `//go:build integration`; full-API walk |
+| `internal/provider/github/github_test.go` | modify | Add `FindPRByMergeCommit` test |
+| `internal/provider/gitlab/gitlab_test.go` | modify | Add `FindPRByMergeCommit` test |
+| `internal/provider/gitea/gitea_test.go` | modify | Add `FindPRByMergeCommit` test |
+| `internal/release/render.go` | modify | Append `<!-- monorel-trailers ... -->` block to PR body |
+| `internal/release/release.go` | modify | Add `Provider` field to `TagOptions`; fall back to PR-body lookup on `ErrNoReleaseCommit` |
+| `internal/release/release_test.go` | modify | Add fallback-success and fallback-no-PR tests |
+| `internal/release/render_test.go` | modify | Add trailers-comment-block test |
+| `internal/cli/tag.go` | modify | Pass `Provider` from runtime into `TagOptions` |
+| `docs/src/integrations/bitbucket.md` | create | Setup walkthrough |
+| `docs/src/_partials/bitbucket-pipelines-yml.md` | create | Pipelines snippet partial |
+| `examples/bitbucket/monorel.toml` | create | Reference config |
+| `examples/bitbucket/bitbucket-pipelines.yml` | create | Reference CI |
+| `examples/bitbucket/.changeset/README.md` | create | Mirror of other examples' README |
+| `docs/.vitepress/config.ts` | modify | Add Bitbucket sidebar entry |
+| `docs/src/cheat-sheet.md` | modify | Extend env-vars table |
+| `docs/src/public/llms.txt` | modify | Add bitbucket entries |
+| `docs/src/public/llms-full.txt` | modify | Add bitbucket entries |
+| `docs/src/faq.md` | modify | Amend tag-recovery FAQ to mention trailers fallback |
+| `README.md` | modify | List Bitbucket alongside other providers |
+| `.changeset/bitbucket-provider.md` | create | `:minor` bump |
+
+---
+
+## Phase 1: Provider Interface Extension
+
+The new `FindPRByMergeCommit(ctx, sha)` method ships on the `Client` interface. Every existing provider gets an implementation before bitbucket lands. This phase lays groundwork; the trailers fallback feature uses it later.
+
+### Task 1: Add `FindPRByMergeCommit` to Client interface
+
+**Files:**
+- Modify: `internal/provider/provider.go`
+
+- [ ] **Step 1: Modify the Client interface**
+
+In `internal/provider/provider.go`, add the new method below `CreateRelease`:
+
+```go
+	CreateRelease(ctx context.Context, opts CreateReleaseOptions) (*Release, error)
+
+	// FindPRByMergeCommit returns the PR/MR that was merged into the
+	// repo at the given commit SHA, if one exists. Returns (nil, nil)
+	// when no PR matches (NOT an error) — the caller treats that as
+	// "no fallback available."
+	//
+	// Used by the universal PR-body trailers fallback: monorel tag
+	// reads its release-trailer set from HEAD's commit message
+	// normally, but falls back to fetching the merged PR's body
+	// (looking for a `<!-- monorel-trailers ... -->` block) when the
+	// commit body is empty (typically because of a squash-merge).
+	FindPRByMergeCommit(ctx context.Context, sha string) (*PullRequest, error)
+}
+```
+
+- [ ] **Step 2: Verify it compiles (will fail to compile because Fake + each provider lack the method)**
+
+Run: `cd /home/theo/projects/monorel && go build ./...`
+Expected: errors like `*Fake does not implement Client (missing method FindPRByMergeCommit)`. That's the next task's job.
+
+- [ ] **Step 3: Don't commit yet**
+
+We commit after the Fake + every provider implements the method (Tasks 2-5). One commit lands the interface change atomically across implementations.
+
+### Task 2: Add `FindPRByMergeCommit` to the Fake
+
+**Files:**
+- Modify: `internal/provider/fake.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/provider/fake_test.go` (create if it doesn't exist; check first):
+
+```go
+func TestFake_FindPRByMergeCommit(t *testing.T) {
+	f := NewFake()
+	// Pre-seed a "merged" PR at a known SHA. The fake doesn't model
+	// merging directly; we set MergedSHA on the PR.
+	pr, err := f.CreatePR(context.Background(), CreatePROptions{
+		Title:      "release",
+		Body:       "body",
+		HeadBranch: "monorel/release",
+		BaseBranch: "main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.PRs[pr.Number].MergedSHA = "abc123"
+
+	got, err := f.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got == nil || got.Number != pr.Number {
+		t.Errorf("got %v, want PR #%d", got, pr.Number)
+	}
+
+	miss, err := f.FindPRByMergeCommit(context.Background(), "nosuchsha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if miss != nil {
+		t.Errorf("expected nil for unknown SHA; got %v", miss)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test — verify it fails to compile**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/ 2>&1 | head -10`
+Expected: build failure, e.g. `pr.MergedSHA undefined` or `f.FindPRByMergeCommit undefined`.
+
+- [ ] **Step 3: Add `MergedSHA` field to `PullRequest`**
+
+In `internal/provider/provider.go`, the existing `PullRequest` struct:
+
+```go
+type PullRequest struct {
+	Number  int
+	State   string // "open" or "closed"
+	Title   string
+	Body    string
+	HeadRef string
+	HTMLURL string
+
+	// MergedSHA is the merge-commit SHA when this PR was merged (state
+	// transitioned through "merged"). Empty for unmerged PRs. Used by
+	// FindPRByMergeCommit's reverse lookup.
+	MergedSHA string
+}
+```
+
+- [ ] **Step 4: Implement `FindPRByMergeCommit` on Fake**
+
+In `internal/provider/fake.go`, add at the end (after `CreateRelease`):
+
+```go
+// FindPRByMergeCommit implements [Client.FindPRByMergeCommit].
+func (f *Fake) FindPRByMergeCommit(_ context.Context, sha string) (*PullRequest, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return nil, err
+	}
+	for _, pr := range f.PRs {
+		if pr.MergedSHA == sha {
+			cp := *pr
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+```
+
+- [ ] **Step 5: Run the Fake test — verify it passes**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/ -run TestFake_FindPRByMergeCommit -v`
+Expected: PASS.
+
+- [ ] **Step 6: Don't commit yet**
+
+Continue to Task 3 (real provider implementations); commit Phase 1 atomically after each provider lands its method.
+
+### Task 3: Implement `FindPRByMergeCommit` for GitHub
+
+**Files:**
+- Modify: `internal/provider/github/github.go`
+- Modify: `internal/provider/github/github_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/provider/github/github_test.go`. First check existing httptest patterns in the file (look at how `TestFindOpenReleasePR` or similar is structured) and follow that shape.
+
+```go
+func TestFindPRByMergeCommit(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/widget/commits/abc123/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[{
+			"number": 42,
+			"state": "closed",
+			"title": "release",
+			"body": "release body",
+			"head": {"ref": "monorel/release"},
+			"merge_commit_sha": "abc123",
+			"merged_at": "2026-05-03T00:00:00Z",
+			"html_url": "https://github.com/acme/widget/pull/42"
+		}]`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL) // helper used elsewhere in the file
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected PR; got nil")
+	}
+	if got.Number != 42 || got.MergedSHA != "abc123" {
+		t.Errorf("got %+v, want #42 with MergedSHA=abc123", got)
+	}
+}
+```
+
+If `newTestClient` helper doesn't exist with the signature above, mirror whatever pattern this file already uses to instantiate the github provider against a fake host. Don't invent a new helper if one exists; do reuse it.
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/github/ -run TestFindPRByMergeCommit -v`
+Expected: FAIL — `c.FindPRByMergeCommit undefined`.
+
+- [ ] **Step 3: Implement**
+
+In `internal/provider/github/github.go`, add the method on `*client` (find where the other Client methods live and append):
+
+```go
+func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
+	prs, _, err := c.gh.PullRequests.ListPullRequestsWithCommit(ctx, c.owner, c.repo, sha, &gh.ListOptions{PerPage: 50})
+	if err != nil {
+		return nil, fmt.Errorf("github: list PRs for commit %s: %w", sha, err)
+	}
+	for _, pr := range prs {
+		if pr.GetMergeCommitSHA() == sha {
+			return githubToPR(pr), nil
+		}
+	}
+	return nil, nil
+}
+```
+
+The existing `githubToPR` helper presumably converts `*github.PullRequest` to `*provider.PullRequest`. If it doesn't carry `MergedSHA`, update it:
+
+```go
+func githubToPR(pr *gh.PullRequest) *provider.PullRequest {
+	out := &provider.PullRequest{
+		Number:  pr.GetNumber(),
+		State:   pr.GetState(),
+		Title:   pr.GetTitle(),
+		Body:    pr.GetBody(),
+		HeadRef: pr.GetHead().GetRef(),
+		HTMLURL: pr.GetHTMLURL(),
+		MergedSHA: pr.GetMergeCommitSHA(),
+	}
+	// Existing helper mapping returned state from "open"/"closed" stays.
+	return out
+}
+```
+
+- [ ] **Step 4: Run — pass**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/github/ -run TestFindPRByMergeCommit -v`
+Expected: PASS.
+
+- [ ] **Step 5: Don't commit yet**
+
+### Task 4: Implement `FindPRByMergeCommit` for GitLab
+
+**Files:**
+- Modify: `internal/provider/gitlab/gitlab.go`
+- Modify: `internal/provider/gitlab/gitlab_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/provider/gitlab/gitlab_test.go`. GitLab's API is `GET /projects/:id/repository/commits/:sha/merge_requests`. Mirror the existing test patterns in the file.
+
+```go
+func TestFindPRByMergeCommit_GitLab(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v4/projects/team%2Fwidget/repository/commits/abc123/merge_requests" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[{
+			"iid": 42,
+			"state": "merged",
+			"title": "release",
+			"description": "release body",
+			"source_branch": "monorel/release",
+			"merge_commit_sha": "abc123",
+			"web_url": "https://gitlab.com/team/widget/-/merge_requests/42"
+		}]`)
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), Options{Owner: "team", Repo: "widget", Host: srv.URL, Token: "tok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got == nil || got.Number != 42 || got.MergedSHA != "abc123" {
+		t.Errorf("got %+v, want MR #42 with MergedSHA=abc123", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/gitlab/ -run TestFindPRByMergeCommit_GitLab -v`
+Expected: FAIL with `c.FindPRByMergeCommit undefined`.
+
+- [ ] **Step 3: Implement**
+
+Add to `internal/provider/gitlab/gitlab.go`. The go-gitlab client exposes `Commits.ListMergeRequestsByCommit`:
+
+```go
+func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
+	mrs, _, err := c.gl.Commits.ListMergeRequestsByCommit(c.pid, sha, gl.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("gitlab: list MRs for commit %s: %w", sha, err)
+	}
+	for _, mr := range mrs {
+		// MergeCommitSHA is the field name on go-gitlab's BasicMergeRequest.
+		if mr.MergeCommitSHA == sha {
+			return basicMRToPR(mr), nil
+		}
+	}
+	return nil, nil
+}
+```
+
+Update the existing `basicMRToPR` helper (or whichever conversion helper this file uses) to populate `MergedSHA: mr.MergeCommitSHA`.
+
+- [ ] **Step 4: Run — pass**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/gitlab/ -run TestFindPRByMergeCommit_GitLab -v`
+Expected: PASS.
+
+- [ ] **Step 5: Don't commit yet**
+
+### Task 5: Implement `FindPRByMergeCommit` for Gitea
+
+**Files:**
+- Modify: `internal/provider/gitea/gitea.go`
+- Modify: `internal/provider/gitea/gitea_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/provider/gitea/gitea_test.go`. Gitea's API doesn't have a single "list PRs for commit" endpoint as cleanly as GitHub or GitLab. The supported pattern is to list closed PRs and filter by `merged_commit_id`:
+
+```go
+func TestFindPRByMergeCommit_Gitea(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Gitea SDK calls GET /repos/{owner}/{repo}/pulls?state=closed
+		if !strings.Contains(r.URL.Path, "/pulls") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[{
+			"number": 42,
+			"state": "closed",
+			"merged": true,
+			"title": "release",
+			"body": "release body",
+			"head": {"ref": "monorel/release"},
+			"merge_commit_sha": "abc123",
+			"html_url": "https://gitea.example.com/acme/widget/pulls/42"
+		}]`)
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), Options{Owner: "acme", Repo: "widget", Host: srv.URL, Token: "tok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got == nil || got.Number != 42 || got.MergedSHA != "abc123" {
+		t.Errorf("got %+v, want #42 with MergedSHA=abc123", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/gitea/ -run TestFindPRByMergeCommit_Gitea -v`
+Expected: FAIL with `c.FindPRByMergeCommit undefined`.
+
+- [ ] **Step 3: Implement**
+
+Add to `internal/provider/gitea/gitea.go`:
+
+```go
+func (c *client) FindPRByMergeCommit(_ context.Context, sha string) (*provider.PullRequest, error) {
+	page := 1
+	for {
+		prs, _, err := c.gt.ListRepoPullRequests(c.owner, c.repo, gitea.ListPullRequestsOptions{
+			ListOptions: gitea.ListOptions{Page: page, PageSize: 50},
+			State:       gitea.StateClosed,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("gitea: list PRs: %w", err)
+		}
+		for _, pr := range prs {
+			if pr.MergedCommitID != nil && *pr.MergedCommitID == sha {
+				return giteaToPR(pr), nil
+			}
+		}
+		if len(prs) < 50 {
+			return nil, nil
+		}
+		page++
+	}
+}
+```
+
+Update `giteaToPR` to set `MergedSHA: derefOr(pr.MergedCommitID, "")` (or whatever the existing dereferencing helper looks like).
+
+- [ ] **Step 4: Run — pass**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/gitea/ -run TestFindPRByMergeCommit_Gitea -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run all tests — verify nothing else broke**
+
+Run: `cd /home/theo/projects/monorel && go test ./...`
+Expected: PASS (everything still compiles + passes).
+
+- [ ] **Step 6: Commit Phase 1**
+
+```bash
+cd /home/theo/projects/monorel
+git add internal/provider/
+git commit -m "feat(provider): add FindPRByMergeCommit to Client interface
+
+New method on the provider Client interface for the universal
+PR-body trailers fallback. Each provider implements it:
+
+  - github: uses go-github's ListPullRequestsWithCommit.
+  - gitlab: uses go-gitlab's Commits.ListMergeRequestsByCommit.
+  - gitea: lists closed PRs and filters by merged_commit_id.
+  - fake: in-memory match against PullRequest.MergedSHA.
+
+PullRequest gains a MergedSHA field, populated by every provider's
+PR-conversion helper. Returns (nil, nil) when no PR matches the
+SHA — the caller treats that as 'no fallback available'."
+```
+
+### Task 6: Add `EmailEnvVars` helper + extend `TokenEnvVars` for Bitbucket
+
+**Files:**
+- Modify: `internal/provider/provider.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/provider/provider_test.go` (create if missing):
+
+```go
+func TestEmailEnvVars(t *testing.T) {
+	if got := EmailEnvVars("bitbucket"); !equalSlices(got, []string{"BITBUCKET_EMAIL"}) {
+		t.Errorf("EmailEnvVars(bitbucket) = %v", got)
+	}
+	if got := EmailEnvVars("github"); got != nil {
+		t.Errorf("EmailEnvVars(github) = %v, want nil", got)
+	}
+}
+
+func TestTokenEnvVars_Bitbucket(t *testing.T) {
+	if got := TokenEnvVars("bitbucket"); !equalSlices(got, []string{"BITBUCKET_TOKEN"}) {
+		t.Errorf("TokenEnvVars(bitbucket) = %v", got)
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/ -run "TestEmailEnvVars|TestTokenEnvVars_Bitbucket" -v`
+Expected: FAIL — `EmailEnvVars undefined` and the bitbucket case missing from TokenEnvVars.
+
+- [ ] **Step 3: Implement in provider.go**
+
+Find `TokenEnvVars` in `internal/provider/provider.go` and add a `bitbucket` arm + a parallel `EmailEnvVars`:
+
+```go
+func TokenEnvVars(provider string) []string {
+	switch config.ResolveProvider(provider) {
+	case config.ProviderGitHub:
+		return []string{"GITHUB_TOKEN", "GH_TOKEN"}
+	case config.ProviderGitea:
+		return []string{"GITEA_TOKEN"}
+	case config.ProviderGitLab:
+		return []string{"GITLAB_TOKEN", "CI_JOB_TOKEN"}
+	case config.ProviderBitbucket:
+		return []string{"BITBUCKET_TOKEN"}
+	}
+	return nil
+}
+
+// EmailEnvVars returns environment variable names to consult for a
+// provider's auth-email, in priority order. Most providers don't use
+// a separate email (the token alone authenticates); Bitbucket Cloud
+// is the exception because its REST API uses HTTP Basic with
+// `email + token`. Returns nil for providers that don't need a
+// separate email.
+func EmailEnvVars(provider string) []string {
+	if config.ResolveProvider(provider) == config.ProviderBitbucket {
+		return []string{"BITBUCKET_EMAIL"}
+	}
+	return nil
+}
+```
+
+Note: `config.ProviderBitbucket` doesn't exist yet — Task 7 adds it. To keep this task self-contained, hold off until Task 7 completes, then come back. (Or do both in a tight order. The build will break temporarily if you do this task before Task 7.)
+
+- [ ] **Step 4: Hold the commit until Task 7 lands the constant**
+
+Combined into Task 7's commit.
+
+### Task 7: Add `ProviderBitbucket` constant
+
+**Files:**
+- Modify: `config/provider.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `config/provider_test.go`:
+
+```go
+func TestProviderBitbucket_IsKnown(t *testing.T) {
+	if !IsKnownProvider(ProviderBitbucket) {
+		t.Error("ProviderBitbucket should be recognized")
+	}
+}
+
+func TestKnownProviders_IncludesBitbucket(t *testing.T) {
+	for _, p := range KnownProviders {
+		if p == ProviderBitbucket {
+			return
+		}
+	}
+	t.Error("KnownProviders should include ProviderBitbucket")
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./config/ -run "TestProviderBitbucket|TestKnownProviders" -v`
+Expected: FAIL with `ProviderBitbucket undefined`.
+
+- [ ] **Step 3: Add the constant + extend KnownProviders**
+
+In `config/provider.go`:
+
+```go
+const (
+	ProviderGitHub    = "github"
+	ProviderGitea     = "gitea"
+	ProviderGitLab    = "gitlab"
+	ProviderBitbucket = "bitbucket"
+)
+```
+
+```go
+var KnownProviders = []string{
+	ProviderBitbucket,
+	ProviderGitea,
+	ProviderGitHub,
+	ProviderGitLab,
+}
+```
+
+(Alphabetical order; `bitbucket` lands first.)
+
+- [ ] **Step 4: Run all tests in provider/ + config/**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/ ./config/`
+Expected: PASS (the `EmailEnvVars` test from Task 6 now compiles because `ProviderBitbucket` exists).
+
+- [ ] **Step 5: Commit Phase-1-tail (Tasks 6 + 7 together)**
+
+```bash
+git add config/provider.go config/provider_test.go internal/provider/provider.go internal/provider/provider_test.go
+git commit -m "feat(config,provider): register ProviderBitbucket
+
+Adds the constant + appends to KnownProviders. The provider's
+factory wiring is in a follow-up task; this one is just the
+catalog entry. Plus EmailEnvVars/TokenEnvVars know about
+BITBUCKET_EMAIL and BITBUCKET_TOKEN so the orchestrator can
+resolve credentials when bitbucket is the selected provider."
+```
+
+---
+
+## Phase 2: Bitbucket Package Skeleton
+
+Lay down the package directory, the package-level documentation, the constructor + Options, the HTTP transport with auth header construction, and the error sentinels. No business methods yet (those follow in Phase 3).
+
+### Task 8: Package overview (`doc.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/doc.go`
+
+- [ ] **Step 1: Write the file**
+
+```go
+// Package bitbucket is the [provider.Client] implementation for
+// Bitbucket Cloud (bitbucket.org).
+//
+// Bitbucket Data Center / Server is out of scope; that variant uses
+// a different REST API (/rest/api/1.0/...) and a different auth
+// model. If support is added later, it should land under
+// internal/provider/bitbucket/datacenter/ as a sibling of the
+// current Cloud implementation.
+//
+// # Auth
+//
+// REST API: HTTP Basic with `email:token`. Both BITBUCKET_EMAIL and
+// BITBUCKET_TOKEN are required. The token must be an Atlassian API
+// token created with Bitbucket scopes:
+// read/write:repository:bitbucket and read/write:pullrequest:bitbucket.
+//
+// Git over HTTPS uses a different identifier: <bitbucket-username>:<token>
+// (NOT email). The provider client probes /2.0/user on first call to
+// learn the username and caches it. Callers that need to construct
+// an HTTPS git URL ask for the username via the cached state.
+//
+// # Releases
+//
+// Bitbucket Cloud has no first-class Release concept. CreateRelease
+// is a no-op that returns a synthetic *Release pointing at the tag's
+// /src/ URL. Per-package CHANGELOG.md is the canonical release-notes
+// source.
+//
+// # State mapping
+//
+// Bitbucket PR states are OPEN / MERGED / DECLINED / SUPERSEDED.
+// Provider-interface State is "open" / "closed". Map OPEN -> "open";
+// everything else -> "closed".
+package bitbucket
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Run: `cd /home/theo/projects/monorel && go build ./internal/provider/bitbucket/`
+Expected: success.
+
+- [ ] **Step 3: Don't commit yet**
+
+Combined commit at the end of Phase 2.
+
+### Task 9: Constructor + Options (`bitbucket.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/bitbucket.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/provider/bitbucket/bitbucket_test.go`:
+
+```go
+package bitbucket
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNew_RejectsMissingEmail(t *testing.T) {
+	_, err := New(context.Background(), Options{Workspace: "ws", Repo: "r", Token: "t"})
+	if err == nil {
+		t.Fatal("expected error for missing email")
+	}
+}
+
+func TestNew_RejectsMissingToken(t *testing.T) {
+	_, err := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com"})
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+}
+
+func TestNew_RejectsMissingWorkspaceOrRepo(t *testing.T) {
+	for _, tc := range []Options{
+		{Repo: "r", Email: "e@x.com", Token: "t"},
+		{Workspace: "ws", Email: "e@x.com", Token: "t"},
+	} {
+		if _, err := New(context.Background(), tc); err == nil {
+			t.Errorf("expected error for %+v", tc)
+		}
+	}
+}
+
+func TestNew_RejectsNonEmptyHost(t *testing.T) {
+	_, err := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r", Host: "self-hosted",
+		Email: "e@x.com", Token: "t",
+	})
+	if err == nil {
+		t.Fatal("expected error for non-empty Host (Cloud-only)")
+	}
+}
+
+func TestNew_HappyPath(t *testing.T) {
+	c, err := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r",
+		Email: "e@x.com", Token: "t",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/bitbucket/ -v`
+Expected: FAIL — `New undefined` etc.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/provider/bitbucket/bitbucket.go`:
+
+```go
+package bitbucket
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+// Options configures a new Bitbucket Cloud-backed [provider.Client].
+type Options struct {
+	// Workspace is the bitbucket workspace slug (the part of the URL
+	// like bitbucket.org/<workspace>/<repo>). Mirrors the `owner`
+	// field from monorel.toml.
+	Workspace string
+
+	// Repo is the repository slug.
+	Repo string
+
+	// Host must be empty (Cloud-only). Non-empty is rejected with an
+	// error pointing at the future Data Center extension path.
+	Host string
+
+	// Email is the Atlassian-account email. Required for REST auth
+	// (HTTP Basic with email + token).
+	Email string
+
+	// Token is an Atlassian API token with Bitbucket scopes
+	// (read/write:repository:bitbucket and
+	// read/write:pullrequest:bitbucket).
+	Token string
+}
+
+// ErrMissingWorkspaceRepo is returned when Options doesn't carry both
+// a workspace and a repo.
+var ErrMissingWorkspaceRepo = errors.New("bitbucket: Workspace and Repo are required")
+
+// ErrMissingEmail is returned when Options.Email is empty.
+var ErrMissingEmail = errors.New("bitbucket: Email is required (REST auth uses HTTP Basic with email + token)")
+
+// ErrMissingToken is returned when Options.Token is empty.
+var ErrMissingToken = errors.New("bitbucket: Token is required")
+
+// ErrHostNotSupported is returned when Options.Host is non-empty.
+// Bitbucket Data Center / Server is not implemented; only Cloud is
+// supported.
+var ErrHostNotSupported = errors.New("bitbucket: Host must be empty (Cloud-only); Data Center support is not implemented")
+
+// New returns a [provider.Client] backed by Bitbucket Cloud's REST
+// API v2. Does NOT make a network call: the first request fires when
+// one of the Client methods is invoked, including the lazy
+// /2.0/user probe that resolves the auth username for git
+// credentials.
+func New(_ context.Context, opts Options) (provider.Client, error) {
+	if opts.Workspace == "" || opts.Repo == "" {
+		return nil, ErrMissingWorkspaceRepo
+	}
+	if opts.Email == "" {
+		return nil, ErrMissingEmail
+	}
+	if opts.Token == "" {
+		return nil, ErrMissingToken
+	}
+	if opts.Host != "" {
+		return nil, ErrHostNotSupported
+	}
+	return &client{
+		workspace: opts.Workspace,
+		repo:      opts.Repo,
+		email:     opts.Email,
+		token:     opts.Token,
+		baseURL:   "https://api.bitbucket.org/2.0",
+		http: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+// client is the unexported provider.Client implementation. Public
+// surface is the Options + New constructor only.
+type client struct {
+	workspace string
+	repo      string
+	email     string
+	token     string
+
+	baseURL string
+
+	http *http.Client
+
+	// Identity-probe state. Lazily populated on first call needing
+	// the username.
+	identityOnce sync.Once
+	username     string
+	identityErr  error
+}
+```
+
+- [ ] **Step 4: Run — partial pass**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/bitbucket/ -run TestNew -v`
+Expected: PASS (constructor tests). Other tests (full Client interface) fail because methods aren't implemented yet — that's Phase 3.
+
+- [ ] **Step 5: Don't commit yet**
+
+### Task 10: HTTP transport + auth header (`client.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/client.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/provider/bitbucket/bitbucket_test.go`:
+
+```go
+import (
+	"encoding/base64"
+	"net/http/httptest"
+	"strings"
+)
+
+func TestClient_AuthHeader(t *testing.T) {
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r",
+		Email: "e@x.com", Token: "tok",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	if _, err := bc.do(context.Background(), "GET", "/some-path", nil, nil); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("e@x.com:tok"))
+	if seen != want {
+		t.Errorf("Authorization header = %q, want %q", seen, want)
+	}
+}
+
+func TestClient_DoMapsStatus(t *testing.T) {
+	cases := []struct {
+		status int
+		body   string
+		want   string // substring of err message
+	}{
+		{401, `{"error":{"message":"unauth"}}`, "auth failed"},
+		{403, `{"error":{"message":"no scope"}}`, "forbidden"},
+		{404, `{"error":{"message":"missing"}}`, "not found"},
+		{402, `{"error":{"message":"plan"}}`, "plan not configured"},
+		{429, `{"error":{"message":"slow down"}}`, "rate limited"},
+		{500, `{"error":{"message":"oops"}}`, "server error"},
+		{400, `{"error":{"message":"bad input"}}`, "bad input"},
+	}
+	for _, tc := range cases {
+		t.Run(strings.TrimSpace(tc.want), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c, _ := New(context.Background(), Options{
+				Workspace: "ws", Repo: "r",
+				Email: "e@x.com", Token: "tok",
+			})
+			bc := c.(*client)
+			bc.baseURL = srv.URL
+
+			_, err := bc.do(context.Background(), "GET", "/x", nil, nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q, want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/bitbucket/ -run "TestClient_AuthHeader|TestClient_DoMapsStatus"`
+Expected: FAIL with `bc.do undefined`.
+
+- [ ] **Step 3: Implement client.go**
+
+Create `internal/provider/bitbucket/client.go`:
+
+```go
+package bitbucket
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// do issues an authenticated HTTP request and decodes the JSON
+// response body into out (if non-nil). Returns a wrapped error on
+// non-2xx, with status-code-specific messages for the common cases.
+//
+// path is the API path (e.g. "/repositories/ws/r"); the baseURL is
+// prepended. query is appended as URL-encoded parameters when
+// non-nil. body, when non-nil, is JSON-encoded and sent as the
+// request body with Content-Type: application/json.
+func (c *client) do(ctx context.Context, method, path string, query url.Values, body any) (*http.Response, error) {
+	full := c.baseURL + path
+	if len(query) > 0 {
+		full += "?" + query.Encode()
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		buf := new(bytes.Buffer)
+		if err := json.NewEncoder(buf).Encode(body); err != nil {
+			return nil, fmt.Errorf("bitbucket: marshal request body: %w", err)
+		}
+		bodyReader = buf
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, full, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("bitbucket: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(c.email+":"+c.token)))
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bitbucket: %s %s: %w", method, full, err)
+	}
+
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		respBytes, _ := io.ReadAll(resp.Body)
+		return nil, mapStatusError(resp.StatusCode, respBytes, c.workspace, c.repo)
+	}
+	return resp, nil
+}
+
+// decodeJSON reads resp.Body, JSON-decodes into out, and closes the
+// body. Convenience for the common one-shot pattern.
+func decodeJSON(resp *http.Response, out any) error {
+	defer resp.Body.Close()
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("bitbucket: decode response: %w", err)
+	}
+	return nil
+}
+
+// repoBase returns the API base path for the configured repo, e.g.
+// /repositories/<workspace>/<repo>. Includes URL-encoding of the
+// workspace and repo slugs (rare but possible if the slug contains
+// reserved characters).
+func (c *client) repoBase() string {
+	return "/repositories/" + url.PathEscape(c.workspace) + "/" + url.PathEscape(c.repo)
+}
+```
+
+`mapStatusError` is defined in `errors.go` (Task 11).
+
+- [ ] **Step 4: Don't commit yet**
+
+### Task 11: Error sentinels + status-code mapper (`errors.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/errors.go`
+
+- [ ] **Step 1: Implement (test came earlier in Task 10's `TestClient_DoMapsStatus`)**
+
+Create `internal/provider/bitbucket/errors.go`:
+
+```go
+package bitbucket
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ErrPlanGate is returned when Bitbucket rejects an API or git
+// operation with HTTP 402 because the workspace plan isn't
+// configured. The user must accept a plan at
+// bitbucket.org/<workspace>/workspace/settings/plans before monorel
+// can push commits or call certain APIs.
+//
+// 402 is most commonly observed on git push (which monorel doesn't
+// invoke directly — the orchestrator's git layer surfaces it). The
+// REST client surfaces it for completeness.
+var ErrPlanGate = errors.New("bitbucket: workspace plan not configured (visit bitbucket.org/<workspace>/workspace/settings/plans)")
+
+// ErrRateLimited is returned when Bitbucket responds with HTTP 429.
+// Callers may retry after a short delay; the response's Retry-After
+// header is not yet parsed by this client.
+var ErrRateLimited = errors.New("bitbucket: rate limited (HTTP 429); retry after a short delay")
+
+// errorResponse is Bitbucket's error envelope shape.
+type errorResponse struct {
+	Type  string `json:"type"`
+	Error struct {
+		Message string `json:"message"`
+		Detail  string `json:"detail"`
+	} `json:"error"`
+}
+
+// mapStatusError converts an HTTP error response into a wrapped Go
+// error with a user-actionable message. Includes workspace/repo
+// context for 404s.
+func mapStatusError(status int, body []byte, workspace, repo string) error {
+	msg := decodeErrorMessage(body)
+	switch status {
+	case 401:
+		return fmt.Errorf("bitbucket: auth failed (check BITBUCKET_EMAIL + BITBUCKET_TOKEN); verify the token has Bitbucket scopes: %s", msg)
+	case 402:
+		return ErrPlanGate
+	case 403:
+		return fmt.Errorf("bitbucket: forbidden; the token is missing a scope (required: read/write repository, read/write pullrequest): %s", msg)
+	case 404:
+		return fmt.Errorf("bitbucket: not found (workspace=%q repo=%q); verify the slugs and that you have access: %s", workspace, repo, msg)
+	case 429:
+		return ErrRateLimited
+	case 400:
+		return fmt.Errorf("bitbucket: bad input: %s", msg)
+	}
+	if status >= 500 {
+		return fmt.Errorf("bitbucket: server error %d: %s", status, msg)
+	}
+	return fmt.Errorf("bitbucket: unexpected status %d: %s", status, msg)
+}
+
+// decodeErrorMessage tries to extract a human-readable message from
+// Bitbucket's error envelope. Falls back to the raw body when the
+// envelope doesn't parse.
+func decodeErrorMessage(body []byte) string {
+	var er errorResponse
+	if err := json.Unmarshal(body, &er); err == nil && er.Error.Message != "" {
+		if er.Error.Detail != "" {
+			return er.Error.Message + " — " + er.Error.Detail
+		}
+		return er.Error.Message
+	}
+	if len(body) == 0 {
+		return "(empty response body)"
+	}
+	if len(body) > 200 {
+		return string(body[:200]) + "..."
+	}
+	return string(body)
+}
+```
+
+- [ ] **Step 2: Run client tests**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/bitbucket/ -run "TestClient_AuthHeader|TestClient_DoMapsStatus" -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit Phase 2**
+
+```bash
+git add internal/provider/bitbucket/
+git commit -m "feat(provider/bitbucket): package skeleton
+
+Adds the Cloud-only Bitbucket provider package: doc.go (package
+overview), bitbucket.go (Options + New constructor with input
+validation), client.go (HTTP transport with HTTP Basic auth header),
+errors.go (sentinel errors + status-code mapper). No business
+methods yet — those land in Phase 3."
+```
+
+---
+
+## Phase 3: Bitbucket REST Methods
+
+Each method is one task: write the test against an `httptest.NewServer` fake, run, fail, implement, run, pass, hold the commit until the phase wraps.
+
+### Task 12: Identity probe (`identity.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/identity.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `bitbucket_test.go`:
+
+```go
+func TestIdentityProbe_CachesUsername(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/user" {
+			calls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"username":"theo-bb","display_name":"Theo","uuid":"{abc}"}`)
+			return
+		}
+		t.Errorf("unexpected path %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r",
+		Email: "e@x.com", Token: "tok",
+	})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := bc.resolveUsername(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "theo-bb" {
+		t.Errorf("got %q, want theo-bb", got)
+	}
+
+	// Call again; should hit the cache, not the server.
+	if _, err := bc.resolveUsername(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 probe call, got %d", calls)
+	}
+}
+
+func TestIdentityProbe_SurfacesAuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+		fmt.Fprintln(w, `{"error":{"message":"bad creds"}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r",
+		Email: "e@x.com", Token: "tok",
+	})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	_, err := bc.resolveUsername(context.Background())
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	if !strings.Contains(err.Error(), "auth failed") {
+		t.Errorf("err = %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/bitbucket/ -run TestIdentityProbe -v`
+Expected: FAIL — `resolveUsername undefined`.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/provider/bitbucket/identity.go`:
+
+```go
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+)
+
+// resolveUsername returns the Bitbucket username associated with the
+// configured email + token. Probes /2.0/user on first call and caches
+// the result; concurrent first calls share the probe via sync.Once.
+func (c *client) resolveUsername(ctx context.Context) (string, error) {
+	c.identityOnce.Do(func() {
+		resp, err := c.do(ctx, "GET", "/user", nil, nil)
+		if err != nil {
+			c.identityErr = fmt.Errorf("bitbucket: probe /2.0/user: %w", err)
+			return
+		}
+		var body struct {
+			Username    string `json:"username"`
+			DisplayName string `json:"display_name"`
+			UUID        string `json:"uuid"`
+		}
+		if err := decodeJSON(resp, &body); err != nil {
+			c.identityErr = err
+			return
+		}
+		if body.Username == "" {
+			c.identityErr = fmt.Errorf("bitbucket: /2.0/user returned empty username")
+			return
+		}
+		c.username = body.Username
+	})
+	if c.identityErr != nil {
+		return "", c.identityErr
+	}
+	return c.username, nil
+}
+```
+
+- [ ] **Step 4: Run — pass**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/bitbucket/ -run TestIdentityProbe -v`
+Expected: PASS.
+
+- [ ] **Step 5: Don't commit yet**
+
+### Task 13: GetDefaultBranch (`repo.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/repo.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `bitbucket_test.go`:
+
+```go
+func TestGetDefaultBranch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repositories/ws/r" {
+			t.Errorf("path = %s, want /repositories/ws/r", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"mainbranch":{"name":"master","type":"branch"}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t",
+	})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.GetDefaultBranch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "master" {
+		t.Errorf("got %q, want master", got)
+	}
+}
+
+func TestGetDefaultBranch_EmptyMainbranch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t",
+	})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	_, err := c.GetDefaultBranch(context.Background())
+	if err == nil {
+		t.Fatal("expected error for missing mainbranch")
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+- [ ] **Step 3: Implement**
+
+Create `internal/provider/bitbucket/repo.go`:
+
+```go
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+)
+
+func (c *client) GetDefaultBranch(ctx context.Context) (string, error) {
+	resp, err := c.do(ctx, "GET", c.repoBase(), nil, nil)
+	if err != nil {
+		return "", err
+	}
+	var body struct {
+		Mainbranch struct {
+			Name string `json:"name"`
+		} `json:"mainbranch"`
+	}
+	if err := decodeJSON(resp, &body); err != nil {
+		return "", err
+	}
+	if body.Mainbranch.Name == "" {
+		return "", fmt.Errorf("bitbucket: %s/%s has no default branch", c.workspace, c.repo)
+	}
+	return body.Mainbranch.Name, nil
+}
+```
+
+- [ ] **Step 4: Run — pass**
+
+- [ ] **Step 5: Don't commit yet**
+
+### Task 14: PR ops (`pulls.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/pulls.go`
+
+This task implements four `provider.Client` methods together since they share request/response shapes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `bitbucket_test.go`:
+
+```go
+func TestFindOpenReleasePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.URL.Query().Get("q")
+		want := `state="OPEN" AND source.branch.name="monorel/release"`
+		if got != want {
+			t.Errorf("q = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"values":[{
+			"id": 7,
+			"state": "OPEN",
+			"title": "release",
+			"summary":{"raw":"body"},
+			"source":{"branch":{"name":"monorel/release"}},
+			"merge_commit":null,
+			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/7"}}
+		}]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.FindOpenReleasePR(context.Background(), "monorel/release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Number != 7 || got.State != "open" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestFindOpenReleasePR_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"values":[]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.FindOpenReleasePR(context.Background(), "monorel/release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}
+
+func TestCreatePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		var body struct {
+			Title       string `json:"title"`
+			Description string `json:"description"`
+			Source      struct {
+				Branch struct{ Name string `json:"name"` } `json:"branch"`
+			} `json:"source"`
+			Destination struct {
+				Branch struct{ Name string `json:"name"` } `json:"branch"`
+			} `json:"destination"`
+		}
+		json.NewDecoder(r.Body).Decode(&body)
+		if body.Title != "release" || body.Source.Branch.Name != "monorel/release" || body.Destination.Branch.Name != "main" {
+			t.Errorf("body = %+v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{
+			"id": 7, "state":"OPEN", "title":"release", "summary":{"raw":"body"},
+			"source":{"branch":{"name":"monorel/release"}},
+			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/7"}}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.CreatePR(context.Background(), provider.CreatePROptions{
+		Title:      "release",
+		Body:       "body",
+		HeadBranch: "monorel/release",
+		BaseBranch: "main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Number != 7 {
+		t.Errorf("got #%d, want #7", got.Number)
+	}
+}
+
+func TestUpdatePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{
+			"id": 7, "state":"OPEN", "title":"new title", "summary":{"raw":"new body"},
+			"source":{"branch":{"name":"monorel/release"}},
+			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/7"}}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	title := "new title"
+	body := "new body"
+	got, err := c.UpdatePR(context.Background(), 7, provider.UpdatePROptions{Title: &title, Body: &body})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "new title" {
+		t.Errorf("got %q", got.Title)
+	}
+}
+
+func TestClosePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repositories/ws/r/pullrequests/7/decline" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(200)
+		fmt.Fprintln(w, `{"id":7,"state":"DECLINED"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	if err := c.ClosePR(context.Background(), 7); err != nil {
+		t.Fatal(err)
+	}
+}
+```
+
+Add to the `import` block at the top of the test file (it may already include some of these):
+
+```go
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"monorel.disaresta.com/internal/provider"
+)
+```
+
+- [ ] **Step 2: Run — fail**
+
+- [ ] **Step 3: Implement**
+
+Create `internal/provider/bitbucket/pulls.go`:
+
+```go
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+// bbPullRequest is Bitbucket's PR-shape we care about.
+type bbPullRequest struct {
+	ID      int    `json:"id"`
+	State   string `json:"state"`
+	Title   string `json:"title"`
+	Summary struct {
+		Raw string `json:"raw"`
+	} `json:"summary"`
+	Source struct {
+		Branch struct {
+			Name string `json:"name"`
+		} `json:"branch"`
+	} `json:"source"`
+	MergeCommit *struct {
+		Hash string `json:"hash"`
+	} `json:"merge_commit"`
+	Links struct {
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+	} `json:"links"`
+}
+
+// toProviderPR converts to the neutral provider.PullRequest shape.
+// State is normalized: OPEN -> "open"; everything else -> "closed".
+func (p *bbPullRequest) toProviderPR() *provider.PullRequest {
+	state := "closed"
+	if p.State == "OPEN" {
+		state = "open"
+	}
+	pr := &provider.PullRequest{
+		Number:  p.ID,
+		State:   state,
+		Title:   p.Title,
+		Body:    p.Summary.Raw,
+		HeadRef: p.Source.Branch.Name,
+		HTMLURL: p.Links.HTML.Href,
+	}
+	if p.MergeCommit != nil {
+		pr.MergedSHA = p.MergeCommit.Hash
+	}
+	return pr
+}
+
+func (c *client) FindOpenReleasePR(ctx context.Context, headBranch string) (*provider.PullRequest, error) {
+	q := url.Values{}
+	q.Set("q", fmt.Sprintf(`state="OPEN" AND source.branch.name=%q`, headBranch))
+	resp, err := c.do(ctx, "GET", c.repoBase()+"/pullrequests", q, nil)
+	if err != nil {
+		return nil, err
+	}
+	var body struct {
+		Values []bbPullRequest `json:"values"`
+	}
+	if err := decodeJSON(resp, &body); err != nil {
+		return nil, err
+	}
+	if len(body.Values) == 0 {
+		return nil, nil
+	}
+	return body.Values[0].toProviderPR(), nil
+}
+
+func (c *client) CreatePR(ctx context.Context, opts provider.CreatePROptions) (*provider.PullRequest, error) {
+	type branch struct {
+		Name string `json:"name"`
+	}
+	type ref struct {
+		Branch branch `json:"branch"`
+	}
+	type createBody struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		Source      ref    `json:"source"`
+		Destination ref    `json:"destination"`
+	}
+	body := createBody{
+		Title:       opts.Title,
+		Description: opts.Body,
+		Source:      ref{Branch: branch{Name: opts.HeadBranch}},
+		Destination: ref{Branch: branch{Name: opts.BaseBranch}},
+	}
+	resp, err := c.do(ctx, "POST", c.repoBase()+"/pullrequests", nil, body)
+	if err != nil {
+		return nil, err
+	}
+	var out bbPullRequest
+	if err := decodeJSON(resp, &out); err != nil {
+		return nil, err
+	}
+	return out.toProviderPR(), nil
+}
+
+func (c *client) UpdatePR(ctx context.Context, number int, opts provider.UpdatePROptions) (*provider.PullRequest, error) {
+	if opts.Title == nil && opts.Body == nil {
+		return nil, fmt.Errorf("bitbucket: UpdatePR has nothing to change")
+	}
+	patch := map[string]any{}
+	if opts.Title != nil {
+		patch["title"] = *opts.Title
+	}
+	if opts.Body != nil {
+		patch["description"] = *opts.Body
+	}
+	resp, err := c.do(ctx, "PUT", c.repoBase()+"/pullrequests/"+strconv.Itoa(number), nil, patch)
+	if err != nil {
+		return nil, err
+	}
+	var out bbPullRequest
+	if err := decodeJSON(resp, &out); err != nil {
+		return nil, err
+	}
+	return out.toProviderPR(), nil
+}
+
+func (c *client) ClosePR(ctx context.Context, number int) error {
+	resp, err := c.do(ctx, "POST", c.repoBase()+"/pullrequests/"+strconv.Itoa(number)+"/decline", nil, nil)
+	if err != nil {
+		return err
+	}
+	return decodeJSON(resp, nil)
+}
+```
+
+- [ ] **Step 4: Run — pass**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/bitbucket/ -v`
+Expected: All previously-written tests pass; remaining tests (CreateRelease, FindPRByMergeCommit) compile-fail until the rest of Phase 3.
+
+- [ ] **Step 5: Don't commit yet**
+
+### Task 15: CreateRelease (no-op) (`release.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/release.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestCreateRelease_NoOp(t *testing.T) {
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	rel, err := c.CreateRelease(context.Background(), provider.CreateReleaseOptions{
+		Tag:  "transports/foo/v1.7.0",
+		Name: "transports/foo v1.7.0",
+		Body: "release body",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel == nil {
+		t.Fatal("expected non-nil release")
+	}
+	if rel.Tag != "transports/foo/v1.7.0" {
+		t.Errorf("Tag = %q", rel.Tag)
+	}
+	if !strings.Contains(rel.HTMLURL, "/src/transports/foo/v1.7.0") {
+		t.Errorf("HTMLURL = %q; want a /src/<tag> URL", rel.HTMLURL)
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+- [ ] **Step 3: Implement**
+
+Create `internal/provider/bitbucket/release.go`:
+
+```go
+package bitbucket
+
+import (
+	"context"
+	"net/url"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+// CreateRelease is a no-op for Bitbucket Cloud, which has no
+// first-class Release concept. Returns a synthetic *Release whose
+// HTMLURL points at the tag's source view (bitbucket.org/<ws>/<repo>/src/<tag>).
+//
+// The orchestrator's call site treats CreateRelease as advisory:
+// per-package CHANGELOG.md is the canonical release-notes source.
+// monorel publish reports `0/0 releases` when every CreateRelease
+// call returned a no-op (TODO when the publish summary is updated;
+// for now the synthetic Release counts as success).
+func (c *client) CreateRelease(_ context.Context, opts provider.CreateReleaseOptions) (*provider.Release, error) {
+	tagPath := url.PathEscape(opts.Tag)
+	htmlURL := "https://bitbucket.org/" +
+		url.PathEscape(c.workspace) + "/" +
+		url.PathEscape(c.repo) + "/src/" + tagPath
+	return &provider.Release{
+		Tag:     opts.Tag,
+		HTMLURL: htmlURL,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run — pass**
+
+- [ ] **Step 5: Don't commit yet**
+
+### Task 16: FindPRByMergeCommit (`trailers.go`)
+
+**Files:**
+- Create: `internal/provider/bitbucket/trailers.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestFindPRByMergeCommit_Bitbucket(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.URL.Query().Get("q")
+		want := `state="MERGED" AND merge_commit.hash="abc123"`
+		if got != want {
+			t.Errorf("q = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"values":[{
+			"id": 42, "state":"MERGED", "title":"release", "summary":{"raw":"body"},
+			"source":{"branch":{"name":"monorel/release"}},
+			"merge_commit":{"hash":"abc123"},
+			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/42"}}
+		}]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Number != 42 || got.MergedSHA != "abc123" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestFindPRByMergeCommit_Bitbucket_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"values":[]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+- [ ] **Step 3: Implement**
+
+Create `internal/provider/bitbucket/trailers.go`:
+
+```go
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
+	q := url.Values{}
+	q.Set("q", fmt.Sprintf(`state="MERGED" AND merge_commit.hash=%q`, sha))
+	resp, err := c.do(ctx, "GET", c.repoBase()+"/pullrequests", q, nil)
+	if err != nil {
+		return nil, err
+	}
+	var body struct {
+		Values []bbPullRequest `json:"values"`
+	}
+	if err := decodeJSON(resp, &body); err != nil {
+		return nil, err
+	}
+	if len(body.Values) == 0 {
+		return nil, nil
+	}
+	return body.Values[0].toProviderPR(), nil
+}
+```
+
+- [ ] **Step 4: Run all bitbucket tests — pass**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/provider/bitbucket/ -v`
+Expected: every test PASS.
+
+- [ ] **Step 5: Wire factory.go**
+
+In `internal/provider/factory/factory.go`, add the bitbucket arm:
+
+```go
+import (
+	// ... existing imports ...
+	"monorel.disaresta.com/internal/provider/bitbucket"
+)
+
+// In the switch:
+case config.ProviderBitbucket:
+	return bitbucket.New(ctx, bitbucket.Options{
+		Workspace: cfg.Owner,
+		Repo:      cfg.Repo,
+		Host:      cfg.Host,
+		Email:     os.Getenv("BITBUCKET_EMAIL"),
+		Token:     token,
+	})
+```
+
+(`os` import may need adding.)
+
+- [ ] **Step 6: Run all tests**
+
+Run: `cd /home/theo/projects/monorel && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit Phase 3**
+
+```bash
+git add internal/provider/bitbucket/ internal/provider/factory/
+git commit -m "feat(provider/bitbucket): implement REST methods + factory wiring
+
+- identity.go: /2.0/user probe with sync.Once cache.
+- repo.go: GetDefaultBranch reads mainbranch.name.
+- pulls.go: FindOpenReleasePR / CreatePR / UpdatePR / ClosePR.
+  PR state OPEN maps to 'open'; everything else (MERGED /
+  DECLINED / SUPERSEDED) maps to 'closed'.
+- release.go: CreateRelease is a no-op returning a synthetic
+  *Release whose HTMLURL points at the tag's /src/ view.
+  Bitbucket Cloud has no first-class Release concept; per-package
+  CHANGELOG.md is the canonical release-notes source.
+- trailers.go: FindPRByMergeCommit queries MERGED PRs by
+  merge_commit.hash via Bitbucket's BBQL.
+- factory: case ProviderBitbucket constructs a bitbucket client
+  using Owner as the workspace and BITBUCKET_EMAIL from env."
+```
+
+---
+
+## Phase 4: Universal Trailers Fallback
+
+The interface plumbing landed in Phase 1. Now wire the actual write side (preview render) and read side (Tag fallback).
+
+### Task 17: Preview renderer appends `<!-- monorel-trailers ... -->` block
+
+**Files:**
+- Modify: `internal/release/render.go`
+- Modify: `internal/release/render_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/release/render_test.go`:
+
+```go
+func TestRenderPreview_IncludesTrailersComment(t *testing.T) {
+	p := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{
+			{
+				Name: "transports/foo",
+				From: "v1.6.0",
+				To:   "v1.7.0",
+				Bump: semver.Minor,
+				Tag:  "transports/foo/v1.7.0",
+			},
+			{
+				Name: "go.example.com/widget",
+				From: "v2.0.0",
+				To:   "v2.0.1",
+				Bump: semver.Patch,
+				Tag:  "v2.0.1",
+			},
+		},
+	}
+	got := RenderPreview(p, "2026-05-03")
+
+	if !strings.Contains(got, "<!-- monorel-trailers") {
+		t.Errorf("expected monorel-trailers comment; got:\n%s", got)
+	}
+	for _, want := range []string{
+		"monorel-Release: transports/foo v1.7.0",
+		"monorel-Release: go.example.com/widget v2.0.1",
+		"monorel-PreRelease: false",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in body:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderPreview_TrailersInPrereleaseMode(t *testing.T) {
+	p := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{{
+			Name:       "transports/foo",
+			From:       "v1.6.0",
+			To:         "v1.7.0-rc.0",
+			Bump:       semver.Minor,
+			Tag:        "transports/foo/v1.7.0-rc.0",
+			Prerelease: true,
+		}},
+	}
+	got := RenderPreview(p, "2026-05-03")
+
+	if !strings.Contains(got, "monorel-PreRelease: true") {
+		t.Errorf("PreRelease trailer should be true:\n%s", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run — fail**
+
+- [ ] **Step 3: Implement**
+
+In `internal/release/render.go`, find where `RenderPreview` returns and append the trailers comment block before returning. Add at the end of the function (before `return b.String()`):
+
+```go
+	// Append the monorel-trailers comment block. Invisible in the
+	// rendered PR body (HTML comment); used by `monorel tag` as a
+	// fallback when the merge commit body is rewritten (e.g. by
+	// squash-merge). All four providers preserve HTML comments on
+	// PR-body fetches.
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)")
+	for _, r := range p.Releases {
+		fmt.Fprintf(&b, "monorel-Release: %s %s\n", r.Name, r.To)
+	}
+	fmt.Fprintf(&b, "monorel-PreRelease: %t\n", anyPrerelease(p))
+	fmt.Fprintln(&b, "-->")
+```
+
+- [ ] **Step 4: Run — pass**
+
+- [ ] **Step 5: Don't commit yet**
+
+### Task 18: Add Provider field to TagOptions; implement fallback
+
+**Files:**
+- Modify: `internal/release/release.go`
+- Modify: `internal/release/release_test.go`
+- Modify: `internal/cli/tag.go`
+
+- [ ] **Step 1: Write the failing test (release_test.go)**
+
+Add a fresh test:
+
+```go
+func TestTag_FallbackToPRBody(t *testing.T) {
+	repo := newFakeRepoForTag(t)  // reuse existing helper or build one
+	repo.HeadCommitMessageValue = "chore(release): foo v1.7.0\n\n(no trailers; squash-merge)" // commit body lacks trailers
+	repo.HeadSHAValue = "abc123"
+
+	pf := provider.NewFake()
+	pf.PRs[42] = &provider.PullRequest{
+		Number: 42,
+		State:  "closed",
+		Title:  "release",
+		Body: `Plan body
+<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)
+monorel-Release: transports/foo v1.7.0
+monorel-PreRelease: false
+-->`,
+		MergedSHA: "abc123",
+	}
+
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"transports/foo": {Path: "transports/foo", TagPrefix: "transports/foo"},
+		},
+	}
+	res, err := Tag(TagOptions{Config: cfg, Repo: repo, Provider: pf})
+	if err != nil {
+		t.Fatalf("Tag with fallback: %v", err)
+	}
+	if len(res.Releases) != 1 || res.Releases[0].Tag != "transports/foo/v1.7.0" {
+		t.Errorf("got %+v", res.Releases)
+	}
+}
+
+func TestTag_FallbackBothMissing(t *testing.T) {
+	repo := newFakeRepoForTag(t)
+	repo.HeadCommitMessageValue = "chore(release): foo v1.7.0\n\n(no trailers)"
+	repo.HeadSHAValue = "abc123"
+	pf := provider.NewFake()
+	// No PR seeded.
+
+	cfg := &config.Config{Packages: map[string]config.PackageConfig{}}
+	_, err := Tag(TagOptions{Config: cfg, Repo: repo, Provider: pf})
+	if err == nil {
+		t.Fatal("expected ErrNoReleaseCommit")
+	}
+	if !errors.Is(err, ErrNoReleaseCommit) {
+		t.Errorf("err = %v, want ErrNoReleaseCommit", err)
+	}
+}
+```
+
+(If `newFakeRepoForTag` doesn't exist, use whatever helper this test file already uses; mirror it. The point is HeadCommitMessage returns a body without `monorel-Release:` trailers and HeadSHA returns a known value.)
+
+- [ ] **Step 2: Run — fail**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/release/ -run TestTag_Fallback`
+Expected: FAIL — `Provider undefined on TagOptions`.
+
+- [ ] **Step 3: Add Provider field + fallback path**
+
+In `internal/release/release.go`:
+
+```go
+type TagOptions struct {
+	Config *config.Config
+	Repo   git.Repo
+
+	// Provider, when non-nil, enables the universal PR-body trailers
+	// fallback: when HEAD's commit message has no monorel-Release:
+	// trailers (e.g. a squash-merge rewrote the body), Tag looks up
+	// the PR that was merged at HEAD's SHA via
+	// Provider.FindPRByMergeCommit and parses trailers from the PR
+	// body's <!-- monorel-trailers ... --> comment block.
+	//
+	// nil disables the fallback (Tag returns ErrNoReleaseCommit on
+	// missing trailers, the pre-fallback behavior).
+	Provider provider.Client
+}
+```
+
+Add `import "monorel.disaresta.com/internal/provider"` if not already present.
+
+In `Tag(opts TagOptions)`, modify the `len(tagged) == 0` branch:
+
+```go
+	tagged, prerelease := parseReleaseTrailers(msg)
+	if len(tagged) == 0 {
+		// Fallback: look up the merged PR's body for a trailers comment block.
+		if opts.Provider != nil {
+			fallbackTagged, fallbackPre, err := tryPRBodyFallback(opts)
+			if err != nil {
+				return nil, err
+			}
+			if len(fallbackTagged) > 0 {
+				tagged, prerelease = fallbackTagged, fallbackPre
+			}
+		}
+		if len(tagged) == 0 {
+			return nil, ErrNoReleaseCommit
+		}
+	}
+```
+
+Add the helper:
+
+```go
+// tryPRBodyFallback queries the provider for the merged PR at HEAD's
+// SHA and parses release trailers from the PR body's
+// <!-- monorel-trailers ... --> comment block. Returns empty slices
+// when the PR isn't found or the comment block is absent — both are
+// "no fallback available," not errors.
+func tryPRBodyFallback(opts TagOptions) ([]taggedRelease, bool, error) {
+	headSHA, err := opts.Repo.CurrentSHA()
+	if err != nil {
+		return nil, false, fmt.Errorf("release: read HEAD SHA for fallback: %w", err)
+	}
+	pr, err := opts.Provider.FindPRByMergeCommit(context.Background(), headSHA)
+	if err != nil {
+		return nil, false, fmt.Errorf("release: PR-body fallback: %w", err)
+	}
+	if pr == nil {
+		return nil, false, nil
+	}
+	block := extractTrailersBlock(pr.Body)
+	if block == "" {
+		return nil, false, nil
+	}
+	tagged, prerelease := parseReleaseTrailers(block)
+	return tagged, prerelease, nil
+}
+
+// extractTrailersBlock returns the lines inside an HTML comment block
+// of the form `<!-- monorel-trailers ... -->`, or "" if no such block
+// is present. Bitbucket / GitHub / GitLab / Gitea all preserve HTML
+// comments on PR-body fetches.
+func extractTrailersBlock(prBody string) string {
+	const startMarker = "<!-- monorel-trailers"
+	const endMarker = "-->"
+	start := strings.Index(prBody, startMarker)
+	if start == -1 {
+		return ""
+	}
+	tail := prBody[start+len(startMarker):]
+	end := strings.Index(tail, endMarker)
+	if end == -1 {
+		return ""
+	}
+	return strings.TrimSpace(tail[:end])
+}
+```
+
+Add `import "context"` and `import "strings"` if not present.
+
+- [ ] **Step 4: Update CLI to thread Provider into TagOptions**
+
+In `internal/cli/tag.go`, find where `release.Tag(release.TagOptions{...})` is called and add `Provider: rt.Provider` (or whatever the runtime exposes for the provider client):
+
+```go
+res, err := release.Tag(release.TagOptions{
+	Config:   rt.Config,
+	Repo:     rt.Repo,
+	Provider: rt.Provider, // new: enables PR-body trailers fallback
+})
+```
+
+If `rt.Provider` doesn't exist, look for how other commands (e.g. `preview.go`) access the provider — they probably build it inline via factory.New from `rt.Config`. Mirror that pattern in `tag.go`.
+
+- [ ] **Step 5: Run — pass**
+
+Run: `cd /home/theo/projects/monorel && go test ./internal/release/ ./internal/cli/`
+Expected: PASS (existing tests continue to pass; new fallback tests pass; CLI compiles).
+
+- [ ] **Step 6: Commit Phase 4**
+
+```bash
+git add internal/release/ internal/cli/tag.go
+git commit -m "feat(release): universal PR-body trailers fallback
+
+monorel preview now appends a <!-- monorel-trailers ... --> HTML
+comment block to the rendered PR body. Invisible in the rendered
+view; persists in the source.
+
+monorel tag, when given a Provider, falls back to fetching the
+merged PR's body and parsing trailers from that comment block when
+HEAD's commit message has no monorel-Release: trailers (e.g.
+because squash-merge rewrote the body). On both-missing the call
+still returns ErrNoReleaseCommit.
+
+Provider on TagOptions is optional: nil disables the fallback,
+preserving the prior behavior for callers that haven't been
+updated. internal/cli/tag.go threads the runtime provider client
+through so monorel tag picks up the fallback automatically."
+```
+
+---
+
+## Phase 5: Tests + Integration
+
+The unit tests are already written task-by-task above. This phase adds the build-tag-gated integration test and any missing cross-provider coverage.
+
+### Task 19: Build-tag integration test
+
+**Files:**
+- Create: `internal/provider/bitbucket/integration_test.go`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `internal/provider/bitbucket/integration_test.go`:
+
+```go
+//go:build integration
+
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+// TestIntegration_FullLifecycle creates a temp repo in the configured
+// workspace, walks the full PR lifecycle, and deletes the repo on
+// success. Skipped unless BITBUCKET_INTEGRATION=1 + BITBUCKET_EMAIL
+// + BITBUCKET_TOKEN + BITBUCKET_WORKSPACE are set.
+//
+// Run with: go test -tags=integration ./internal/provider/bitbucket/ -v
+func TestIntegration_FullLifecycle(t *testing.T) {
+	if os.Getenv("BITBUCKET_INTEGRATION") != "1" {
+		t.Skip("set BITBUCKET_INTEGRATION=1 to run")
+	}
+	email := os.Getenv("BITBUCKET_EMAIL")
+	token := os.Getenv("BITBUCKET_TOKEN")
+	ws := os.Getenv("BITBUCKET_WORKSPACE")
+	if email == "" || token == "" || ws == "" {
+		t.Fatal("BITBUCKET_EMAIL, BITBUCKET_TOKEN, and BITBUCKET_WORKSPACE all required")
+	}
+
+	repoName := fmt.Sprintf("monorel-integration-%d", time.Now().Unix())
+
+	// Create the repo via REST.
+	c, err := New(context.Background(), Options{
+		Workspace: ws, Repo: repoName,
+		Email: email, Token: token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bc := c.(*client)
+
+	// Create the repo via the Bitbucket API directly (out of band of
+	// the Client interface — repo creation isn't a provider.Client
+	// method).
+	if _, err := bc.do(context.Background(), "POST", bc.repoBase(), nil, map[string]any{
+		"is_private":  false,
+		"scm":         "git",
+		"description": "monorel integration test; safe to delete.",
+	}); err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_, err := bc.do(context.Background(), "DELETE", bc.repoBase(), nil, nil)
+		if err != nil {
+			t.Logf("delete repo (test cleanup): %v", err)
+		}
+	})
+
+	// Read default branch.
+	defaultBranch, err := c.GetDefaultBranch(context.Background())
+	if err != nil {
+		t.Fatalf("GetDefaultBranch: %v", err)
+	}
+	if defaultBranch != "master" && defaultBranch != "main" {
+		t.Errorf("unexpected default branch %q", defaultBranch)
+	}
+
+	// (PR-lifecycle test requires pushing branches, which uses
+	// git over HTTPS. Out of scope for the REST-only integration
+	// test; covered by the spike's manual run.)
+}
+```
+
+- [ ] **Step 2: Run with the build tag**
+
+Run: `cd /home/theo/projects/monorel && go test -tags=integration ./internal/provider/bitbucket/ -v -run TestIntegration`
+Expected: skip (env vars unset). With the env vars set, expected: PASS.
+
+- [ ] **Step 3: Commit Phase 5**
+
+```bash
+git add internal/provider/bitbucket/integration_test.go
+git commit -m "test(provider/bitbucket): build-tag-gated integration test
+
+Walks the REST lifecycle against a real Bitbucket workspace
+(create repo -> GetDefaultBranch -> delete repo). Skipped unless
+BITBUCKET_INTEGRATION=1 plus BITBUCKET_EMAIL, BITBUCKET_TOKEN,
+BITBUCKET_WORKSPACE are set.
+
+Pushed-branch / PR-lifecycle coverage is out of scope for the
+REST-only test; it requires git over HTTPS and was validated
+manually during the spike."
+```
+
+---
+
+## Phase 6: Documentation
+
+### Task 20: Integration page
+
+**Files:**
+- Create: `docs/src/integrations/bitbucket.md`
+
+- [ ] **Step 1: Write the page**
+
+Use `docs/src/integrations/gitlab.md` as the structural template. Sections:
+
+1. Overview (one paragraph: Bitbucket Cloud only; Data Center not supported).
+2. Setup (toml + env vars).
+3. The two-env-var auth model (BITBUCKET_EMAIL + BITBUCKET_TOKEN); how to create an Atlassian API token with Bitbucket scopes.
+4. Workspace plan acceptance (one-time at `bitbucket.org/<workspace>/workspace/settings/plans`); symptom = HTTP 402 on push.
+5. Merge-strategy requirement (allow fast-forward / merge-commit; reject squash; the universal trailers fallback recovers from squash anyway).
+6. No-native-releases note (CHANGELOG.md is the canonical source; `monorel publish` is a no-op).
+7. CI walkthrough using `bitbucket-pipelines.yml`.
+8. Token revocation guidance (Atlassian id.atlassian.com).
+
+Mirror the structure used in `gitlab.md` (which the user can read for reference).
+
+- [ ] **Step 2: Don't commit yet**
+
+### Task 21: Pipelines partial
+
+**Files:**
+- Create: `docs/src/_partials/bitbucket-pipelines-yml.md`
+
+- [ ] **Step 1: Write the partial**
+
+```markdown
+```yaml
+# bitbucket-pipelines.yml
+image: ghcr.io/disaresta-org/monorel:0.13.0
+
+pipelines:
+  branches:
+    main:
+      - step:
+          name: monorel
+          script:
+            - export GIT_AUTHOR_NAME="monorel-bot[automation]"
+            - export GIT_AUTHOR_EMAIL="monorel-bot@users.noreply.example.com"
+            - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+            - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+            - if echo "$BITBUCKET_COMMIT_MESSAGE" | grep -q "^chore(release):"; then
+                monorel tag &&
+                git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
+                monorel publish;
+              else
+                git fetch origin "$BITBUCKET_BRANCH" &&
+                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH" &&
+                apply_out=$(monorel apply); echo "$apply_out";
+                if ! echo "$apply_out" | grep -qF "Nothing to apply."; then
+                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release &&
+                  monorel preview --upsert;
+                fi;
+              fi
+```
+```
+
+This is a starting template; the implementer should validate it against an actual Bitbucket Pipelines run as part of the integration test follow-up.
+
+- [ ] **Step 2: Don't commit yet**
+
+### Task 22: Examples
+
+**Files:**
+- Create: `examples/bitbucket/monorel.toml`
+- Create: `examples/bitbucket/bitbucket-pipelines.yml`
+- Create: `examples/bitbucket/.changeset/README.md`
+
+- [ ] **Step 1: Mirror the gitlab/ example**
+
+`examples/bitbucket/monorel.toml`:
+
+```toml
+# monorel configuration for a Bitbucket Cloud-hosted repo.
+
+[provider]
+name  = "bitbucket"
+owner = "your-workspace"   # bitbucket workspace slug
+repo  = "your-repo"
+
+[packages."your-repo"]
+tag_prefix = ""
+path       = "."
+changelog  = "CHANGELOG.md"
+```
+
+`examples/bitbucket/bitbucket-pipelines.yml`: copy the partial's content as a real file.
+
+`examples/bitbucket/.changeset/README.md`: copy from `examples/github/.changeset/README.md`.
+
+- [ ] **Step 2: Don't commit yet**
+
+### Task 23: Sidebar + cheat sheet + LLM files + README + FAQ
+
+**Files:**
+- Modify: `docs/.vitepress/config.ts`
+- Modify: `docs/src/cheat-sheet.md`
+- Modify: `docs/src/public/llms.txt`
+- Modify: `docs/src/public/llms-full.txt`
+- Modify: `docs/src/faq.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Sidebar**
+
+In `docs/.vitepress/config.ts`, find the Integrations group and add Bitbucket alongside GitHub / Gitea / GitLab:
+
+```ts
+{
+  text: 'Integrations',
+  items: [
+    { text: 'GitHub', link: '/integrations/github' },
+    { text: 'Gitea / Forgejo', link: '/integrations/gitea' },
+    { text: 'GitLab', link: '/integrations/gitlab' },
+    { text: 'Bitbucket', link: '/integrations/bitbucket' },
+  ],
+},
+```
+
+- [ ] **Step 2: Cheat sheet**
+
+In `docs/src/cheat-sheet.md`, find the env-vars table and append:
+
+```markdown
+| `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN` | `preview`, `publish` | Auth for the Bitbucket Cloud provider. Email is the Atlassian-account email; token is an API token with Bitbucket scopes. |
+```
+
+- [ ] **Step 3: llms.txt**
+
+In `docs/src/public/llms.txt`, find the provider-auth table:
+
+```markdown
+| Bitbucket Cloud | `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN` | API token with `read/write:repository:bitbucket` + `read/write:pullrequest:bitbucket` scopes. |
+```
+
+- [ ] **Step 4: llms-full.txt**
+
+In `docs/src/public/llms-full.txt`, add a Bitbucket section to the integrations table and a paragraph noting the no-native-releases gap, the two-env-var auth, and the workspace-plan-acceptance one-time setup.
+
+- [ ] **Step 5: faq.md**
+
+Find the squash-merge / tag-recovery FAQ entry and amend:
+
+```markdown
+The `<!-- monorel-trailers ... -->` HTML comment that monorel preview writes to the PR body is the recovery path: monorel tag falls back to it when the merge commit body lacks trailers. So even if a contributor force-merges via squash, the release still completes. The fallback fails only when both the commit body AND the PR body's comment block are absent (the latter would mean a contributor edited the PR body and removed the comment).
+```
+
+- [ ] **Step 6: README.md**
+
+In the providers list / table, add Bitbucket to the row showing supported providers.
+
+- [ ] **Step 7: Don't commit yet**
+
+### Task 24: Changeset + final commit
+
+**Files:**
+- Create: `.changeset/bitbucket-provider.md`
+
+- [ ] **Step 1: Write the changeset**
+
+```markdown
+---
+"monorel.disaresta.com": minor
+---
+
+monorel now supports Bitbucket Cloud (`provider.name = "bitbucket"`) alongside GitHub, Gitea / Forgejo, and GitLab. The `internal/provider/bitbucket/` package implements the `provider.Client` interface against Bitbucket's REST API v2 (hand-rolled `net/http`; no new direct deps).
+
+Auth uses two environment variables: `BITBUCKET_EMAIL` (Atlassian account email) and `BITBUCKET_TOKEN` (Atlassian API token with Bitbucket scopes). The Bitbucket username for git over HTTPS is probed from `/2.0/user` and cached on the client.
+
+Bitbucket Cloud has no first-class Release concept, so `monorel publish` is a no-op on Bitbucket; per-package `CHANGELOG.md` is the canonical release-notes source.
+
+Plus a defensive recovery mechanism that benefits every provider: `monorel preview` now appends a `<!-- monorel-trailers ... -->` HTML comment to the PR body. `monorel tag` falls back to that block when the merge commit body lacks `monorel-Release:` trailers (e.g. because of a squash-merge that rewrote the body). The fallback uses the new `provider.Client.FindPRByMergeCommit` method, implemented by every provider.
+
+See [Bitbucket integration](/integrations/bitbucket).
+```
+
+- [ ] **Step 2: Run all tests one last time**
+
+Run: `cd /home/theo/projects/monorel && go test ./...`
+Expected: PASS.
+
+Run: `cd /home/theo/projects/monorel && cd docs && bun run docs:build`
+Expected: clean build.
+
+- [ ] **Step 3: Commit + push**
+
+```bash
+git add .
+git commit -m "docs: integration page, examples, cheat sheet, LLM files, README, FAQ, sidebar, changeset
+
+Closes the documentation surface for the Bitbucket provider PR:
+- docs/src/integrations/bitbucket.md walks through setup,
+  auth (two env vars), workspace plan acceptance, merge-strategy
+  guidance, no-native-releases note, CI via bitbucket-pipelines.yml.
+- examples/bitbucket/{monorel.toml, bitbucket-pipelines.yml,
+  .changeset/README.md} provides a copy-paste reference.
+- docs/.vitepress/config.ts adds Bitbucket to the Integrations
+  sidebar.
+- docs/src/cheat-sheet.md, llms.txt, llms-full.txt list the new
+  env vars.
+- docs/src/faq.md amends the squash-merge / tag-recovery entry to
+  mention the new universal trailers fallback.
+- README.md lists Bitbucket alongside the other providers.
+- .changeset/bitbucket-provider.md ships the change as a :minor
+  bump."
+
+git push -u origin feat/bitbucket-provider
+```
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --repo disaresta-org/monorel --fill
+```
+
+(The fill takes the commit messages as the PR title + body; or use `--body-file` with a written-out summary.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- [x] Goal 1 (Bitbucket provider) — Tasks 8-16 implement the package.
+- [x] Goal 2 (universal trailers fallback) — Tasks 1-5, 17, 18 implement the interface + render + fallback.
+- [x] Decision 1 (Cloud-only, layout-ready) — Task 8's `doc.go` documents the layout intent; the package lives at `internal/provider/bitbucket/` rather than `bitbucket/cloud/` for now (Data Center adds `bitbucket/datacenter/` later).
+- [x] Decision 2 (CreateRelease no-op) — Task 15.
+- [x] Decision 3 (merge strategy + trailers fallback) — Task 17, 18; integration page (Task 20) documents the strategy.
+- [x] Decision 4 (auth surface) — Tasks 9 (Options), 12 (probe), 6 (env-var helpers).
+- [x] Decision 5 (hand-rolled) — Tasks 9-16; no new deps.
+- [x] Decision 6 (one-PR scope) — all tasks land on `feat/bitbucket-provider`.
+
+**Placeholder scan:** no TBDs / TODOs in step content. Code blocks are complete. Test bodies show the actual assertions.
+
+**Type consistency:** `provider.PullRequest.MergedSHA` introduced in Task 2, used by all subsequent provider implementations and the trailers fallback. `bbPullRequest.toProviderPR()` populates it. `TagOptions.Provider` introduced in Task 18, used by `internal/cli/tag.go`. Constructor `New(ctx, Options)` shape matches across all four provider packages.
+
+**Ambiguity check:** the Bitbucket-Pipelines YAML in Task 21 references `BB_USER` and `BITBUCKET_TOKEN` as env vars the user must configure in pipeline secrets — this should be called out in the integration page (Task 20). The fallback's behavior when `Provider == nil` is documented as "skip the fallback; return ErrNoReleaseCommit as before" — preserved as Task 18's contract.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-03-bitbucket-provider.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-03-bitbucket-provider-design.md
+++ b/docs/superpowers/specs/2026-05-03-bitbucket-provider-design.md
@@ -1,0 +1,203 @@
+# Bitbucket Cloud provider + universal PR-body trailers fallback
+
+Closes the "Bitbucket support" item on the v1.0 readiness list, plus a defensive recovery mechanism that benefits every provider.
+
+## Goals
+
+1. Add a fourth provider (`bitbucket`) so monorel covers the canonical Cloud SCMs: GitHub, Gitea / Forgejo, GitLab, Bitbucket.
+2. Defend the release pipeline against squash-merge stripping `monorel-Release:` trailers from the commit body. `monorel preview --upsert` writes a redundant trailers block to the PR body as an HTML comment; `monorel tag` falls back to it when the commit body is empty.
+
+## Non-goals
+
+- Bitbucket Data Center / Server. Different REST API; out of scope. Layout reserves room for a future `bitbucket/datacenter/` sibling.
+- Bitbucket Cloud's no-native-releases gap. `CreateRelease` is a no-op with a log line; the per-package `CHANGELOG.md` carries release notes.
+- Switching the existing providers' SDK choices. github / gitea / gitlab keep their official SDKs.
+
+## Decisions
+
+| # | Decision | Picked |
+|---|---|---|
+| 1 | Cloud-only with layout-ready directory structure for future Data Center | Approved |
+| 2 | `CreateRelease` policy on Bitbucket | No-op + log line; CHANGELOG.md is the canonical source |
+| 3 | Merge-strategy guidance | Allow fast-forward and merge-commit; reject squash. Plus universal trailers fallback (squash safety net) |
+| 4 | Auth surface | Two env vars: `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN`. Username probed via `GET /2.0/user` and cached |
+| 5 | API client | Hand-rolled `net/http`; zero new direct deps |
+| 6 | Scope | Approach 2: Bitbucket provider + universal trailers fallback in one PR |
+
+## Architecture
+
+```
+internal/provider/bitbucket/
+├── bitbucket.go              Public package facade. New(ctx, Options) (*Client, error).
+├── client.go                 net/http transport + auth header construction + JSON marshal helpers.
+├── pulls.go                  PR ops: FindOpenReleasePR, CreatePR, UpdatePR, ClosePR.
+├── repo.go                   GetDefaultBranch.
+├── release.go                CreateRelease: no-op returning a synthetic *Release pointing at /src/<tag>.
+├── identity.go               /2.0/user probe; caches email + username on the Client.
+├── trailers.go               FindPRByMergeCommit (used by the universal fallback).
+├── errors.go                 Sentinel errors (ErrPlanGate, ErrRateLimited).
+├── bitbucket_test.go         Unit tests against httptest fakes.
+├── integration_test.go       //go:build integration; gated end-to-end against a real Bitbucket workspace.
+└── doc.go                    Package overview.
+```
+
+Cross-package additions (universal trailers fallback):
+
+- `internal/provider/provider.go`: new `Client` method `FindPRByMergeCommit(ctx, sha) (*PullRequest, error)`. Implemented by all four providers.
+- `internal/release/render.go` (or equivalent): append the trailers HTML comment block to the rendered PR body in `monorel preview`.
+- `internal/release/release.go`'s `Tag`: on `ErrNoReleaseCommit`, fall back to looking up the merged PR via `client.FindPRByMergeCommit(headSHA)`, parse trailers from the PR body's comment block.
+
+Wiring:
+
+- `config/provider.go`: add `ProviderBitbucket = "bitbucket"` constant; add to `KnownProviders`.
+- `internal/provider/factory/factory.go`: add `case config.ProviderBitbucket` arm.
+- `internal/provider/provider.go`'s `TokenEnvVars(provider)` returns `["BITBUCKET_TOKEN"]`. New parallel `EmailEnvVars(provider)` returns `["BITBUCKET_EMAIL"]` (or empty for providers that don't need a separate email).
+
+## Components and contracts
+
+### `bitbucket.Options`
+
+```go
+type Options struct {
+    Workspace string  // owner field from monorel.toml
+    Repo      string
+    Host      string  // unused for now (Cloud only); validated empty
+    Email     string  // from BITBUCKET_EMAIL env
+    Token     string  // from BITBUCKET_TOKEN env
+}
+```
+
+Constructor errors when `Email` or `Token` is empty. `Host` non-empty is rejected with a clear error pointing at the future Data Center extension path.
+
+### REST endpoint map
+
+| Interface method | HTTP |
+|---|---|
+| `GetDefaultBranch` | `GET /2.0/repositories/{ws}/{repo}` -> `mainbranch.name` |
+| `FindOpenReleasePR(headBranch)` | `GET /2.0/repositories/{ws}/{repo}/pullrequests?q=state="OPEN" AND source.branch.name="<branch>"` |
+| `CreatePR` | `POST /2.0/repositories/{ws}/{repo}/pullrequests` (JSON body) |
+| `UpdatePR` | `PUT /2.0/repositories/{ws}/{repo}/pullrequests/{id}` (JSON body) |
+| `ClosePR` | `POST /2.0/repositories/{ws}/{repo}/pullrequests/{id}/decline` |
+| `CreateRelease` | no-op; returns `&Release{Tag, HTMLURL: ".../src/{tag}"}` plus an INFO log per call |
+| `FindPRByMergeCommit(sha)` | `GET /2.0/repositories/{ws}/{repo}/pullrequests?q=state="MERGED" AND merge_commit.hash="<sha>"` |
+
+### State mapping
+
+Bitbucket PR states are `OPEN` / `MERGED` / `DECLINED` / `SUPERSEDED`. Provider-interface `PullRequest.State` is `"open"` / `"closed"`. Map `OPEN` to `"open"`; everything else to `"closed"`.
+
+### Error sentinels (`errors.go`)
+
+```go
+var ErrPlanGate    = errors.New("bitbucket: workspace plan not configured (visit bitbucket.org/<workspace>/workspace/settings/plans)")
+var ErrRateLimited = errors.New("bitbucket: rate limited (HTTP 429); retry after a short delay")
+```
+
+402 surfaces from the orchestrator's `git push` step (not the REST client) but is covered for completeness on REST too.
+
+## Data flow
+
+### Auth on the wire
+
+- REST: `Authorization: Basic <base64(email:token)>` on every call.
+- Git over HTTPS: the orchestrator builds clone/push URLs. For Bitbucket, the URL needs `<username>:<token>@bitbucket.org/...`. Provider clients gain a `GitCredentials() (username, token string, err error)` method:
+  - github / gitea / gitlab return `(token, "")` (single bearer-equivalent).
+  - bitbucket returns the probed username + token.
+
+The orchestrator queries the provider client for git credentials rather than re-implementing per-provider URL construction.
+
+### Username probe
+
+1. Constructor stores email, token, workspace, repo. No network calls.
+2. On the first call to any method that needs the username (`GitCredentials`, or any REST call), the client calls `GET /2.0/user`, parses, caches `username`. A `sync.Once` guards against concurrent first-call double-probes.
+3. If the probe fails, the original method returns the probe error.
+4. Subsequent calls reuse the cached value.
+
+### Universal trailers fallback (Approach 2)
+
+Write side - `monorel preview --upsert` appends to the rendered PR body:
+
+```
+<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)
+monorel-Release: transports/foo v1.7.0
+monorel-Release: go.example.com/widget v2.0.1
+monorel-PreRelease: false
+-->
+```
+
+HTML comments are invisible in the rendered PR body but persist in the source. All four providers preserve them on PR-body fetches.
+
+Read side - `monorel tag`:
+
+1. Read HEAD's commit message; parse `monorel-Release:` trailers (existing behavior).
+2. If trailers found: proceed as today.
+3. If no trailers found: compute HEAD's SHA. Call `client.FindPRByMergeCommit(sha)`. Parse trailers from the returned PR body's `monorel-trailers` comment block.
+4. If neither HEAD body nor PR body has trailers: return a wrapped `ErrNoReleaseCommit` with an actionable message.
+
+## Error handling
+
+| Source | Status | Sentinel / wrap |
+|---|---|---|
+| Auth bad | 401 | `bitbucket: auth failed (check BITBUCKET_EMAIL + BITBUCKET_TOKEN); verify the token has Bitbucket scopes` |
+| Auth scope insufficient | 403 | `bitbucket: forbidden; the token is missing a scope. Required: read/write repository, read/write pullrequest` |
+| Repo not found | 404 | `bitbucket: repo %q not found in workspace %q (or you lack access)` |
+| Workspace plan gate | 402 | `ErrPlanGate` (sentinel; message includes settings URL) |
+| Validation | 400 | wrap response body's `error.message` |
+| Rate limit | 429 | `ErrRateLimited` |
+| Server | 5xx | `bitbucket: server error %d: %s` |
+| Network | n/a | passthrough from `net/http`'s error |
+
+`FindOpenReleasePR` and `FindPRByMergeCommit` return `(nil, nil)` for "no such PR." `CreateRelease` returns `(*Release, nil)` always (no-op success).
+
+`monorel tag`'s fallback failure message:
+
+> release: HEAD has no monorel-Release: trailers and the merged PR (#42) body also lacks the monorel-trailers comment block. The squash-merge probably rewrote both, OR a contributor edited the PR body. Recover by:
+>
+> - re-running monorel preview against this PR's source state, or
+> - hand-creating tags: `git tag -a <prefix>/v<X.Y.Z> <merge-sha> -m "..."` for each package the PR was supposed to bump.
+
+## Testing
+
+### Unit tests
+
+- `internal/provider/bitbucket/bitbucket_test.go`: each REST method against an `httptest.NewServer` fake. Verifies request URL, query, body JSON, and parsed response.
+- Auth probe tests: success path (cache populated), 401 surfacing, concurrent-first-call locking under `t.Parallel`.
+- Error-mapping tests per status code (401 / 403 / 402 / 429 / 500).
+
+### Integration tests (build-tag gated)
+
+- `internal/provider/bitbucket/integration_test.go` with `//go:build integration`.
+- Runs only when `BITBUCKET_INTEGRATION=1` + `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN` are set, plus `BITBUCKET_WORKSPACE` for the target workspace.
+- Walks the API: create repo, push initial branch + a feature branch + a tag, list PRs, create PR, find by head ref, update PR title, decline PR, delete repo.
+
+### Cross-provider tests for the trailers fallback
+
+- `internal/release/tag_test.go` (or equivalent): cases for read-from-PR-body fallback success, both-missing failure path.
+- Each existing provider (github, gitea, gitlab) gets a `FindPRByMergeCommit` test against an httptest fake to confirm correct query construction.
+
+## Documentation
+
+- `docs/src/integrations/bitbucket.md` (new): setup walkthrough, auth (two env vars), merge-strategy requirement, plan-gate troubleshooting, no-native-releases note.
+- `examples/bitbucket/`: `monorel.toml` + `bitbucket-pipelines.yml` (their CI format).
+- `docs/src/_partials/bitbucket-pipelines-yml.md` (new): the pipelines snippet.
+- `docs/.vitepress/config.ts`: add Bitbucket to the Integrations sidebar.
+- `docs/src/cheat-sheet.md`: extend the env-vars table with `BITBUCKET_EMAIL` + `BITBUCKET_TOKEN`.
+- `docs/src/public/llms.txt` and `docs/src/public/llms-full.txt`: add Bitbucket to provider tables.
+- `docs/src/introduction.md`'s "At a glance" comparison table: extend if Bitbucket adds a row-distinguishing capability (probably none).
+- `README.md`: list Bitbucket alongside the other providers.
+- `docs/src/faq.md`: amend the squash-merge / tag-recovery entry to mention the trailers fallback.
+- `.changeset/bitbucket-provider.md`: `:minor` bump.
+
+## Risks and mitigation
+
+- **Bitbucket changes the `/2.0/user` endpoint or its scope requirements.** Probe failure surfaces immediately with a clear error pointing at scopes. Doc note in the integration page lists the required scopes verbatim. Hand-rolled client makes the probe call easy to update.
+- **HTML comment in PR body gets edited away by a contributor.** `monorel tag` falls back to a clear error message naming the PR and listing recovery steps. The damage is bounded: only when commit body trailers are ALSO missing (i.e. squash-merged AND PR body edited).
+- **402 plan-gate confuses users.** The integration page walks through the one-time plan-acceptance step explicitly. The provider's wrapped error includes the URL to visit.
+- **Atlassian eventually launches first-class Bitbucket Cloud releases.** When that happens, `CreateRelease`'s no-op gets replaced with a real implementation. Backward-compatible (the existing `Release{Tag, HTMLURL}` shape works for both).
+- **The trailers fallback breaks an existing provider's tag flow.** The fallback only fires on `ErrNoReleaseCommit` from the existing path; today the existing path covers fast-forward / merge-commit / no-rebase merges fine. Defensive only.
+
+## Effort
+
+- Bitbucket package: ~1 day (hand-rolled HTTP client, 7 endpoints, error mapping, identity probe).
+- Universal trailers fallback: ~0.5 day (4 provider implementations of `FindPRByMergeCommit`, render side, `Tag` fallback path, tests).
+- Documentation sweep: ~0.5 day.
+- Total: ~2 days focused work.

--- a/examples/bitbucket/.changeset/README.md
+++ b/examples/bitbucket/.changeset/README.md
@@ -1,0 +1,15 @@
+# Changesets
+
+This directory holds pending release intents for [monorel](https://monorel.disaresta.com).
+
+A `.changeset/<name>.md` file declares which packages should release at what bump level when the next release lands, plus the changelog body to use for each release.
+
+```markdown
+---
+"<package-name>": minor
+---
+
+What changed and why.
+```
+
+Run `monorel add` for the interactive flow, or write the file directly. See [the docs](https://monorel.disaresta.com/changesets) for details.

--- a/examples/bitbucket/README.md
+++ b/examples/bitbucket/README.md
@@ -1,0 +1,23 @@
+# Bitbucket example
+
+Minimal monorel setup for a Bitbucket Cloud-hosted project with two packages (root + one sub-module under `transports/foo/`). Uses Bitbucket Pipelines with the published Docker image (`ghcr.io/disaresta-org/monorel`).
+
+```
+bitbucket/
+├── monorel.toml
+├── .changeset/README.md
+└── bitbucket-pipelines.yml
+```
+
+Copy these files into your repo, replace `your-workspace` / `your-repo` with your workspace slug and repo slug, then:
+
+1. Generate an Atlassian API token **with Bitbucket scopes** at [`id.atlassian.com/manage-profile/security/api-tokens`](https://id.atlassian.com/manage-profile/security/api-tokens) (the plain "Create API token" button generates a token without Bitbucket scopes; use **Create API token with scopes** instead). Required scopes: `read:repository:bitbucket`, `write:repository:bitbucket`, `read:pullrequest:bitbucket`, `write:pullrequest:bitbucket`, `read:account`.
+2. Add the token as `BITBUCKET_TOKEN` and your Bitbucket username as `BB_USER` under Repository settings → Repository variables. Both are referenced by the pipeline's git-push command.
+3. **Accept the workspace plan** at `https://bitbucket.org/<workspace>/workspace/settings/plans` if you haven't already. Workspaces created or migrated since September 2024 require this one-time acceptance step or every push will return HTTP 402 Payment Required.
+4. Push `bitbucket-pipelines.yml` to your default branch.
+
+The single pipeline branches on whether the just-landed commit is a `chore(release):` merge: non-release commits run `monorel apply` + `monorel preview --upsert` to maintain the always-open release PR; release commits run `monorel tag` + `git push --follow-tags` + `monorel publish`.
+
+Bitbucket Cloud has no first-class Release concept, so `monorel publish` is a no-op on Bitbucket; per-package `CHANGELOG.md` is the canonical release-notes source.
+
+See [Getting Started](https://monorel.disaresta.com/getting-started) and the [Bitbucket integration page](https://monorel.disaresta.com/integrations/bitbucket) for the full walkthrough.

--- a/examples/bitbucket/bitbucket-pipelines.yml
+++ b/examples/bitbucket/bitbucket-pipelines.yml
@@ -1,5 +1,5 @@
 # bitbucket-pipelines.yml
-image: ghcr.io/disaresta-org/monorel:0.13.0
+image: ghcr.io/disaresta-org/monorel:0.14.0
 
 pipelines:
   branches:

--- a/examples/bitbucket/bitbucket-pipelines.yml
+++ b/examples/bitbucket/bitbucket-pipelines.yml
@@ -11,16 +11,24 @@ pipelines:
             - export GIT_AUTHOR_EMAIL="monorel-bot@users.noreply.example.com"
             - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
             - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
-            - if echo "$BITBUCKET_COMMIT_MESSAGE" | grep -q "^chore(release):"; then
+            # Detect release-merge commits by scanning the FULL commit
+            # message (subject + body) for the chore(release): trailer
+            # marker. Bitbucket's merge strategies replace the source
+            # subject with `Merged in <branch> (pull request #N)`, so a
+            # subject-only check would never match. Both squash and
+            # merge_commit preserve the source subject as a body line.
+            - HEAD_MSG=$(git log -1 --format=%B)
+            - if echo "$HEAD_MSG" | grep -qE '(^|\n)chore\(release\):'; then
                 monorel tag &&
                 git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
                 monorel publish;
               else
                 git fetch origin "$BITBUCKET_BRANCH" &&
-                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH" &&
+                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH";
                 apply_out=$(monorel apply); echo "$apply_out";
                 if ! echo "$apply_out" | grep -qF "Nothing to apply."; then
-                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release &&
-                  monorel preview --upsert;
+                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release;
                 fi;
+                git checkout "$BITBUCKET_BRANCH" &&
+                monorel preview --upsert;
               fi

--- a/examples/bitbucket/bitbucket-pipelines.yml
+++ b/examples/bitbucket/bitbucket-pipelines.yml
@@ -1,0 +1,26 @@
+# bitbucket-pipelines.yml
+image: ghcr.io/disaresta-org/monorel:0.13.0
+
+pipelines:
+  branches:
+    main:
+      - step:
+          name: monorel
+          script:
+            - export GIT_AUTHOR_NAME="monorel-bot[automation]"
+            - export GIT_AUTHOR_EMAIL="monorel-bot@users.noreply.example.com"
+            - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+            - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+            - if echo "$BITBUCKET_COMMIT_MESSAGE" | grep -q "^chore(release):"; then
+                monorel tag &&
+                git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
+                monorel publish;
+              else
+                git fetch origin "$BITBUCKET_BRANCH" &&
+                git checkout -B monorel/release "origin/$BITBUCKET_BRANCH" &&
+                apply_out=$(monorel apply); echo "$apply_out";
+                if ! echo "$apply_out" | grep -qF "Nothing to apply."; then
+                  git push -f "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" monorel/release &&
+                  monorel preview --upsert;
+                fi;
+              fi

--- a/examples/bitbucket/monorel.toml
+++ b/examples/bitbucket/monorel.toml
@@ -1,0 +1,16 @@
+# monorel configuration. See https://monorel.disaresta.com/configuration
+
+[provider]
+name  = "bitbucket"
+owner = "your-workspace"   # bitbucket workspace slug
+repo  = "your-repo"
+
+[packages."your-repo"]
+tag_prefix = ""
+path       = "."
+changelog  = "CHANGELOG.md"
+
+[packages."transports/foo"]
+tag_prefix = "transports/foo"
+path       = "transports/foo"
+changelog  = "transports/foo/CHANGELOG.md"

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -386,7 +386,7 @@ func TestDoInit_RejectsUnknownProvider(t *testing.T) {
 	writeMod(t, dir, "go.mod", "module example.com/foo\n")
 	err := doInit(loglayer.NewMock(), initOptions{
 		dir:      dir,
-		provider: "bitbucket", // not in KnownProviders today.
+		provider: "sourcehut", // not in KnownProviders.
 		owner:    "acme",
 		repo:     "widget",
 	})

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -1,10 +1,14 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
+	"monorel.disaresta.com/config"
+	"monorel.disaresta.com/internal/provider"
+	"monorel.disaresta.com/internal/provider/factory"
 	"monorel.disaresta.com/internal/release"
 )
 
@@ -44,9 +48,28 @@ func runTag(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// Build a provider client when the auth token is in the
+	// environment. The provider is only used for the universal PR-body
+	// trailers fallback (when HEAD's commit message has no trailers,
+	// e.g. squash-merge rewrote it). Tag works without a provider in
+	// the common case; we only need it for recovery.
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var providerClient provider.Client
+	providerName := config.ResolveProvider(rt.Config.Provider.Name)
+	if token := provider.TokenFromEnv(providerName); token != "" {
+		providerClient, err = factory.New(ctx, rt.Config.Provider, token)
+		if err != nil {
+			return fmt.Errorf("provider client: %w", err)
+		}
+	}
+
 	res, err := release.Tag(release.TagOptions{
-		Config: rt.Config,
-		Repo:   rt.Repo,
+		Config:   rt.Config,
+		Repo:     rt.Repo,
+		Provider: providerClient,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/tag.go
+++ b/internal/cli/tag.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -72,6 +74,16 @@ func runTag(cmd *cobra.Command, _ []string) error {
 		Provider: providerClient,
 	})
 	if err != nil {
+		// When the trailers are missing AND no provider client was
+		// built (no token in env), the PR-body fallback couldn't even
+		// be tried. Hint the operator at the env var that would
+		// enable it; advisory only, the exit code stays the same.
+		if errors.Is(err, release.ErrNoReleaseCommit) && providerClient == nil {
+			if envVars := provider.TokenEnvVars(providerName); len(envVars) > 0 {
+				rt.Log.Warn("Tip: set %s to enable the PR-body trailers fallback (covers squash-merged release PRs).",
+					strings.Join(envVars, " or "))
+			}
+		}
 		return err
 	}
 

--- a/internal/provider/bitbucket/bitbucket.go
+++ b/internal/provider/bitbucket/bitbucket.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"monorel.disaresta.com/internal/provider"
 )
 
 // Options configures a new Bitbucket Cloud-backed [provider.Client].
@@ -47,17 +49,11 @@ var ErrMissingToken = errors.New("bitbucket: Token is required")
 // supported.
 var ErrHostNotSupported = errors.New("bitbucket: Host must be empty (Cloud-only); Data Center support is not implemented")
 
-// New returns a Bitbucket Cloud REST API v2 client. Does NOT make a
-// network call: the first request fires when one of the Client
-// methods is invoked, including the lazy /2.0/user probe that
+// New returns a Bitbucket Cloud REST API v2 [provider.Client]. Does
+// NOT make a network call: the first request fires when one of the
+// Client methods is invoked, including the lazy /2.0/user probe that
 // resolves the auth username for git credentials.
-//
-// The return type is the unexported *client during Phase 2 of the
-// build-out. It will be widened to [provider.Client] once the full
-// interface (GetDefaultBranch, FindOpenReleasePR, CreatePR,
-// UpdatePR, ClosePR, CreateRelease, FindPRByMergeCommit) is
-// implemented in Phase 3.
-func New(_ context.Context, opts Options) (*client, error) {
+func New(_ context.Context, opts Options) (provider.Client, error) {
 	if opts.Workspace == "" || opts.Repo == "" {
 		return nil, ErrMissingWorkspaceRepo
 	}
@@ -95,9 +91,8 @@ type client struct {
 	http *http.Client
 
 	// Identity-probe state. Lazily populated on first call needing
-	// the username. Wired in Phase 3 (identity.go); declared here so
-	// Phase 2 ships the full client shape.
-	identityOnce sync.Once //lint:ignore U1000 wired by identity.go in Phase 3
-	username     string    //lint:ignore U1000 wired by identity.go in Phase 3
-	identityErr  error     //lint:ignore U1000 wired by identity.go in Phase 3
+	// the username; see resolveUsername in identity.go.
+	identityOnce sync.Once
+	username     string
+	identityErr  error
 }

--- a/internal/provider/bitbucket/bitbucket.go
+++ b/internal/provider/bitbucket/bitbucket.go
@@ -1,0 +1,103 @@
+package bitbucket
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Options configures a new Bitbucket Cloud-backed [provider.Client].
+type Options struct {
+	// Workspace is the bitbucket workspace slug (the part of the URL
+	// like bitbucket.org/<workspace>/<repo>). Mirrors the `owner`
+	// field from monorel.toml.
+	Workspace string
+
+	// Repo is the repository slug.
+	Repo string
+
+	// Host must be empty (Cloud-only). Non-empty is rejected with an
+	// error pointing at the future Data Center extension path.
+	Host string
+
+	// Email is the Atlassian-account email. Required for REST auth
+	// (HTTP Basic with email + token).
+	Email string
+
+	// Token is an Atlassian API token with Bitbucket scopes
+	// (read/write:repository:bitbucket and
+	// read/write:pullrequest:bitbucket).
+	Token string
+}
+
+// ErrMissingWorkspaceRepo is returned when Options doesn't carry both
+// a workspace and a repo.
+var ErrMissingWorkspaceRepo = errors.New("bitbucket: Workspace and Repo are required")
+
+// ErrMissingEmail is returned when Options.Email is empty.
+var ErrMissingEmail = errors.New("bitbucket: Email is required (REST auth uses HTTP Basic with email + token)")
+
+// ErrMissingToken is returned when Options.Token is empty.
+var ErrMissingToken = errors.New("bitbucket: Token is required")
+
+// ErrHostNotSupported is returned when Options.Host is non-empty.
+// Bitbucket Data Center / Server is not implemented; only Cloud is
+// supported.
+var ErrHostNotSupported = errors.New("bitbucket: Host must be empty (Cloud-only); Data Center support is not implemented")
+
+// New returns a Bitbucket Cloud REST API v2 client. Does NOT make a
+// network call: the first request fires when one of the Client
+// methods is invoked, including the lazy /2.0/user probe that
+// resolves the auth username for git credentials.
+//
+// The return type is the unexported *client during Phase 2 of the
+// build-out. It will be widened to [provider.Client] once the full
+// interface (GetDefaultBranch, FindOpenReleasePR, CreatePR,
+// UpdatePR, ClosePR, CreateRelease, FindPRByMergeCommit) is
+// implemented in Phase 3.
+func New(_ context.Context, opts Options) (*client, error) {
+	if opts.Workspace == "" || opts.Repo == "" {
+		return nil, ErrMissingWorkspaceRepo
+	}
+	if opts.Email == "" {
+		return nil, ErrMissingEmail
+	}
+	if opts.Token == "" {
+		return nil, ErrMissingToken
+	}
+	if opts.Host != "" {
+		return nil, ErrHostNotSupported
+	}
+	return &client{
+		workspace: opts.Workspace,
+		repo:      opts.Repo,
+		email:     opts.Email,
+		token:     opts.Token,
+		baseURL:   "https://api.bitbucket.org/2.0",
+		http: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+// client is the unexported provider.Client implementation. Public
+// surface is the Options + New constructor only.
+type client struct {
+	workspace string
+	repo      string
+	email     string
+	token     string
+
+	baseURL string
+
+	http *http.Client
+
+	// Identity-probe state. Lazily populated on first call needing
+	// the username. Wired in Phase 3 (identity.go); declared here so
+	// Phase 2 ships the full client shape.
+	identityOnce sync.Once //lint:ignore U1000 wired by identity.go in Phase 3
+	username     string    //lint:ignore U1000 wired by identity.go in Phase 3
+	identityErr  error     //lint:ignore U1000 wired by identity.go in Phase 3
+}

--- a/internal/provider/bitbucket/bitbucket_test.go
+++ b/internal/provider/bitbucket/bitbucket_test.go
@@ -1,0 +1,125 @@
+package bitbucket
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNew_RejectsMissingEmail(t *testing.T) {
+	_, err := New(context.Background(), Options{Workspace: "ws", Repo: "r", Token: "t"})
+	if err == nil {
+		t.Fatal("expected error for missing email")
+	}
+}
+
+func TestNew_RejectsMissingToken(t *testing.T) {
+	_, err := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com"})
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+}
+
+func TestNew_RejectsMissingWorkspaceOrRepo(t *testing.T) {
+	for _, tc := range []Options{
+		{Repo: "r", Email: "e@x.com", Token: "t"},
+		{Workspace: "ws", Email: "e@x.com", Token: "t"},
+	} {
+		if _, err := New(context.Background(), tc); err == nil {
+			t.Errorf("expected error for %+v", tc)
+		}
+	}
+}
+
+func TestNew_RejectsNonEmptyHost(t *testing.T) {
+	_, err := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r", Host: "self-hosted",
+		Email: "e@x.com", Token: "t",
+	})
+	if err == nil {
+		t.Fatal("expected error for non-empty Host (Cloud-only)")
+	}
+}
+
+func TestNew_HappyPath(t *testing.T) {
+	c, err := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r",
+		Email: "e@x.com", Token: "t",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestClient_AuthHeader(t *testing.T) {
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c, err := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r",
+		Email: "e@x.com", Token: "tok",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.baseURL = srv.URL
+
+	if _, err := c.do(context.Background(), "GET", "/some-path", nil, nil); err != nil {
+		t.Fatalf("do: %v", err)
+	}
+
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("e@x.com:tok"))
+	if seen != want {
+		t.Errorf("Authorization header = %q, want %q", seen, want)
+	}
+}
+
+func TestClient_DoMapsStatus(t *testing.T) {
+	cases := []struct {
+		status int
+		body   string
+		want   string // substring of err message
+	}{
+		{401, `{"error":{"message":"unauth"}}`, "auth failed"},
+		{403, `{"error":{"message":"no scope"}}`, "forbidden"},
+		{404, `{"error":{"message":"missing"}}`, "not found"},
+		{402, `{"error":{"message":"plan"}}`, "plan not configured"},
+		{429, `{"error":{"message":"slow down"}}`, "rate limited"},
+		{500, `{"error":{"message":"oops"}}`, "server error"},
+		{400, `{"error":{"message":"bad input"}}`, "bad input"},
+	}
+	for _, tc := range cases {
+		t.Run(strings.TrimSpace(tc.want), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c, _ := New(context.Background(), Options{
+				Workspace: "ws", Repo: "r",
+				Email: "e@x.com", Token: "tok",
+			})
+			c.baseURL = srv.URL
+
+			_, err := c.do(context.Background(), "GET", "/x", nil, nil)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q, want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/bitbucket/bitbucket_test.go
+++ b/internal/provider/bitbucket/bitbucket_test.go
@@ -3,6 +3,7 @@ package bitbucket
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,26 +12,33 @@ import (
 
 func TestNew_RejectsMissingEmail(t *testing.T) {
 	_, err := New(context.Background(), Options{Workspace: "ws", Repo: "r", Token: "t"})
-	if err == nil {
-		t.Fatal("expected error for missing email")
+	if !errors.Is(err, ErrMissingEmail) {
+		t.Fatalf("err = %v, want ErrMissingEmail", err)
 	}
 }
 
 func TestNew_RejectsMissingToken(t *testing.T) {
 	_, err := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com"})
-	if err == nil {
-		t.Fatal("expected error for missing token")
+	if !errors.Is(err, ErrMissingToken) {
+		t.Fatalf("err = %v, want ErrMissingToken", err)
 	}
 }
 
 func TestNew_RejectsMissingWorkspaceOrRepo(t *testing.T) {
-	for _, tc := range []Options{
-		{Repo: "r", Email: "e@x.com", Token: "t"},
-		{Workspace: "ws", Email: "e@x.com", Token: "t"},
-	} {
-		if _, err := New(context.Background(), tc); err == nil {
-			t.Errorf("expected error for %+v", tc)
-		}
+	cases := []struct {
+		name string
+		opts Options
+	}{
+		{"missing-workspace", Options{Repo: "r", Email: "e@x.com", Token: "t"}},
+		{"missing-repo", Options{Workspace: "ws", Email: "e@x.com", Token: "t"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := New(context.Background(), tc.opts)
+			if !errors.Is(err, ErrMissingWorkspaceRepo) {
+				t.Errorf("err = %v, want ErrMissingWorkspaceRepo", err)
+			}
+		})
 	}
 }
 
@@ -39,8 +47,8 @@ func TestNew_RejectsNonEmptyHost(t *testing.T) {
 		Workspace: "ws", Repo: "r", Host: "self-hosted",
 		Email: "e@x.com", Token: "t",
 	})
-	if err == nil {
-		t.Fatal("expected error for non-empty Host (Cloud-only)")
+	if !errors.Is(err, ErrHostNotSupported) {
+		t.Fatalf("err = %v, want ErrHostNotSupported", err)
 	}
 }
 

--- a/internal/provider/bitbucket/bitbucket_test.go
+++ b/internal/provider/bitbucket/bitbucket_test.go
@@ -3,11 +3,15 @@ package bitbucket
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"monorel.disaresta.com/internal/provider"
 )
 
 func TestNew_RejectsMissingEmail(t *testing.T) {
@@ -81,9 +85,10 @@ func TestClient_AuthHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.baseURL = srv.URL
+	bc := c.(*client)
+	bc.baseURL = srv.URL
 
-	if _, err := c.do(context.Background(), "GET", "/some-path", nil, nil); err != nil {
+	if _, err := bc.do(context.Background(), "GET", "/some-path", nil, nil); err != nil {
 		t.Fatalf("do: %v", err)
 	}
 
@@ -119,9 +124,10 @@ func TestClient_DoMapsStatus(t *testing.T) {
 				Workspace: "ws", Repo: "r",
 				Email: "e@x.com", Token: "tok",
 			})
-			c.baseURL = srv.URL
+			bc := c.(*client)
+			bc.baseURL = srv.URL
 
-			_, err := c.do(context.Background(), "GET", "/x", nil, nil)
+			_, err := bc.do(context.Background(), "GET", "/x", nil, nil)
 			if err == nil {
 				t.Fatal("expected error")
 			}
@@ -129,5 +135,331 @@ func TestClient_DoMapsStatus(t *testing.T) {
 				t.Errorf("err = %q, want substring %q", err.Error(), tc.want)
 			}
 		})
+	}
+}
+
+func TestIdentityProbe_CachesUsername(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/user" {
+			calls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintln(w, `{"username":"theo-bb","display_name":"Theo","uuid":"{abc}"}`)
+			return
+		}
+		t.Errorf("unexpected path %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r",
+		Email: "e@x.com", Token: "tok",
+	})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := bc.resolveUsername(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "theo-bb" {
+		t.Errorf("got %q, want theo-bb", got)
+	}
+
+	// Call again; should hit the cache, not the server.
+	if _, err := bc.resolveUsername(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 probe call, got %d", calls)
+	}
+}
+
+func TestIdentityProbe_SurfacesAuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(401)
+		fmt.Fprintln(w, `{"error":{"message":"bad creds"}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r",
+		Email: "e@x.com", Token: "tok",
+	})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	_, err := bc.resolveUsername(context.Background())
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	if !strings.Contains(err.Error(), "auth failed") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestGetDefaultBranch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repositories/ws/r" {
+			t.Errorf("path = %s, want /repositories/ws/r", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"mainbranch":{"name":"master","type":"branch"}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t",
+	})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.GetDefaultBranch(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "master" {
+		t.Errorf("got %q, want master", got)
+	}
+}
+
+func TestGetDefaultBranch_EmptyMainbranch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{
+		Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t",
+	})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	_, err := c.GetDefaultBranch(context.Background())
+	if err == nil {
+		t.Fatal("expected error for missing mainbranch")
+	}
+}
+
+func TestFindOpenReleasePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.URL.Query().Get("q")
+		want := `state="OPEN" AND source.branch.name="monorel/release"`
+		if got != want {
+			t.Errorf("q = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"values":[{
+			"id": 7,
+			"state": "OPEN",
+			"title": "release",
+			"summary":{"raw":"body"},
+			"source":{"branch":{"name":"monorel/release"}},
+			"merge_commit":null,
+			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/7"}}
+		}]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.FindOpenReleasePR(context.Background(), "monorel/release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Number != 7 || got.State != "open" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestFindOpenReleasePR_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"values":[]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.FindOpenReleasePR(context.Background(), "monorel/release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}
+
+func TestCreatePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		var body struct {
+			Title       string `json:"title"`
+			Description string `json:"description"`
+			Source      struct {
+				Branch struct {
+					Name string `json:"name"`
+				} `json:"branch"`
+			} `json:"source"`
+			Destination struct {
+				Branch struct {
+					Name string `json:"name"`
+				} `json:"branch"`
+			} `json:"destination"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Title != "release" || body.Source.Branch.Name != "monorel/release" || body.Destination.Branch.Name != "main" {
+			t.Errorf("body = %+v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{
+			"id": 7, "state":"OPEN", "title":"release", "summary":{"raw":"body"},
+			"source":{"branch":{"name":"monorel/release"}},
+			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/7"}}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.CreatePR(context.Background(), provider.CreatePROptions{
+		Title:      "release",
+		Body:       "body",
+		HeadBranch: "monorel/release",
+		BaseBranch: "main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Number != 7 {
+		t.Errorf("got #%d, want #7", got.Number)
+	}
+}
+
+func TestUpdatePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{
+			"id": 7, "state":"OPEN", "title":"new title", "summary":{"raw":"new body"},
+			"source":{"branch":{"name":"monorel/release"}},
+			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/7"}}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	title := "new title"
+	body := "new body"
+	got, err := c.UpdatePR(context.Background(), 7, provider.UpdatePROptions{Title: &title, Body: &body})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "new title" {
+		t.Errorf("got %q", got.Title)
+	}
+}
+
+func TestClosePR(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repositories/ws/r/pullrequests/7/decline" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(200)
+		fmt.Fprintln(w, `{"id":7,"state":"DECLINED"}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	if err := c.ClosePR(context.Background(), 7); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateRelease_NoOp(t *testing.T) {
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	rel, err := c.CreateRelease(context.Background(), provider.CreateReleaseOptions{
+		Tag:  "transports/foo/v1.7.0",
+		Name: "transports/foo v1.7.0",
+		Body: "release body",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rel == nil {
+		t.Fatal("expected non-nil release")
+	}
+	if rel.Tag != "transports/foo/v1.7.0" {
+		t.Errorf("Tag = %q", rel.Tag)
+	}
+	if !strings.Contains(rel.HTMLURL, "/src/transports/foo/v1.7.0") {
+		t.Errorf("HTMLURL = %q; want a /src/<tag> URL", rel.HTMLURL)
+	}
+}
+
+func TestFindPRByMergeCommit_Bitbucket(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got := r.URL.Query().Get("q")
+		want := `state="MERGED" AND merge_commit.hash="abc123"`
+		if got != want {
+			t.Errorf("q = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"values":[{
+			"id": 42, "state":"MERGED", "title":"release", "summary":{"raw":"body"},
+			"source":{"branch":{"name":"monorel/release"}},
+			"merge_commit":{"hash":"abc123"},
+			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/42"}}
+		}]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Number != 42 || got.MergedSHA != "abc123" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestFindPRByMergeCommit_Bitbucket_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `{"values":[]}`)
+	}))
+	defer srv.Close()
+
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	bc := c.(*client)
+	bc.baseURL = srv.URL
+
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil; got %+v", got)
 	}
 }

--- a/internal/provider/bitbucket/bitbucket_test.go
+++ b/internal/provider/bitbucket/bitbucket_test.go
@@ -270,7 +270,7 @@ func TestFindOpenReleasePR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got == nil || got.Number != 7 || got.State != "open" {
+	if got == nil || got.Number != 7 || got.State != "open" || got.MergedSHA != "" {
 		t.Errorf("got %+v", got)
 	}
 }
@@ -346,36 +346,85 @@ func TestCreatePR(t *testing.T) {
 }
 
 func TestUpdatePR(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "PUT" {
-			t.Errorf("method = %s, want PUT", r.Method)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `{
-			"id": 7, "state":"OPEN", "title":"new title", "summary":{"raw":"new body"},
-			"source":{"branch":{"name":"monorel/release"}},
-			"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/7"}}
-		}`)
-	}))
-	defer srv.Close()
-
-	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
-	bc := c.(*client)
-	bc.baseURL = srv.URL
-
-	title := "new title"
-	body := "new body"
-	got, err := c.UpdatePR(context.Background(), 7, provider.UpdatePROptions{Title: &title, Body: &body})
-	if err != nil {
-		t.Fatal(err)
+	cases := []struct {
+		name      string
+		opts      provider.UpdatePROptions
+		wantBody  bool
+		wantTitle bool
+	}{
+		{"both", makeUpdateOpts("new title", "new description"), true, true},
+		{"title-only", makeUpdateOptsTitleOnly("new title"), false, true},
+		{"body-only", makeUpdateOptsBodyOnly("new description"), true, false},
 	}
-	if got.Title != "new title" {
-		t.Errorf("got %q", got.Title)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "PUT" {
+					t.Errorf("method = %s, want PUT", r.Method)
+				}
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if tc.wantTitle {
+					if _, ok := body["title"]; !ok {
+						t.Error("expected title in patch")
+					}
+				} else if _, ok := body["title"]; ok {
+					t.Error("unexpected title in patch")
+				}
+				if tc.wantBody {
+					if _, ok := body["description"]; !ok {
+						t.Error("expected description in patch (Bitbucket field name)")
+					}
+					if _, ok := body["body"]; ok {
+						t.Error("patch should use description, not body")
+					}
+				} else if _, ok := body["description"]; ok {
+					t.Error("unexpected description in patch")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintln(w, `{
+					"id": 7, "state":"OPEN", "title":"x", "summary":{"raw":"x"},
+					"source":{"branch":{"name":"monorel/release"}},
+					"links":{"html":{"href":"https://bitbucket.org/ws/r/pull-requests/7"}}
+				}`)
+			}))
+			defer srv.Close()
+
+			c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+			bc := c.(*client)
+			bc.baseURL = srv.URL
+			if _, err := c.UpdatePR(context.Background(), 7, tc.opts); err != nil {
+				t.Fatalf("UpdatePR: %v", err)
+			}
+		})
+	}
+}
+
+func makeUpdateOpts(title, body string) provider.UpdatePROptions {
+	return provider.UpdatePROptions{Title: &title, Body: &body}
+}
+func makeUpdateOptsTitleOnly(title string) provider.UpdatePROptions {
+	return provider.UpdatePROptions{Title: &title}
+}
+func makeUpdateOptsBodyOnly(body string) provider.UpdatePROptions {
+	return provider.UpdatePROptions{Body: &body}
+}
+
+func TestUpdatePR_NothingToChange(t *testing.T) {
+	c, _ := New(context.Background(), Options{Workspace: "ws", Repo: "r", Email: "e@x.com", Token: "t"})
+	_, err := c.UpdatePR(context.Background(), 7, provider.UpdatePROptions{})
+	if err == nil {
+		t.Fatal("expected error when both Title and Body are nil")
 	}
 }
 
 func TestClosePR(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
 		if r.URL.Path != "/repositories/ws/r/pullrequests/7/decline" {
 			t.Errorf("path = %s", r.URL.Path)
 		}
@@ -439,7 +488,7 @@ func TestFindPRByMergeCommit_Bitbucket(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got == nil || got.Number != 42 || got.MergedSHA != "abc123" {
+	if got == nil || got.Number != 42 || got.State != "closed" || got.MergedSHA != "abc123" {
 		t.Errorf("got %+v", got)
 	}
 }

--- a/internal/provider/bitbucket/client.go
+++ b/internal/provider/bitbucket/client.go
@@ -57,8 +57,9 @@ func (c *client) do(ctx context.Context, method, path string, query url.Values, 
 	return resp, nil
 }
 
-// decodeJSON reads resp.Body, JSON-decodes into out, and closes the
-// body. Convenience for the common one-shot pattern.
+// decodeJSON closes resp.Body. If out is non-nil, it JSON-decodes
+// the body into out before closing. Convenience for the common
+// one-shot pattern.
 func decodeJSON(resp *http.Response, out any) error {
 	defer resp.Body.Close()
 	if out == nil {

--- a/internal/provider/bitbucket/client.go
+++ b/internal/provider/bitbucket/client.go
@@ -59,8 +59,6 @@ func (c *client) do(ctx context.Context, method, path string, query url.Values, 
 
 // decodeJSON reads resp.Body, JSON-decodes into out, and closes the
 // body. Convenience for the common one-shot pattern.
-//
-//lint:ignore U1000 used by Phase 3 REST methods
 func decodeJSON(resp *http.Response, out any) error {
 	defer resp.Body.Close()
 	if out == nil {
@@ -76,8 +74,6 @@ func decodeJSON(resp *http.Response, out any) error {
 // /repositories/<workspace>/<repo>. Includes URL-encoding of the
 // workspace and repo slugs (rare but possible if the slug contains
 // reserved characters).
-//
-//lint:ignore U1000 used by Phase 3 REST methods
 func (c *client) repoBase() string {
 	return "/repositories/" + url.PathEscape(c.workspace) + "/" + url.PathEscape(c.repo)
 }

--- a/internal/provider/bitbucket/client.go
+++ b/internal/provider/bitbucket/client.go
@@ -1,0 +1,83 @@
+package bitbucket
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// do issues an authenticated HTTP request and decodes the JSON
+// response body into out (if non-nil). Returns a wrapped error on
+// non-2xx, with status-code-specific messages for the common cases.
+//
+// path is the API path (e.g. "/repositories/ws/r"); the baseURL is
+// prepended. query is appended as URL-encoded parameters when
+// non-nil. body, when non-nil, is JSON-encoded and sent as the
+// request body with Content-Type: application/json.
+func (c *client) do(ctx context.Context, method, path string, query url.Values, body any) (*http.Response, error) {
+	full := c.baseURL + path
+	if len(query) > 0 {
+		full += "?" + query.Encode()
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		buf := new(bytes.Buffer)
+		if err := json.NewEncoder(buf).Encode(body); err != nil {
+			return nil, fmt.Errorf("bitbucket: marshal request body: %w", err)
+		}
+		bodyReader = buf
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, full, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("bitbucket: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(c.email+":"+c.token)))
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bitbucket: %s %s: %w", method, full, err)
+	}
+
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		respBytes, _ := io.ReadAll(resp.Body)
+		return nil, mapStatusError(resp.StatusCode, respBytes, c.workspace, c.repo)
+	}
+	return resp, nil
+}
+
+// decodeJSON reads resp.Body, JSON-decodes into out, and closes the
+// body. Convenience for the common one-shot pattern.
+//
+//lint:ignore U1000 used by Phase 3 REST methods
+func decodeJSON(resp *http.Response, out any) error {
+	defer resp.Body.Close()
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("bitbucket: decode response: %w", err)
+	}
+	return nil
+}
+
+// repoBase returns the API base path for the configured repo, e.g.
+// /repositories/<workspace>/<repo>. Includes URL-encoding of the
+// workspace and repo slugs (rare but possible if the slug contains
+// reserved characters).
+//
+//lint:ignore U1000 used by Phase 3 REST methods
+func (c *client) repoBase() string {
+	return "/repositories/" + url.PathEscape(c.workspace) + "/" + url.PathEscape(c.repo)
+}

--- a/internal/provider/bitbucket/doc.go
+++ b/internal/provider/bitbucket/doc.go
@@ -16,8 +16,11 @@
 //
 // Git over HTTPS uses a different identifier: <bitbucket-username>:<token>
 // (NOT email). The provider client probes /2.0/user on first call to
-// learn the username and caches it. Callers that need to construct
-// an HTTPS git URL ask for the username via the cached state.
+// learn the username (used internally to validate the token's
+// read:account scope at construction time) and caches it. External
+// shell wrappers that need to construct an HTTPS git URL set the
+// username themselves via a CI variable; today no exported accessor
+// surfaces the cached username outside the package.
 //
 // # Releases
 //

--- a/internal/provider/bitbucket/doc.go
+++ b/internal/provider/bitbucket/doc.go
@@ -1,0 +1,34 @@
+// Package bitbucket is the [provider.Client] implementation for
+// Bitbucket Cloud (bitbucket.org).
+//
+// Bitbucket Data Center / Server is out of scope; that variant uses
+// a different REST API (/rest/api/1.0/...) and a different auth
+// model. If support is added later, it should land under
+// internal/provider/bitbucket/datacenter/ as a sibling of the
+// current Cloud implementation.
+//
+// # Auth
+//
+// REST API: HTTP Basic with `email:token`. Both BITBUCKET_EMAIL and
+// BITBUCKET_TOKEN are required. The token must be an Atlassian API
+// token created with Bitbucket scopes:
+// read/write:repository:bitbucket and read/write:pullrequest:bitbucket.
+//
+// Git over HTTPS uses a different identifier: <bitbucket-username>:<token>
+// (NOT email). The provider client probes /2.0/user on first call to
+// learn the username and caches it. Callers that need to construct
+// an HTTPS git URL ask for the username via the cached state.
+//
+// # Releases
+//
+// Bitbucket Cloud has no first-class Release concept. CreateRelease
+// is a no-op that returns a synthetic *Release pointing at the tag's
+// /src/ URL. Per-package CHANGELOG.md is the canonical release-notes
+// source.
+//
+// # State mapping
+//
+// Bitbucket PR states are OPEN / MERGED / DECLINED / SUPERSEDED.
+// Provider-interface State is "open" / "closed". Map OPEN -> "open";
+// everything else -> "closed".
+package bitbucket

--- a/internal/provider/bitbucket/errors.go
+++ b/internal/provider/bitbucket/errors.go
@@ -24,7 +24,6 @@ var ErrRateLimited = errors.New("bitbucket: rate limited (HTTP 429); retry after
 
 // errorResponse is Bitbucket's error envelope shape.
 type errorResponse struct {
-	Type  string `json:"type"`
 	Error struct {
 		Message string `json:"message"`
 		Detail  string `json:"detail"`

--- a/internal/provider/bitbucket/errors.go
+++ b/internal/provider/bitbucket/errors.go
@@ -1,0 +1,77 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ErrPlanGate is returned when Bitbucket rejects an API or git
+// operation with HTTP 402 because the workspace plan isn't
+// configured. The user must accept a plan at
+// bitbucket.org/<workspace>/workspace/settings/plans before monorel
+// can push commits or call certain APIs.
+//
+// 402 is most commonly observed on git push (which monorel doesn't
+// invoke directly; the orchestrator's git layer surfaces it). The
+// REST client surfaces it for completeness.
+var ErrPlanGate = errors.New("bitbucket: workspace plan not configured (visit bitbucket.org/<workspace>/workspace/settings/plans)")
+
+// ErrRateLimited is returned when Bitbucket responds with HTTP 429.
+// Callers may retry after a short delay; the response's Retry-After
+// header is not yet parsed by this client.
+var ErrRateLimited = errors.New("bitbucket: rate limited (HTTP 429); retry after a short delay")
+
+// errorResponse is Bitbucket's error envelope shape.
+type errorResponse struct {
+	Type  string `json:"type"`
+	Error struct {
+		Message string `json:"message"`
+		Detail  string `json:"detail"`
+	} `json:"error"`
+}
+
+// mapStatusError converts an HTTP error response into a wrapped Go
+// error with a user-actionable message. Includes workspace/repo
+// context for 404s.
+func mapStatusError(status int, body []byte, workspace, repo string) error {
+	msg := decodeErrorMessage(body)
+	switch status {
+	case 401:
+		return fmt.Errorf("bitbucket: auth failed (check BITBUCKET_EMAIL + BITBUCKET_TOKEN); verify the token has Bitbucket scopes: %s", msg)
+	case 402:
+		return ErrPlanGate
+	case 403:
+		return fmt.Errorf("bitbucket: forbidden; the token is missing a scope (required: read/write repository, read/write pullrequest): %s", msg)
+	case 404:
+		return fmt.Errorf("bitbucket: not found (workspace=%q repo=%q); verify the slugs and that you have access: %s", workspace, repo, msg)
+	case 429:
+		return ErrRateLimited
+	case 400:
+		return fmt.Errorf("bitbucket: bad input: %s", msg)
+	}
+	if status >= 500 {
+		return fmt.Errorf("bitbucket: server error %d: %s", status, msg)
+	}
+	return fmt.Errorf("bitbucket: unexpected status %d: %s", status, msg)
+}
+
+// decodeErrorMessage tries to extract a human-readable message from
+// Bitbucket's error envelope. Falls back to the raw body when the
+// envelope doesn't parse.
+func decodeErrorMessage(body []byte) string {
+	var er errorResponse
+	if err := json.Unmarshal(body, &er); err == nil && er.Error.Message != "" {
+		if er.Error.Detail != "" {
+			return er.Error.Message + " (" + er.Error.Detail + ")"
+		}
+		return er.Error.Message
+	}
+	if len(body) == 0 {
+		return "(empty response body)"
+	}
+	if len(body) > 200 {
+		return string(body[:200]) + "..."
+	}
+	return string(body)
+}

--- a/internal/provider/bitbucket/identity.go
+++ b/internal/provider/bitbucket/identity.go
@@ -1,0 +1,37 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+)
+
+// resolveUsername returns the Bitbucket username associated with the
+// configured email + token. Probes /2.0/user on first call and caches
+// the result; concurrent first calls share the probe via sync.Once.
+func (c *client) resolveUsername(ctx context.Context) (string, error) {
+	c.identityOnce.Do(func() {
+		resp, err := c.do(ctx, "GET", "/user", nil, nil)
+		if err != nil {
+			c.identityErr = fmt.Errorf("bitbucket: probe /2.0/user: %w", err)
+			return
+		}
+		var body struct {
+			Username    string `json:"username"`
+			DisplayName string `json:"display_name"`
+			UUID        string `json:"uuid"`
+		}
+		if err := decodeJSON(resp, &body); err != nil {
+			c.identityErr = err
+			return
+		}
+		if body.Username == "" {
+			c.identityErr = fmt.Errorf("bitbucket: /2.0/user returned empty username")
+			return
+		}
+		c.username = body.Username
+	})
+	if c.identityErr != nil {
+		return "", c.identityErr
+	}
+	return c.username, nil
+}

--- a/internal/provider/bitbucket/identity.go
+++ b/internal/provider/bitbucket/identity.go
@@ -8,6 +8,9 @@ import (
 // resolveUsername returns the Bitbucket username associated with the
 // configured email + token. Probes /2.0/user on first call and caches
 // the result; concurrent first calls share the probe via sync.Once.
+//
+// First-call errors (transient 5xx, context canceled, etc.) are
+// cached for the client's lifetime. Restart monorel to retry.
 func (c *client) resolveUsername(ctx context.Context) (string, error) {
 	c.identityOnce.Do(func() {
 		resp, err := c.do(ctx, "GET", "/user", nil, nil)

--- a/internal/provider/bitbucket/integration_test.go
+++ b/internal/provider/bitbucket/integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestIntegration_FullLifecycle creates a temp repo in the configured
+// workspace, walks the full PR lifecycle, and deletes the repo on
+// success. Skipped unless BITBUCKET_INTEGRATION=1 + BITBUCKET_EMAIL
+// + BITBUCKET_TOKEN + BITBUCKET_WORKSPACE are set.
+//
+// Run with: go test -tags=integration ./internal/provider/bitbucket/ -v
+func TestIntegration_FullLifecycle(t *testing.T) {
+	if os.Getenv("BITBUCKET_INTEGRATION") != "1" {
+		t.Skip("set BITBUCKET_INTEGRATION=1 to run")
+	}
+	email := os.Getenv("BITBUCKET_EMAIL")
+	token := os.Getenv("BITBUCKET_TOKEN")
+	ws := os.Getenv("BITBUCKET_WORKSPACE")
+	if email == "" || token == "" || ws == "" {
+		t.Fatal("BITBUCKET_EMAIL, BITBUCKET_TOKEN, and BITBUCKET_WORKSPACE all required")
+	}
+
+	repoName := fmt.Sprintf("monorel-integration-%d", time.Now().Unix())
+
+	// Create the repo via REST.
+	c, err := New(context.Background(), Options{
+		Workspace: ws, Repo: repoName,
+		Email: email, Token: token,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bc := c.(*client)
+
+	// Create the repo via the Bitbucket API directly (out of band of
+	// the Client interface; repo creation isn't a provider.Client
+	// method).
+	if _, err := bc.do(context.Background(), "POST", bc.repoBase(), nil, map[string]any{
+		"is_private":  false,
+		"scm":         "git",
+		"description": "monorel integration test; safe to delete.",
+	}); err != nil {
+		t.Fatalf("create repo: %v", err)
+	}
+	t.Cleanup(func() {
+		_, err := bc.do(context.Background(), "DELETE", bc.repoBase(), nil, nil)
+		if err != nil {
+			t.Logf("delete repo (test cleanup): %v", err)
+		}
+	})
+
+	// Read default branch.
+	defaultBranch, err := c.GetDefaultBranch(context.Background())
+	if err != nil {
+		t.Fatalf("GetDefaultBranch: %v", err)
+	}
+	if defaultBranch != "master" && defaultBranch != "main" {
+		t.Errorf("unexpected default branch %q", defaultBranch)
+	}
+
+	// (PR-lifecycle test requires pushing branches, which uses
+	// git over HTTPS. Out of scope for the REST-only integration
+	// test; covered by the spike's manual run.)
+}

--- a/internal/provider/bitbucket/integration_test.go
+++ b/internal/provider/bitbucket/integration_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"monorel.disaresta.com/internal/provider"
 )
 
 // TestIntegration_FullLifecycle creates a temp repo in the configured
@@ -56,8 +58,10 @@ func TestIntegration_FullLifecycle(t *testing.T) {
 		}
 	})
 
+	ctx := context.Background()
+
 	// Read default branch.
-	defaultBranch, err := c.GetDefaultBranch(context.Background())
+	defaultBranch, err := c.GetDefaultBranch(ctx)
 	if err != nil {
 		t.Fatalf("GetDefaultBranch: %v", err)
 	}
@@ -65,7 +69,56 @@ func TestIntegration_FullLifecycle(t *testing.T) {
 		t.Errorf("unexpected default branch %q", defaultBranch)
 	}
 
-	// (PR-lifecycle test requires pushing branches, which uses
-	// git over HTTPS. Out of scope for the REST-only integration
-	// test; covered by the spike's manual run.)
+	// FindOpenReleasePR on a fresh repo returns (nil, nil).
+	pr, err := c.FindOpenReleasePR(ctx, "monorel/release")
+	if err != nil {
+		t.Fatalf("FindOpenReleasePR: %v", err)
+	}
+	if pr != nil {
+		t.Errorf("FindOpenReleasePR: expected nil; got %+v", pr)
+	}
+
+	// FindPRByMergeCommit on a fresh repo returns (nil, nil) for any
+	// SHA. This exercises the trailers-fallback query path against the
+	// real BBQL endpoint.
+	pr, err = c.FindPRByMergeCommit(ctx, "deadbeef0000000000000000000000000000beef")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if pr != nil {
+		t.Errorf("FindPRByMergeCommit: expected nil; got %+v", pr)
+	}
+
+	// CreateRelease is a Bitbucket no-op; verify the synthetic
+	// *Release shape and the /src/<tag> URL form.
+	rel, err := c.CreateRelease(ctx, provider.CreateReleaseOptions{
+		Tag:  "transports/foo/v1.0.0",
+		Name: "transports/foo v1.0.0",
+		Body: "Integration smoke release.",
+	})
+	if err != nil {
+		t.Fatalf("CreateRelease: %v", err)
+	}
+	if rel.Tag != "transports/foo/v1.0.0" {
+		t.Errorf("CreateRelease.Tag = %q", rel.Tag)
+	}
+	wantURL := fmt.Sprintf("https://bitbucket.org/%s/%s/src/transports/foo/v1.0.0", ws, repoName)
+	if rel.HTMLURL != wantURL {
+		t.Errorf("CreateRelease.HTMLURL = %q, want %q", rel.HTMLURL, wantURL)
+	}
+
+	// Identity probe lands a username from /2.0/user. The cache is
+	// hit on second call (covered indirectly by all the calls above).
+	username, err := bc.resolveUsername(ctx)
+	if err != nil {
+		t.Fatalf("resolveUsername: %v", err)
+	}
+	if username == "" {
+		t.Error("resolveUsername returned empty string")
+	}
+
+	// (PR-lifecycle write-side methods CreatePR / UpdatePR / ClosePR
+	// require pushed branches, which use git over HTTPS. Out of scope
+	// for this REST-only integration test; the spike validated them
+	// manually.)
 }

--- a/internal/provider/bitbucket/pulls.go
+++ b/internal/provider/bitbucket/pulls.go
@@ -58,9 +58,11 @@ func (p *bbPullRequest) toProviderPR() *provider.PullRequest {
 	return pr
 }
 
-func (c *client) FindOpenReleasePR(ctx context.Context, headBranch string) (*provider.PullRequest, error) {
+// firstPRMatching runs a BBQL query against /pullrequests and
+// returns the first match, (nil, nil) for an empty result.
+func (c *client) firstPRMatching(ctx context.Context, bbql string) (*provider.PullRequest, error) {
 	q := url.Values{}
-	q.Set("q", fmt.Sprintf(`state="OPEN" AND source.branch.name=%q`, headBranch))
+	q.Set("q", bbql)
 	resp, err := c.do(ctx, "GET", c.repoBase()+"/pullrequests", q, nil)
 	if err != nil {
 		return nil, err
@@ -75,6 +77,10 @@ func (c *client) FindOpenReleasePR(ctx context.Context, headBranch string) (*pro
 		return nil, nil
 	}
 	return body.Values[0].toProviderPR(), nil
+}
+
+func (c *client) FindOpenReleasePR(ctx context.Context, headBranch string) (*provider.PullRequest, error) {
+	return c.firstPRMatching(ctx, fmt.Sprintf(`state="OPEN" AND source.branch.name=%q`, headBranch))
 }
 
 func (c *client) CreatePR(ctx context.Context, opts provider.CreatePROptions) (*provider.PullRequest, error) {

--- a/internal/provider/bitbucket/pulls.go
+++ b/internal/provider/bitbucket/pulls.go
@@ -1,0 +1,138 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+// bbPullRequest is the slice of Bitbucket's PR resource shape that
+// monorel cares about. JSON tags match the Bitbucket Cloud REST API
+// v2 response shape (state is OPEN/MERGED/DECLINED/SUPERSEDED;
+// summary.raw carries the description body; merge_commit may be null
+// for unmerged PRs).
+type bbPullRequest struct {
+	ID      int    `json:"id"`
+	State   string `json:"state"`
+	Title   string `json:"title"`
+	Summary struct {
+		Raw string `json:"raw"`
+	} `json:"summary"`
+	Source struct {
+		Branch struct {
+			Name string `json:"name"`
+		} `json:"branch"`
+	} `json:"source"`
+	MergeCommit *struct {
+		Hash string `json:"hash"`
+	} `json:"merge_commit"`
+	Links struct {
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+	} `json:"links"`
+}
+
+// toProviderPR converts to the neutral provider.PullRequest shape.
+// State is normalized: OPEN -> "open"; everything else
+// (MERGED / DECLINED / SUPERSEDED) -> "closed".
+func (p *bbPullRequest) toProviderPR() *provider.PullRequest {
+	state := "closed"
+	if p.State == "OPEN" {
+		state = "open"
+	}
+	pr := &provider.PullRequest{
+		Number:  p.ID,
+		State:   state,
+		Title:   p.Title,
+		Body:    p.Summary.Raw,
+		HeadRef: p.Source.Branch.Name,
+		HTMLURL: p.Links.HTML.Href,
+	}
+	if p.MergeCommit != nil {
+		pr.MergedSHA = p.MergeCommit.Hash
+	}
+	return pr
+}
+
+func (c *client) FindOpenReleasePR(ctx context.Context, headBranch string) (*provider.PullRequest, error) {
+	q := url.Values{}
+	q.Set("q", fmt.Sprintf(`state="OPEN" AND source.branch.name=%q`, headBranch))
+	resp, err := c.do(ctx, "GET", c.repoBase()+"/pullrequests", q, nil)
+	if err != nil {
+		return nil, err
+	}
+	var body struct {
+		Values []bbPullRequest `json:"values"`
+	}
+	if err := decodeJSON(resp, &body); err != nil {
+		return nil, err
+	}
+	if len(body.Values) == 0 {
+		return nil, nil
+	}
+	return body.Values[0].toProviderPR(), nil
+}
+
+func (c *client) CreatePR(ctx context.Context, opts provider.CreatePROptions) (*provider.PullRequest, error) {
+	type branch struct {
+		Name string `json:"name"`
+	}
+	type ref struct {
+		Branch branch `json:"branch"`
+	}
+	type createBody struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		Source      ref    `json:"source"`
+		Destination ref    `json:"destination"`
+	}
+	body := createBody{
+		Title:       opts.Title,
+		Description: opts.Body,
+		Source:      ref{Branch: branch{Name: opts.HeadBranch}},
+		Destination: ref{Branch: branch{Name: opts.BaseBranch}},
+	}
+	resp, err := c.do(ctx, "POST", c.repoBase()+"/pullrequests", nil, body)
+	if err != nil {
+		return nil, err
+	}
+	var out bbPullRequest
+	if err := decodeJSON(resp, &out); err != nil {
+		return nil, err
+	}
+	return out.toProviderPR(), nil
+}
+
+func (c *client) UpdatePR(ctx context.Context, number int, opts provider.UpdatePROptions) (*provider.PullRequest, error) {
+	if opts.Title == nil && opts.Body == nil {
+		return nil, fmt.Errorf("bitbucket: UpdatePR has nothing to change")
+	}
+	patch := map[string]any{}
+	if opts.Title != nil {
+		patch["title"] = *opts.Title
+	}
+	if opts.Body != nil {
+		patch["description"] = *opts.Body
+	}
+	resp, err := c.do(ctx, "PUT", c.repoBase()+"/pullrequests/"+strconv.Itoa(number), nil, patch)
+	if err != nil {
+		return nil, err
+	}
+	var out bbPullRequest
+	if err := decodeJSON(resp, &out); err != nil {
+		return nil, err
+	}
+	return out.toProviderPR(), nil
+}
+
+func (c *client) ClosePR(ctx context.Context, number int) error {
+	resp, err := c.do(ctx, "POST", c.repoBase()+"/pullrequests/"+strconv.Itoa(number)+"/decline", nil, nil)
+	if err != nil {
+		return err
+	}
+	return decodeJSON(resp, nil)
+}

--- a/internal/provider/bitbucket/release.go
+++ b/internal/provider/bitbucket/release.go
@@ -1,0 +1,36 @@
+package bitbucket
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+// CreateRelease is a no-op for Bitbucket Cloud, which has no
+// first-class Release concept. Returns a synthetic *Release whose
+// HTMLURL points at the tag's source view (bitbucket.org/<ws>/<repo>/src/<tag>).
+//
+// The orchestrator's call site treats CreateRelease as advisory:
+// per-package CHANGELOG.md is the canonical release-notes source.
+func (c *client) CreateRelease(_ context.Context, opts provider.CreateReleaseOptions) (*provider.Release, error) {
+	htmlURL := "https://bitbucket.org/" +
+		url.PathEscape(c.workspace) + "/" +
+		url.PathEscape(c.repo) + "/src/" + escapeTagPath(opts.Tag)
+	return &provider.Release{
+		Tag:     opts.Tag,
+		HTMLURL: htmlURL,
+	}, nil
+}
+
+// escapeTagPath URL-escapes each /-separated segment of a tag path so
+// the slashes remain literal path separators (path-prefixed tags like
+// "transports/foo/v1.7.0" stay readable in the URL).
+func escapeTagPath(tag string) string {
+	parts := strings.Split(tag, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
+}

--- a/internal/provider/bitbucket/repo.go
+++ b/internal/provider/bitbucket/repo.go
@@ -1,0 +1,27 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetDefaultBranch returns the repo's default branch by reading
+// `mainbranch.name` from the repository resource.
+func (c *client) GetDefaultBranch(ctx context.Context) (string, error) {
+	resp, err := c.do(ctx, "GET", c.repoBase(), nil, nil)
+	if err != nil {
+		return "", err
+	}
+	var body struct {
+		Mainbranch struct {
+			Name string `json:"name"`
+		} `json:"mainbranch"`
+	}
+	if err := decodeJSON(resp, &body); err != nil {
+		return "", err
+	}
+	if body.Mainbranch.Name == "" {
+		return "", fmt.Errorf("bitbucket: %s/%s has no default branch", c.workspace, c.repo)
+	}
+	return body.Mainbranch.Name, nil
+}

--- a/internal/provider/bitbucket/trailers.go
+++ b/internal/provider/bitbucket/trailers.go
@@ -1,0 +1,31 @@
+package bitbucket
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+// FindPRByMergeCommit queries Bitbucket's BBQL filter for a MERGED PR
+// whose merge_commit.hash matches the given SHA. Returns (nil, nil)
+// when no PR matches; an error only when the API call itself fails.
+func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
+	q := url.Values{}
+	q.Set("q", fmt.Sprintf(`state="MERGED" AND merge_commit.hash=%q`, sha))
+	resp, err := c.do(ctx, "GET", c.repoBase()+"/pullrequests", q, nil)
+	if err != nil {
+		return nil, err
+	}
+	var body struct {
+		Values []bbPullRequest `json:"values"`
+	}
+	if err := decodeJSON(resp, &body); err != nil {
+		return nil, err
+	}
+	if len(body.Values) == 0 {
+		return nil, nil
+	}
+	return body.Values[0].toProviderPR(), nil
+}

--- a/internal/provider/bitbucket/trailers.go
+++ b/internal/provider/bitbucket/trailers.go
@@ -3,7 +3,6 @@ package bitbucket
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	"monorel.disaresta.com/internal/provider"
 )
@@ -12,20 +11,5 @@ import (
 // whose merge_commit.hash matches the given SHA. Returns (nil, nil)
 // when no PR matches; an error only when the API call itself fails.
 func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
-	q := url.Values{}
-	q.Set("q", fmt.Sprintf(`state="MERGED" AND merge_commit.hash=%q`, sha))
-	resp, err := c.do(ctx, "GET", c.repoBase()+"/pullrequests", q, nil)
-	if err != nil {
-		return nil, err
-	}
-	var body struct {
-		Values []bbPullRequest `json:"values"`
-	}
-	if err := decodeJSON(resp, &body); err != nil {
-		return nil, err
-	}
-	if len(body.Values) == 0 {
-		return nil, nil
-	}
-	return body.Values[0].toProviderPR(), nil
+	return c.firstPRMatching(ctx, fmt.Sprintf(`state="MERGED" AND merge_commit.hash=%q`, sha))
 }

--- a/internal/provider/factory/factory.go
+++ b/internal/provider/factory/factory.go
@@ -9,9 +9,11 @@ package factory
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"monorel.disaresta.com/config"
 	"monorel.disaresta.com/internal/provider"
+	"monorel.disaresta.com/internal/provider/bitbucket"
 	"monorel.disaresta.com/internal/provider/gitea"
 	"monorel.disaresta.com/internal/provider/github"
 	"monorel.disaresta.com/internal/provider/gitlab"
@@ -42,6 +44,14 @@ func New(ctx context.Context, cfg config.ProviderConfig, token string) (provider
 			Repo:  cfg.Repo,
 			Host:  cfg.Host,
 			Token: token,
+		})
+	case config.ProviderBitbucket:
+		return bitbucket.New(ctx, bitbucket.Options{
+			Workspace: cfg.Owner,
+			Repo:      cfg.Repo,
+			Host:      cfg.Host,
+			Email:     os.Getenv("BITBUCKET_EMAIL"),
+			Token:     token,
 		})
 	default:
 		return nil, fmt.Errorf("provider: unknown provider %q", cfg.Name)

--- a/internal/provider/factory/factory.go
+++ b/internal/provider/factory/factory.go
@@ -46,11 +46,18 @@ func New(ctx context.Context, cfg config.ProviderConfig, token string) (provider
 			Token: token,
 		})
 	case config.ProviderBitbucket:
+		var email string
+		for _, name := range provider.EmailEnvVars(config.ProviderBitbucket) {
+			if v := os.Getenv(name); v != "" {
+				email = v
+				break
+			}
+		}
 		return bitbucket.New(ctx, bitbucket.Options{
 			Workspace: cfg.Owner,
 			Repo:      cfg.Repo,
 			Host:      cfg.Host,
-			Email:     os.Getenv("BITBUCKET_EMAIL"),
+			Email:     email,
 			Token:     token,
 		})
 	default:

--- a/internal/provider/fake.go
+++ b/internal/provider/fake.go
@@ -190,6 +190,22 @@ func (f *Fake) ClosePR(_ context.Context, number int) error {
 	return nil
 }
 
+// FindPRByMergeCommit implements [Client.FindPRByMergeCommit].
+func (f *Fake) FindPRByMergeCommit(_ context.Context, sha string) (*PullRequest, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.take(); err != nil {
+		return nil, err
+	}
+	for _, pr := range f.PRs {
+		if pr.MergedSHA == sha {
+			cp := *pr
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
 // CreateRelease implements [Client.CreateRelease].
 func (f *Fake) CreateRelease(_ context.Context, opts CreateReleaseOptions) (*Release, error) {
 	f.mu.Lock()

--- a/internal/provider/fake_test.go
+++ b/internal/provider/fake_test.go
@@ -149,6 +149,40 @@ func TestFake_FailOnNth(t *testing.T) {
 	}
 }
 
+func TestFake_FindPRByMergeCommit(t *testing.T) {
+	f := provider.NewFake()
+	ctx := context.Background()
+
+	// Pre-seed a "merged" PR at a known SHA. The fake doesn't model
+	// merging directly; we set MergedSHA on the PR.
+	pr, err := f.CreatePR(ctx, provider.CreatePROptions{
+		Title:      "release",
+		Body:       "body",
+		HeadBranch: "monorel/release",
+		BaseBranch: "main",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.PRs[pr.Number].MergedSHA = "abc123"
+
+	got, err := f.FindPRByMergeCommit(ctx, "abc123")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got == nil || got.Number != pr.Number {
+		t.Errorf("got %v, want PR #%d", got, pr.Number)
+	}
+
+	miss, err := f.FindPRByMergeCommit(ctx, "nosuchsha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if miss != nil {
+		t.Errorf("expected nil for unknown SHA; got %v", miss)
+	}
+}
+
 func TestFake_UpdatePR_NoOpRejected(t *testing.T) {
 	f := provider.NewFake()
 	ctx := context.Background()

--- a/internal/provider/gitea/gitea.go
+++ b/internal/provider/gitea/gitea.go
@@ -192,6 +192,34 @@ func (c *client) CreateRelease(ctx context.Context, opts provider.CreateReleaseO
 	}, nil
 }
 
+// FindPRByMergeCommit implements [provider.Client.FindPRByMergeCommit].
+//
+// Gitea has no single "list PRs for commit" endpoint; the supported
+// pattern is to list closed PRs and filter by merge_commit_sha. The
+// loop pages through results until a match or until the SDK reports
+// no NextPage.
+func (c *client) FindPRByMergeCommit(_ context.Context, sha string) (*provider.PullRequest, error) {
+	page := 1
+	for {
+		prs, resp, err := c.gt.ListRepoPullRequests(c.owner, c.repo, gtsdk.ListPullRequestsOptions{
+			ListOptions: gtsdk.ListOptions{Page: page, PageSize: 50},
+			State:       gtsdk.StateClosed,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("gitea: list PRs %s/%s: %w", c.owner, c.repo, err)
+		}
+		for _, pr := range prs {
+			if pr.MergedCommitID != nil && *pr.MergedCommitID == sha {
+				return convertPR(pr), nil
+			}
+		}
+		if resp == nil || resp.NextPage == 0 {
+			return nil, nil
+		}
+		page = resp.NextPage
+	}
+}
+
 // convertPR maps a Gitea SDK PullRequest into the provider-neutral
 // shape. Returns nil when src is nil so callers can pass through
 // nil-from-FindOpenReleasePR cleanly.
@@ -208,6 +236,9 @@ func convertPR(src *gtsdk.PullRequest) *provider.PullRequest {
 	}
 	if src.Head != nil {
 		pr.HeadRef = src.Head.Ref
+	}
+	if src.MergedCommitID != nil {
+		pr.MergedSHA = *src.MergedCommitID
 	}
 	return pr
 }

--- a/internal/provider/gitea/gitea.go
+++ b/internal/provider/gitea/gitea.go
@@ -198,7 +198,7 @@ func (c *client) CreateRelease(ctx context.Context, opts provider.CreateReleaseO
 // pattern is to list closed PRs and filter by merge_commit_sha. The
 // loop pages through results until a match or until the SDK reports
 // no NextPage.
-func (c *client) FindPRByMergeCommit(_ context.Context, sha string) (*provider.PullRequest, error) {
+func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
 	page := 1
 	for {
 		prs, resp, err := c.gt.ListRepoPullRequests(c.owner, c.repo, gtsdk.ListPullRequestsOptions{

--- a/internal/provider/gitea/gitea_test.go
+++ b/internal/provider/gitea/gitea_test.go
@@ -3,6 +3,10 @@ package gitea_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"monorel.disaresta.com/internal/provider/gitea"
@@ -31,5 +35,47 @@ func TestNew_RejectsMissingHost(t *testing.T) {
 	_, err := gitea.New(context.Background(), gitea.Options{Owner: "o", Repo: "r"})
 	if !errors.Is(err, gitea.ErrMissingHost) {
 		t.Errorf("err = %v, want ErrMissingHost", err)
+	}
+}
+
+func TestFindPRByMergeCommit_Gitea(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/api/v1/version"):
+			fmt.Fprintln(w, `{"version":"1.23.0"}`)
+		case strings.Contains(r.URL.Path, "/pulls"):
+			fmt.Fprintln(w, `[{
+				"number": 42,
+				"state": "closed",
+				"merged": true,
+				"title": "release",
+				"body": "release body",
+				"head": {"ref": "monorel/release"},
+				"merge_commit_sha": "abc123",
+				"html_url": "https://gitea.example.com/acme/widget/pulls/42"
+			}]`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c, err := gitea.New(context.Background(), gitea.Options{
+		Owner: "acme",
+		Repo:  "widget",
+		Host:  srv.URL,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got == nil || got.Number != 42 || got.MergedSHA != "abc123" {
+		t.Errorf("got %+v, want #42 with MergedSHA=abc123", got)
 	}
 }

--- a/internal/provider/github/github.go
+++ b/internal/provider/github/github.go
@@ -178,16 +178,30 @@ func (c *client) CreateRelease(ctx context.Context, opts provider.CreateReleaseO
 	}, nil
 }
 
+func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
+	prs, _, err := c.gh.PullRequests.ListPullRequestsWithCommit(ctx, c.owner, c.repo, sha, &gogh.ListOptions{PerPage: 50})
+	if err != nil {
+		return nil, fmt.Errorf("github: list PRs for commit %s: %w", sha, err)
+	}
+	for _, pr := range prs {
+		if pr.GetMergeCommitSHA() == sha {
+			return convertPR(pr), nil
+		}
+	}
+	return nil, nil
+}
+
 func convertPR(pr *gogh.PullRequest) *provider.PullRequest {
 	if pr == nil {
 		return nil
 	}
 	out := &provider.PullRequest{
-		Number:  pr.GetNumber(),
-		State:   strings.ToLower(pr.GetState()),
-		Title:   pr.GetTitle(),
-		Body:    pr.GetBody(),
-		HTMLURL: pr.GetHTMLURL(),
+		Number:    pr.GetNumber(),
+		State:     strings.ToLower(pr.GetState()),
+		Title:     pr.GetTitle(),
+		Body:      pr.GetBody(),
+		HTMLURL:   pr.GetHTMLURL(),
+		MergedSHA: pr.GetMergeCommitSHA(),
 	}
 	if h := pr.GetHead(); h != nil {
 		out.HeadRef = h.GetRef()

--- a/internal/provider/github/github.go
+++ b/internal/provider/github/github.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	gogh "github.com/google/go-github/v68/github"
 	"golang.org/x/oauth2"
@@ -179,6 +178,10 @@ func (c *client) CreateRelease(ctx context.Context, opts provider.CreateReleaseO
 }
 
 func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
+	// First page is sufficient: a commit is the merge commit of at
+	// most one PR, and the API ranks the merging PR first. The loop
+	// below double-checks via GetMergeCommitSHA == sha so an unrelated
+	// PR that merely touches the commit doesn't slip through.
 	prs, _, err := c.gh.PullRequests.ListPullRequestsWithCommit(ctx, c.owner, c.repo, sha, &gogh.ListOptions{PerPage: 50})
 	if err != nil {
 		return nil, fmt.Errorf("github: list PRs for commit %s: %w", sha, err)
@@ -197,7 +200,7 @@ func convertPR(pr *gogh.PullRequest) *provider.PullRequest {
 	}
 	out := &provider.PullRequest{
 		Number:    pr.GetNumber(),
-		State:     strings.ToLower(pr.GetState()),
+		State:     pr.GetState(),
 		Title:     pr.GetTitle(),
 		Body:      pr.GetBody(),
 		HTMLURL:   pr.GetHTMLURL(),

--- a/internal/provider/github/github_test.go
+++ b/internal/provider/github/github_test.go
@@ -1,0 +1,82 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	gogh "github.com/google/go-github/v68/github"
+)
+
+// newTestClient builds a *client whose underlying go-github Client points
+// at the given httptest server. Bypasses [New] (which insists on building a
+// real https URL) so the tests can drive every code path against a local
+// fake.
+func newTestClient(t *testing.T, baseURL, owner, repo string) *client {
+	t.Helper()
+	u, err := url.Parse(strings.TrimRight(baseURL, "/") + "/")
+	if err != nil {
+		t.Fatalf("parse baseURL: %v", err)
+	}
+	gh := gogh.NewClient(nil)
+	gh.BaseURL = u
+	gh.UploadURL = u
+	return &client{owner: owner, repo: repo, gh: gh}
+}
+
+func TestFindPRByMergeCommit(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/widget/commits/abc123/pulls", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[{
+			"number": 42,
+			"state": "closed",
+			"title": "release",
+			"body": "release body",
+			"head": {"ref": "monorel/release"},
+			"merge_commit_sha": "abc123",
+			"merged_at": "2026-05-03T00:00:00Z",
+			"html_url": "https://github.com/acme/widget/pull/42"
+		}]`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL, "acme", "widget")
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected PR; got nil")
+	}
+	if got.Number != 42 || got.MergedSHA != "abc123" {
+		t.Errorf("got %+v, want #42 with MergedSHA=abc123", got)
+	}
+}
+
+func TestFindPRByMergeCommit_NoMatch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/acme/widget/commits/zzz999/pulls", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[]`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL, "acme", "widget")
+	got, err := c.FindPRByMergeCommit(context.Background(), "zzz999")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}

--- a/internal/provider/gitlab/gitlab.go
+++ b/internal/provider/gitlab/gitlab.go
@@ -169,6 +169,19 @@ func (c *client) CreateRelease(ctx context.Context, opts provider.CreateReleaseO
 	}, nil
 }
 
+func (c *client) FindPRByMergeCommit(ctx context.Context, sha string) (*provider.PullRequest, error) {
+	mrs, _, err := c.gl.Commits.ListMergeRequestsByCommit(c.pid, sha, gl.WithContext(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("gitlab: list MRs for commit %s: %w", sha, err)
+	}
+	for _, mr := range mrs {
+		if mr.MergeCommitSHA == sha {
+			return basicMRToPR(mr), nil
+		}
+	}
+	return nil, nil
+}
+
 // mrToPR maps a GitLab full MergeRequest into the provider-neutral
 // shape. Number is the per-project IID (`!N` in the GitLab UI), not
 // the global ID; the provider interface uses IID throughout.
@@ -177,12 +190,13 @@ func mrToPR(src *gl.MergeRequest) *provider.PullRequest {
 		return nil
 	}
 	return &provider.PullRequest{
-		Number:  int(src.IID),
-		State:   src.State,
-		Title:   src.Title,
-		Body:    src.Description,
-		HeadRef: src.SourceBranch,
-		HTMLURL: src.WebURL,
+		Number:    int(src.IID),
+		State:     src.State,
+		Title:     src.Title,
+		Body:      src.Description,
+		HeadRef:   src.SourceBranch,
+		HTMLURL:   src.WebURL,
+		MergedSHA: src.MergeCommitSHA,
 	}
 }
 
@@ -194,12 +208,13 @@ func basicMRToPR(src *gl.BasicMergeRequest) *provider.PullRequest {
 		return nil
 	}
 	return &provider.PullRequest{
-		Number:  int(src.IID),
-		State:   src.State,
-		Title:   src.Title,
-		Body:    src.Description,
-		HeadRef: src.SourceBranch,
-		HTMLURL: src.WebURL,
+		Number:    int(src.IID),
+		State:     src.State,
+		Title:     src.Title,
+		Body:      src.Description,
+		HeadRef:   src.SourceBranch,
+		HTMLURL:   src.WebURL,
+		MergedSHA: src.MergeCommitSHA,
 	}
 }
 

--- a/internal/provider/gitlab/gitlab_test.go
+++ b/internal/provider/gitlab/gitlab_test.go
@@ -3,6 +3,9 @@ package gitlab_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"monorel.disaresta.com/internal/provider/gitlab"
@@ -31,6 +34,44 @@ func TestNew_RejectsMissingToken(t *testing.T) {
 	_, err := gitlab.New(context.Background(), gitlab.Options{Owner: "o", Repo: "r"})
 	if !errors.Is(err, gitlab.ErrMissingToken) {
 		t.Errorf("err = %v, want ErrMissingToken", err)
+	}
+}
+
+func TestFindPRByMergeCommit_GitLab(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// EscapedPath reflects how the SDK URL-encoded the project ID.
+		wantPath := "/api/v4/projects/team%2Fwidget/repository/commits/abc123/merge_requests"
+		if r.URL.EscapedPath() != wantPath {
+			t.Errorf("path = %s, want %s", r.URL.EscapedPath(), wantPath)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[{
+			"iid": 42,
+			"state": "merged",
+			"title": "release",
+			"description": "release body",
+			"source_branch": "monorel/release",
+			"merge_commit_sha": "abc123",
+			"web_url": "https://gitlab.com/team/widget/-/merge_requests/42"
+		}]`)
+	}))
+	defer srv.Close()
+
+	c, err := gitlab.New(context.Background(), gitlab.Options{
+		Owner: "team",
+		Repo:  "widget",
+		Host:  srv.URL,
+		Token: "tok",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := c.FindPRByMergeCommit(context.Background(), "abc123")
+	if err != nil {
+		t.Fatalf("FindPRByMergeCommit: %v", err)
+	}
+	if got == nil || got.Number != 42 || got.MergedSHA != "abc123" {
+		t.Errorf("got %+v, want MR #42 with MergedSHA=abc123", got)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,6 +31,8 @@ func TokenEnvVars(provider string) []string {
 		return []string{"GITEA_TOKEN"}
 	case config.ProviderGitLab:
 		return []string{"GITLAB_TOKEN", "CI_JOB_TOKEN"}
+	case config.ProviderBitbucket:
+		return []string{"BITBUCKET_TOKEN"}
 	}
 	return nil
 }
@@ -44,6 +46,19 @@ func TokenFromEnv(provider string) string {
 		}
 	}
 	return ""
+}
+
+// EmailEnvVars returns environment variable names to consult for a
+// provider's auth-email, in priority order. Most providers don't use
+// a separate email (the token alone authenticates); Bitbucket Cloud
+// is the exception because its REST API uses HTTP Basic with
+// `email + token`. Returns nil for providers that don't need a
+// separate email.
+func EmailEnvVars(provider string) []string {
+	if config.ResolveProvider(provider) == config.ProviderBitbucket {
+		return []string{"BITBUCKET_EMAIL"}
+	}
+	return nil
 }
 
 // Client is the slice of provider operations monorel needs. The methods

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -82,6 +82,18 @@ type Client interface {
 	// Bitbucket) may return an "unsupported" error; callers should
 	// treat that as advisory, not fatal.
 	CreateRelease(ctx context.Context, opts CreateReleaseOptions) (*Release, error)
+
+	// FindPRByMergeCommit returns the PR/MR that was merged into the
+	// repo at the given commit SHA, if one exists. Returns (nil, nil)
+	// when no PR matches (NOT an error): the caller treats that as
+	// "no fallback available."
+	//
+	// Used by the universal PR-body trailers fallback: monorel tag
+	// reads its release-trailer set from HEAD's commit message
+	// normally, but falls back to fetching the merged PR's body
+	// (looking for a `<!-- monorel-trailers ... -->` block) when the
+	// commit body is empty (typically because of a squash-merge).
+	FindPRByMergeCommit(ctx context.Context, sha string) (*PullRequest, error)
 }
 
 // PullRequest is the minimal shape monorel cares about. The name uses
@@ -94,6 +106,11 @@ type PullRequest struct {
 	Body    string
 	HeadRef string
 	HTMLURL string
+
+	// MergedSHA is the merge-commit SHA when this PR was merged
+	// (state transitioned through "merged"). Empty for unmerged PRs.
+	// Used by FindPRByMergeCommit's reverse lookup.
+	MergedSHA string
 }
 
 // CreatePROptions is the input to [Client.CreatePR].

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,13 +1,14 @@
 package provider_test
 
 import (
+	"slices"
 	"testing"
 
 	"monorel.disaresta.com/internal/provider"
 )
 
 func TestEmailEnvVars(t *testing.T) {
-	if got := provider.EmailEnvVars("bitbucket"); !equalSlices(got, []string{"BITBUCKET_EMAIL"}) {
+	if got := provider.EmailEnvVars("bitbucket"); !slices.Equal(got, []string{"BITBUCKET_EMAIL"}) {
 		t.Errorf("EmailEnvVars(bitbucket) = %v", got)
 	}
 	if got := provider.EmailEnvVars("github"); got != nil {
@@ -16,19 +17,7 @@ func TestEmailEnvVars(t *testing.T) {
 }
 
 func TestTokenEnvVars_Bitbucket(t *testing.T) {
-	if got := provider.TokenEnvVars("bitbucket"); !equalSlices(got, []string{"BITBUCKET_TOKEN"}) {
+	if got := provider.TokenEnvVars("bitbucket"); !slices.Equal(got, []string{"BITBUCKET_TOKEN"}) {
 		t.Errorf("TokenEnvVars(bitbucket) = %v", got)
 	}
-}
-
-func equalSlices(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,34 @@
+package provider_test
+
+import (
+	"testing"
+
+	"monorel.disaresta.com/internal/provider"
+)
+
+func TestEmailEnvVars(t *testing.T) {
+	if got := provider.EmailEnvVars("bitbucket"); !equalSlices(got, []string{"BITBUCKET_EMAIL"}) {
+		t.Errorf("EmailEnvVars(bitbucket) = %v", got)
+	}
+	if got := provider.EmailEnvVars("github"); got != nil {
+		t.Errorf("EmailEnvVars(github) = %v, want nil", got)
+	}
+}
+
+func TestTokenEnvVars_Bitbucket(t *testing.T) {
+	if got := provider.TokenEnvVars("bitbucket"); !equalSlices(got, []string{"BITBUCKET_TOKEN"}) {
+		t.Errorf("TokenEnvVars(bitbucket) = %v", got)
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -23,6 +23,7 @@
 package release
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -32,6 +33,7 @@ import (
 	"monorel.disaresta.com/changeset"
 	"monorel.disaresta.com/config"
 	"monorel.disaresta.com/internal/git"
+	"monorel.disaresta.com/internal/provider"
 	"monorel.disaresta.com/plan"
 )
 
@@ -225,6 +227,17 @@ type TagOptions struct {
 	// Repo reads the HEAD commit message and creates the tags. Push
 	// is the caller's job.
 	Repo git.Repo
+
+	// Provider, when non-nil, enables the universal PR-body trailers
+	// fallback: when HEAD's commit message has no monorel-Release:
+	// trailers (e.g. a squash-merge rewrote the body), Tag looks up
+	// the PR that was merged at HEAD's SHA via
+	// [provider.Client.FindPRByMergeCommit] and parses trailers from
+	// the PR body's `<!-- monorel-trailers ... -->` comment block.
+	//
+	// nil disables the fallback (Tag returns [ErrNoReleaseCommit] on
+	// missing trailers, the pre-fallback behavior).
+	Provider provider.Client
 }
 
 // Tag reads HEAD's commit trailers, looks each released package up in
@@ -274,7 +287,24 @@ func Tag(opts TagOptions) (*Result, error) {
 	}
 	tagged, prerelease := parseReleaseTrailers(msg)
 	if len(tagged) == 0 {
-		return nil, ErrNoReleaseCommit
+		// Fallback: look up the merged PR's body for a trailers
+		// comment block. Squash-merges rewrite the commit body, so
+		// the trailers from Apply's commit may not survive the
+		// merge. The preview render also writes the same trailers
+		// into the PR body (an HTML comment), and PR bodies survive
+		// every merge strategy.
+		if opts.Provider != nil {
+			fallbackTagged, fallbackPre, ferr := tryPRBodyFallback(opts)
+			if ferr != nil {
+				return nil, ferr
+			}
+			if len(fallbackTagged) > 0 {
+				tagged, prerelease = fallbackTagged, fallbackPre
+			}
+		}
+		if len(tagged) == 0 {
+			return nil, ErrNoReleaseCommit
+		}
 	}
 
 	// Build the tag list and preflight: every named package must
@@ -512,6 +542,52 @@ func commitMessage(p *plan.ReleasePlan, pre bool) string {
 	fmt.Fprintf(&trailers, "monorel-PreRelease: %t\n", pre)
 
 	return subject + "\n\n" + trailers.String()
+}
+
+// tryPRBodyFallback queries the provider for the merged PR at HEAD's
+// SHA and parses release trailers from the PR body's
+// `<!-- monorel-trailers ... -->` comment block. Returns empty slices
+// when the PR isn't found or the comment block is absent: both are
+// "no fallback available," not errors. Returns a non-nil error only
+// when the underlying repo / provider call fails.
+func tryPRBodyFallback(opts TagOptions) ([]taggedRelease, bool, error) {
+	headSHA, err := opts.Repo.CurrentSHA()
+	if err != nil {
+		return nil, false, fmt.Errorf("release: read HEAD SHA for fallback: %w", err)
+	}
+	pr, err := opts.Provider.FindPRByMergeCommit(context.Background(), headSHA)
+	if err != nil {
+		return nil, false, fmt.Errorf("release: PR-body fallback: %w", err)
+	}
+	if pr == nil {
+		return nil, false, nil
+	}
+	block := extractTrailersBlock(pr.Body)
+	if block == "" {
+		return nil, false, nil
+	}
+	tagged, prerelease := parseReleaseTrailers(block)
+	return tagged, prerelease, nil
+}
+
+// extractTrailersBlock returns the lines inside an HTML comment block
+// of the form `<!-- monorel-trailers ... -->`, or "" if no such block
+// is present. Bitbucket / GitHub / GitLab / Gitea all preserve HTML
+// comments on PR-body fetches, so the same extractor works across
+// providers.
+func extractTrailersBlock(prBody string) string {
+	const startMarker = "<!-- monorel-trailers"
+	const endMarker = "-->"
+	start := strings.Index(prBody, startMarker)
+	if start == -1 {
+		return ""
+	}
+	tail := prBody[start+len(startMarker):]
+	end := strings.Index(tail, endMarker)
+	if end == -1 {
+		return ""
+	}
+	return strings.TrimSpace(tail[:end])
 }
 
 // taggedRelease is a single (name, version) pair extracted from a

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -503,6 +503,69 @@ monorel-PreRelease: false
 	}
 }
 
+func TestTag_FallbackPRWithoutTrailersBlock(t *testing.T) {
+	// HEAD has no trailers; the fallback finds a merged PR but its
+	// body lacks the <!-- monorel-trailers --> comment block. Tag
+	// should still return ErrNoReleaseCommit (a PR exists but offers
+	// nothing to recover from).
+	f := git.NewFake()
+	f.HeadSHA = "abc123"
+	if err := f.Add("dummy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Commit("chore(release): foo v1.7.0\n\n(no trailers; squash-merge)"); err != nil {
+		t.Fatal(err)
+	}
+
+	pf := provider.NewFake()
+	pf.PRs[42] = &provider.PullRequest{
+		Number:    42,
+		State:     "closed",
+		Title:     "release",
+		Body:      "Just a regular PR description, no trailers block here.",
+		MergedSHA: "abc123",
+	}
+
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"foo": pkgConfig("transports/foo", "transports/foo"),
+		},
+	}
+	_, err := release.Tag(release.TagOptions{Config: cfg, Repo: f, Provider: pf})
+	if !errors.Is(err, release.ErrNoReleaseCommit) {
+		t.Fatalf("err = %v, want ErrNoReleaseCommit", err)
+	}
+}
+
+func TestTag_FallbackProviderError(t *testing.T) {
+	// HEAD has no trailers; the provider call itself errors (e.g. a
+	// network failure). Tag should propagate the wrapped error rather
+	// than masking it as ErrNoReleaseCommit.
+	f := git.NewFake()
+	f.HeadSHA = "abc123"
+	if err := f.Add("dummy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Commit("chore(release): foo v1.7.0\n\n(no trailers)"); err != nil {
+		t.Fatal(err)
+	}
+
+	pf := provider.NewFake()
+	pf.FailNext = provider.FailOnce(errors.New("network down"))
+
+	cfg := &config.Config{Packages: map[string]config.PackageConfig{}}
+	_, err := release.Tag(release.TagOptions{Config: cfg, Repo: f, Provider: pf})
+	if err == nil {
+		t.Fatal("expected wrapped network error; got nil")
+	}
+	if errors.Is(err, release.ErrNoReleaseCommit) {
+		t.Errorf("err = %v; should NOT be ErrNoReleaseCommit (provider failed)", err)
+	}
+	if !strings.Contains(err.Error(), "network down") {
+		t.Errorf("err = %q; should wrap underlying network error", err.Error())
+	}
+}
+
 func TestTag_FallbackBothMissing(t *testing.T) {
 	// HEAD has no trailers AND the provider has no PR matching the
 	// SHA. Tag should still return ErrNoReleaseCommit (fallback isn't

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -9,7 +9,9 @@ import (
 
 	"monorel.disaresta.com/changeset"
 	"monorel.disaresta.com/config"
+	"monorel.disaresta.com/internal/git"
 	"monorel.disaresta.com/internal/git/testutil"
+	"monorel.disaresta.com/internal/provider"
 	"monorel.disaresta.com/internal/release"
 	"monorel.disaresta.com/plan"
 	"monorel.disaresta.com/semver"
@@ -457,6 +459,73 @@ func TestApply_PreRelease_TrailerFlagsTrue(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("commit message missing %q\nfull:\n%s", want, msg)
 		}
+	}
+}
+
+func TestTag_FallbackToPRBody(t *testing.T) {
+	// Squash-merge has rewritten HEAD's commit body, removing the
+	// monorel-Release: trailers. Tag with a Provider set should fall
+	// back to fetching the merged PR's body and parsing trailers from
+	// the embedded HTML comment block.
+	f := git.NewFake()
+	f.HeadSHA = "abc123"
+	if err := f.Add("dummy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Commit("chore(release): foo v1.7.0\n\n(no trailers; squash-merge)"); err != nil {
+		t.Fatal(err)
+	}
+
+	pf := provider.NewFake()
+	pf.PRs[42] = &provider.PullRequest{
+		Number: 42,
+		State:  "closed",
+		Title:  "release",
+		Body: `Plan body
+<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)
+monorel-Release: foo v1.7.0
+monorel-PreRelease: false
+-->`,
+		MergedSHA: "abc123",
+	}
+
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"foo": pkgConfig("transports/foo", "transports/foo"),
+		},
+	}
+	res, err := release.Tag(release.TagOptions{Config: cfg, Repo: f, Provider: pf})
+	if err != nil {
+		t.Fatalf("Tag with fallback: %v", err)
+	}
+	if len(res.Releases) != 1 || res.Releases[0].Tag != "transports/foo/v1.7.0" {
+		t.Errorf("got %+v, want one tag transports/foo/v1.7.0", res.Releases)
+	}
+}
+
+func TestTag_FallbackBothMissing(t *testing.T) {
+	// HEAD has no trailers AND the provider has no PR matching the
+	// SHA. Tag should still return ErrNoReleaseCommit (fallback isn't
+	// a free pass; both sources have to be empty for a no-op).
+	f := git.NewFake()
+	f.HeadSHA = "abc123"
+	if err := f.Add("dummy"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Commit("chore(release): foo v1.7.0\n\n(no trailers)"); err != nil {
+		t.Fatal(err)
+	}
+
+	pf := provider.NewFake()
+	// No PR seeded.
+
+	cfg := &config.Config{Packages: map[string]config.PackageConfig{}}
+	_, err := release.Tag(release.TagOptions{Config: cfg, Repo: f, Provider: pf})
+	if err == nil {
+		t.Fatal("expected ErrNoReleaseCommit; got nil")
+	}
+	if !errors.Is(err, release.ErrNoReleaseCommit) {
+		t.Errorf("err = %v, want ErrNoReleaseCommit", err)
 	}
 }
 

--- a/internal/release/render.go
+++ b/internal/release/render.go
@@ -80,6 +80,19 @@ func RenderPreview(p *plan.ReleasePlan, today string) string {
 		fmt.Fprintln(&b, "._")
 	}
 
+	// Append the monorel-trailers comment block. Invisible in the
+	// rendered PR body (HTML comment); used by `monorel tag` as a
+	// fallback when the merge commit body is rewritten (e.g. by
+	// squash-merge). All four providers preserve HTML comments on
+	// PR-body fetches.
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)")
+	for _, r := range p.Releases {
+		fmt.Fprintf(&b, "monorel-Release: %s %s\n", r.Name, r.To)
+	}
+	fmt.Fprintf(&b, "monorel-PreRelease: %t\n", anyPrerelease(p))
+	fmt.Fprintln(&b, "-->")
+
 	return b.String()
 }
 
@@ -141,6 +154,18 @@ func RenderPreviewCompact(p *plan.ReleasePlan) string {
 		fmt.Fprint(&b, strings.Join(names, ", "))
 		fmt.Fprintln(&b, "._")
 	}
+
+	// Trailers comment block: same purpose as in RenderPreview. Even
+	// when the body is compacted to fit a provider's PR-body limit,
+	// `monorel tag`'s squash-merge fallback must still find trailers
+	// here.
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)")
+	for _, r := range p.Releases {
+		fmt.Fprintf(&b, "monorel-Release: %s %s\n", r.Name, r.To)
+	}
+	fmt.Fprintf(&b, "monorel-PreRelease: %t\n", anyPrerelease(p))
+	fmt.Fprintln(&b, "-->")
 
 	return b.String()
 }

--- a/internal/release/render.go
+++ b/internal/release/render.go
@@ -85,13 +85,7 @@ func RenderPreview(p *plan.ReleasePlan, today string) string {
 	// fallback when the merge commit body is rewritten (e.g. by
 	// squash-merge). All four providers preserve HTML comments on
 	// PR-body fetches.
-	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, "<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)")
-	for _, r := range p.Releases {
-		fmt.Fprintf(&b, "monorel-Release: %s %s\n", r.Name, r.To)
-	}
-	fmt.Fprintf(&b, "monorel-PreRelease: %t\n", anyPrerelease(p))
-	fmt.Fprintln(&b, "-->")
+	writeTrailersBlock(&b, p)
 
 	return b.String()
 }
@@ -159,13 +153,7 @@ func RenderPreviewCompact(p *plan.ReleasePlan) string {
 	// when the body is compacted to fit a provider's PR-body limit,
 	// `monorel tag`'s squash-merge fallback must still find trailers
 	// here.
-	fmt.Fprintln(&b)
-	fmt.Fprintln(&b, "<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)")
-	for _, r := range p.Releases {
-		fmt.Fprintf(&b, "monorel-Release: %s %s\n", r.Name, r.To)
-	}
-	fmt.Fprintf(&b, "monorel-PreRelease: %t\n", anyPrerelease(p))
-	fmt.Fprintln(&b, "-->")
+	writeTrailersBlock(&b, p)
 
 	return b.String()
 }
@@ -177,4 +165,19 @@ func anyPrerelease(p *plan.ReleasePlan) bool {
 		}
 	}
 	return false
+}
+
+// writeTrailersBlock appends the <!-- monorel-trailers ... --> HTML
+// comment block to b. monorel tag's PR-body fallback parses this
+// block when a squash-merge has rewritten the commit body. Both
+// RenderPreview and RenderPreviewCompact emit it so the fallback
+// works regardless of which body shape was published.
+func writeTrailersBlock(b *strings.Builder, p *plan.ReleasePlan) {
+	fmt.Fprintln(b)
+	fmt.Fprintln(b, "<!-- monorel-trailers (do not edit; required for tag recovery if the merge commit body is rewritten)")
+	for _, r := range p.Releases {
+		fmt.Fprintf(b, "monorel-Release: %s %s\n", r.Name, r.To)
+	}
+	fmt.Fprintf(b, "monorel-PreRelease: %t\n", anyPrerelease(p))
+	fmt.Fprintln(b, "-->")
 }

--- a/internal/release/render_test.go
+++ b/internal/release/render_test.go
@@ -97,6 +97,60 @@ func TestRenderPreview_PrereleaseNote(t *testing.T) {
 	}
 }
 
+func TestRenderPreview_IncludesTrailersComment(t *testing.T) {
+	p := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{
+			{
+				Name: "transports/foo",
+				From: "v1.6.0",
+				To:   "v1.7.0",
+				Bump: semver.Minor,
+				Tag:  "transports/foo/v1.7.0",
+			},
+			{
+				Name: "go.example.com/widget",
+				From: "v2.0.0",
+				To:   "v2.0.1",
+				Bump: semver.Patch,
+				Tag:  "v2.0.1",
+			},
+		},
+	}
+	got := release.RenderPreview(p, "2026-05-03")
+
+	if !strings.Contains(got, "<!-- monorel-trailers") {
+		t.Errorf("expected monorel-trailers comment; got:\n%s", got)
+	}
+	for _, want := range []string{
+		"monorel-Release: transports/foo v1.7.0",
+		"monorel-Release: go.example.com/widget v2.0.1",
+		"monorel-PreRelease: false",
+		"-->",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in body:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderPreview_TrailersInPrereleaseMode(t *testing.T) {
+	p := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{{
+			Name:       "transports/foo",
+			From:       "v1.6.0",
+			To:         "v1.7.0-rc.0",
+			Bump:       semver.Minor,
+			Tag:        "transports/foo/v1.7.0-rc.0",
+			Prerelease: true,
+		}},
+	}
+	got := release.RenderPreview(p, "2026-05-03")
+
+	if !strings.Contains(got, "monorel-PreRelease: true") {
+		t.Errorf("PreRelease trailer should be true:\n%s", got)
+	}
+}
+
 func TestRenderPreviewCompact(t *testing.T) {
 	cs := &changeset.Changeset{
 		Name:  "first",


### PR DESCRIPTION
## Summary

- New Bitbucket Cloud provider (`provider.name = "bitbucket"`) bringing monorel to a fourth forge alongside GitHub, Gitea / Forgejo, and GitLab. Hand-rolled `net/http` (no new direct deps).
- New `provider.Client.FindPRByMergeCommit(sha)` method, implemented across all four providers and the in-memory Fake. `provider.PullRequest` gains a `MergedSHA` field populated by every provider's PR-conversion helper.
- New universal PR-body trailers fallback that benefits every provider: `monorel preview` writes a `<!-- monorel-trailers ... -->` HTML comment block into the PR body; `monorel tag` falls back to that block when HEAD's commit message has no `monorel-Release:` trailers (e.g. squash-merge rewrote the body).
- Bitbucket Cloud has no first-class Release concept, so `monorel publish` is a no-op on Bitbucket; per-package `CHANGELOG.md` is the canonical release-notes source.

## Architecture

`internal/provider/bitbucket/` mirrors the gitlab package's shape: `Options` + `New(ctx, opts) (provider.Client, error)`, sentinel errors with `errors.Is` semantics, per-method `bbPullRequest` shape mappers, status-code mapper that names the user-actionable fix for each 4xx/5xx (`ErrPlanGate`, `ErrRateLimited`).

REST auth uses HTTP Basic with `email + token` (Atlassian API token with `read:account + read/write:repository:bitbucket + read/write:pullrequest:bitbucket` scopes). Git over HTTPS uses `<bitbucket-username>:<token>` rather than email; the username is probed from `/2.0/user` with a `sync.Once` cache.

The trailers fallback adds an optional `Provider provider.Client` field to `release.TagOptions`. When the field is non-nil and HEAD has no trailers, `monorel tag` queries `Provider.FindPRByMergeCommit(headSHA)` and parses trailers from the merged PR's body. `internal/cli/tag.go` constructs the provider client inline (mirroring `preview.go` / `publish.go`).

## Validation

Live end-to-end against `bitbucket.org/disaresta-org`:

- ✅ `monorel apply` + push `monorel/release` + `preview --upsert` from main → opens release PR with the trailers comment block
- ✅ Squash-merge → `monorel tag` (commit body lacks trailers) → fallback reads PR body → tags successfully
- ✅ merge_commit strategy → same fallback path → tags successfully
- ✅ Post-merge release pipeline (`monorel tag` → push tags → `monorel publish`)

Live testing surfaced **three real bugs** in the originally-shipped `bitbucket-pipelines.yml` example that are fixed in this PR:

1. Detection used `\$BITBUCKET_COMMIT_MESSAGE`, an env var Bitbucket Pipelines doesn't define. Replaced with `git log -1 --format=%B`.
2. The `^chore(release):` regex matched only the commit subject, but Bitbucket's merge strategies (squash and merge_commit) produce subjects like `Merged in <branch> (pull request #N)`. The chore(release): marker only lands as a body line. Updated to `(^|\n)chore\(release\):` against the full message.
3. `preview --upsert` ran from `monorel/release` (where `apply` had just consumed the changesets), so the planner reported an empty plan and no PR opened. Now checks out back to `\$BITBUCKET_BRANCH` first, and runs unconditionally so empty plans can close stale release PRs.

## Test plan

- [x] `go test -race ./...` clean
- [x] `go vet ./...`, `staticcheck ./...`, `gofmt -l .` all clean
- [x] `bun run docs:build` clean
- [x] Build-tag-gated integration test (`go test -tags=integration ./internal/provider/bitbucket/`) passes against live Bitbucket Cloud
- [x] Universal trailers fallback tests cover all four leaves (provider nil / provider returns nil PR / PR body has no block / provider call errored)
- [x] Live release flow validated end-to-end on a temp Bitbucket repo

## Related

- Spec: `docs/superpowers/specs/2026-05-03-bitbucket-provider-design.md`
- Plan: `docs/superpowers/plans/2026-05-03-bitbucket-provider.md`
- Each phase had a per-phase spec-compliance review and code-quality review with follow-up commits; final pre-merge review pass before opening this PR.