### PR TITLE
fix: address issue #54 (cacheseed wrong-hash + pipeline robustness)

### DIFF
--- a/.changeset/cacheseed-fixpoint-and-pipeline-fixes.md
+++ b/.changeset/cacheseed-fixpoint-and-pipeline-fixes.md
@@ -1,0 +1,19 @@
+---
+"monorel.disaresta.com": minor
+---
+
+Fix `cacheseed` writing the wrong h1: hash for released sub-modules
+(would silently produce broken go.sum entries on every release; see
+[`loglayer/loglayer-go`'s v2.1.0 incident](https://github.com/loglayer/loglayer-go/pull/76)).
+Reorder `applyStable` so all working-tree mutations happen before
+the seed step, and replace the single-pass seed-and-tidy with
+iterate-to-fixpoint to handle cross-sibling dep chains.
+
+Add a `go mod download` priming step before offline tidy so fresh
+CI runners (with empty `GOMODCACHE`) can resolve third-party deps.
+The `GOPROXY=off` invariant during tidy is preserved.
+
+Document the `actions/setup-go` prerequisite (sub-modules with
+`go 1.25.0` directives need a 1.25+ runner since `GOTOOLCHAIN=local`
+during tidy blocks auto-download) and the `chore(release):`-commit
+skip filter recipe. See [issue #54](https://github.com/disaresta-org/monorel/issues/54).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ monorel init
 #    examples/{github,gitea,gitlab}/ into your repo
 
 # 4. Author a changeset on a feature branch
-monorel add --package "transports/foo:minor" --message "Adds Lazy() helper."
+monorel add
 git commit && gh pr create
 
 # 5. Merge the PR. The release-pr workflow opens (or updates) an

--- a/ci/github/README.md
+++ b/ci/github/README.md
@@ -40,6 +40,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # monorel runs `go mod tidy` with GOTOOLCHAIN=local during release,
+      # so Go must already be installed at a version satisfying every
+      # released sub-module's `go` directive (the highest one wins).
+      # `go-version-file: go.mod` reads the root module's go.mod; if a
+      # sub-module declares a higher floor, pin `go-version` explicitly.
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -65,6 +70,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # monorel runs `go mod tidy` with GOTOOLCHAIN=local during release,
+      # so Go must already be installed at a version satisfying every
+      # released sub-module's `go` directive (the highest one wins).
+      # `go-version-file: go.mod` reads the root module's go.mod; if a
+      # sub-module declares a higher floor, pin `go-version` explicitly.
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -77,9 +87,38 @@ jobs:
 
 - **`go` on `PATH`.** monorel's `apply` step runs `go mod tidy` (offline, against a seeded local cache) in every released sub-module that requires an in-plan sibling, so the release commit's `go.sum` is canonically clean for the proxy-published state. The runner needs a `go` binary whose version satisfies every released module's `go` directive; use `actions/setup-go@v5` with `go-version-file: go.mod` (or pin `go-version` explicitly) to install the right version. GitHub-hosted runners include a recent Go by default, but pinning is safer than relying on the runner's pre-installed version, especially when modules use a recent `go` directive.
 
+  If the runner's Go is older than the highest sub-module's `go` directive, tidy fails with `go.mod requires go >= X.Y; running Z; GOTOOLCHAIN=local`. The fix is always to bump the runner's Go (raise the `go-version`), not to remove `GOTOOLCHAIN=local` from monorel's tidy step (the env var is part of monorel's offline-tidy determinism guarantee).
+
+  See [Avoiding the chore(release) CI race](../../docs/src/workflows.md#avoiding-the-chorerelease-ci-race) for the related skip-filter pattern other workflows on the same branch should apply.
+
 ## Notes
 
 - The action runs as a composite action that shells out to `monorel`. Calling it via `disaresta-org/monorel/ci/github@vX.Y.Z` pins both the action and the binary version (the action resolves `inputs.version` via the GitHub Releases API).
 - For self-hosted GitHub Enterprise installations, set `monorel.toml`'s `[provider].host` field; the action passes `GITHUB_TOKEN` through and the binary picks up the host from config.
 - Windows runners are supported. The download step matches the binary by name (`monorel` or `monorel.exe`) and installs to `$RUNNER_TEMP` with a `$GITHUB_PATH` entry rather than the Linux/macOS `/usr/local/bin` path.
 - The `pr` command currently runs `monorel preview --upsert` only. It does not yet stage CHANGELOG edits on a release branch; the upserted PR body shows the rendered plan but does not include file diffs. The action will gain branch staging in a follow-up release.
+
+## Recipes
+
+### Skipping CI on chore(release) commits
+
+The release commit `chore(release): ...` is created by the always-open release PR's merge. On the same push event, `release.yml` (using this action with `command: release`) creates and pushes per-package tags. Any *other* workflow that runs on the same push and resolves Go module versions will race the tag-push and may transiently fail with:
+
+```
+go: example.com/foo/v2: reading example.com/foo/go.mod at revision v2.1.0: unknown revision v2.1.0
+```
+
+To avoid the phantom failure, skip the workflow on `chore(release):` commits. The skip filter:
+
+```yaml
+jobs:
+  test:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    # ... rest of job ...
+```
+
+Apply the filter to every job (`test`, `staticcheck`, `govulncheck`, etc.) that runs `go mod tidy` or anything else that resolves the new versions. Pull-request triggers stay always-on; only push-to-main runs are skipped, and only when the head commit is the release-PR merge.
+
+The `release.yml` workflow that runs the actual release pipeline does NOT need this filter; its own `if:` clause is the *opposite* shape (only run on `chore(release):` commits), so it's already mutually exclusive with the skip pattern above.
+
+For non-GitHub-Actions CI systems, see the [universal recipe](../../docs/src/workflows.md#avoiding-the-chorerelease-ci-race) covering GitHub / GitLab / Gitea filter syntax.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   srcDir: 'src',
   appearance: 'force-dark',
   sitemap: { hostname: baseUrl },
+  ignoreDeadLinks: [/ci\/github\/README/],
   async transformHead({ pageData }) {
     const head: HeadConfig[] = [
       // Google Analytics (gtag.js)

--- a/docs/src/workflows.md
+++ b/docs/src/workflows.md
@@ -165,3 +165,64 @@ Switching channels (e.g. `rc` → `beta`) requires `monorel pre exit` first; ent
 - [Changesets](/changesets) for the `.changeset/<name>.md` file format.
 - [GitHub Action](/integrations/github) for the workflow YAML and token setup.
 - [FAQ](/faq) for the questions that come up after the first release.
+
+## CI environment requirements
+
+Any CI system invoking `monorel release` (GitHub Actions, GitLab CI, Gitea Actions, CircleCI, Drone, self-hosted runners) must provide the following:
+
+- **Go installed at a version compatible with every released sub-module's `go` directive.** monorel runs `go mod tidy` with `GOTOOLCHAIN=local` during release; the env var is intentional and part of the offline-tidy determinism guarantee. Auto-toolchain-download is blocked. Pin the runner's Go to the highest floor explicitly (or use `go-version-file: go.mod` if the root module's `go` directive matches the highest sub-module floor).
+- **`GOPROXY` set to a real proxy or `direct`.** monorel's release pipeline includes a "prime cache" step that runs `go mod download` (with the inherited `GOPROXY`) to populate the local module cache for third-party deps. The offline tidy that follows uses `GOPROXY=off` regardless of this setting; only the priming step honors `GOPROXY`. If `GOPROXY` is empty or missing, `go mod download` falls back to its default (`https://proxy.golang.org,direct`), which is what most CI systems already provide implicitly.
+- **Push permissions for tags.** The `release` command runs `git push --follow-tags` to publish the per-package tags created by `monorel release`. The runner's git config needs commit + push credentials.
+- **Provider API token.** For the `pr` command (always-open release PR maintenance) and the `publish` step inside `release`, the provider API token needs `contents: write` and `pull-requests: write` (GitHub naming; equivalent on GitLab / Gitea).
+
+For GitHub Actions, see [`ci/github/README.md`](../../ci/github/README.md) for the canonical workflow examples that satisfy these requirements.
+
+For GitLab CI, the equivalent setup is a `before_script:` block that installs Go (e.g., via the `golang:1.25` image or a `gimme` install) and a `rules:` clause on each job (see "Avoiding the chore(release) CI race" below). The token requirement maps to `CI_JOB_TOKEN` for read-only access plus a project access token for push/release operations.
+
+For Gitea Actions, the syntax matches GitHub Actions (Gitea Actions is API-compatible). Substitute `disaresta-org/monorel/ci/github@<version>` references with whatever path your Gitea instance uses for the same action.
+
+## Avoiding the chore(release) CI race
+
+The release commit `chore(release): ...` (created when the always-open release PR is merged) updates module `go.mod` files to require new in-plan sibling versions. The matching tags are created and pushed by the workflow running `monorel release` on the same push. Any *other* workflow that fires on the same push and resolves Go module versions will race the tag push and may transiently fail with:
+
+```
+go: example.com/foo/v2: reading example.com/foo/go.mod at revision v2.1.0: unknown revision v2.1.0
+```
+
+The release succeeds and the tags get pushed, but the racing workflow's red mark stays in the UI. The fix is to skip the racing workflow when the head commit subject begins with `chore(release):`. The principle is universal; the syntax varies per CI system.
+
+### GitHub Actions / Gitea Actions
+
+Same syntax: an `if:` clause on each job that runs Go module resolution.
+
+```yaml
+jobs:
+  test:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    # ... rest of job ...
+```
+
+See [`ci/github/README.md`](../../ci/github/README.md#skipping-ci-on-chorerelease-commits) for the full GitHub Actions snippet.
+
+### GitLab CI
+
+Use a `rules:` clause on each job:
+
+```yaml
+test:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_TITLE =~ /^chore\(release\):/'
+      when: never
+    - when: on_success
+  script:
+    - go test ./...
+```
+
+The two-clause `rules` first allows merge-request runs through unconditionally, then explicitly drops `chore(release):` push runs on the default branch, then defaults to running.
+
+### Other CI systems
+
+The principle is universal: skip the workflow when the head commit subject starts with `chore(release):`. Most CI systems support a per-job filter on commit message; the exact key varies (`commit.message`, `CI_COMMIT_MESSAGE`, `BUILDKITE_MESSAGE`, etc.). Apply the same `^chore(release):` regex check.
+
+The release-pipeline workflow itself (the one running `monorel release`) does NOT need this filter; its own filter is the *opposite* shape (only run on `chore(release):`), so it's mutually exclusive with the skip pattern above.

--- a/docs/superpowers/plans/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes.md
+++ b/docs/superpowers/plans/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes.md
@@ -1,0 +1,2137 @@
+# cacheseed-fixpoint and release-pipeline fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address [issue #54](https://github.com/disaresta-org/monorel/issues/54) end-to-end. Fix the `cacheseed.go` wrong-`h1:`-hash bug that breaks every monorel-driven release. Add a cache-priming step so offline tidy works on fresh CI runners. Document the toolchain prerequisite and the chore(release) CI race in the right doc layers.
+
+**Architecture:** Three coordinated changes in one PR:
+
+1. Reorder `applyStable` so all working-tree mutations happen before the cache seed, and replace the single-pass seed-and-tidy inside `tidySubmoduleGoSums` with iterate-to-fixpoint.
+2. Add a `primeModuleCache` step before the seed so third-party deps land in `GOMODCACHE` before offline tidy runs with `GOPROXY=off`.
+3. Inline-comment the existing `actions/setup-go` step in `ci/github/README.md`'s example workflows, add a Recipes section with the chore(release) skip filter, and add CI-agnostic universal sections to `docs/src/workflows.md`.
+
+**Tech Stack:** Go 1.26 (per the existing `go.mod`). Test infra: standard `testing` + the existing `setupSubmoduleFixture` helper in `internal/release/gosum_test.go`. Hash computation via `golang.org/x/mod/sumdb/dirhash` and `golang.org/x/mod/zip`. Spec at `docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md`.
+
+---
+
+## File structure
+
+**Modified:**
+
+- `internal/release/release.go`: reorder consumed-changesets deletion in `applyStable` to run before `tidySubmoduleGoSums` (concern #1, fix part 1).
+- `internal/release/cacheseed.go`: change `seedModuleCache` return type from `(func(), error)` to `([]seededEntry, error)`. Add exported helper `clearSeededEntries`.
+- `internal/release/gosum.go`: replace single-pass body of `tidySubmoduleGoSums` with iterate-to-fixpoint loop. Add `readGoSums`, `goSumsChanged`, `stageAffected` helpers. Add `errFixpointNotReached` error type (concern #1, fix part 2). Insert `primeModuleCache` call before the seed step (concern #2).
+- `internal/release/tidy.go`: add `primeModuleCache` and `primeCacheEnv` next to existing `runOfflineTidy` and `offlineTidyEnv` (concern #2).
+- `internal/release/gosum_test.go`: regression tests for concerns #1 and #2.
+- `ci/github/README.md`: inline comments on `actions/setup-go` in both example workflows; strengthen "Requirements" → "go on PATH" bullet; add new "## Recipes" section (concerns #3 and #4 GitHub-specific).
+- `docs/src/workflows.md`: add "## CI environment requirements" and "## Avoiding the chore(release) CI race" sections (concerns #3 and #4 universal).
+- `CHANGELOG.md`: entry under the next release covering all four concerns.
+
+**New:**
+
+- `.changeset/cacheseed-fixpoint-and-pipeline-fixes.md`: changeset declaring a `:minor` bump.
+
+---
+
+## Working agreements
+
+- **Branch:** `fix/cacheseed-fixpoint` in `/tmp/monorel-src` (already cut from `main`). All commits land on this branch.
+- **Per-task verify command:** `go test ./...` from the repo root, unless the task explicitly says otherwise.
+- **Commit format:** Conventional Commits with appropriate scope. Body explains the why; trailers include `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- **No `--no-verify`:** monorel's repo doesn't have a lefthook pre-commit hook today (verified by `ls .lefthook* lefthook.yml` returning empty). If commits fail for unexpected reasons, debug rather than bypass.
+- **TDD discipline:** every code change is preceded by a test that demonstrates the bug. Don't commit "implementation + test" together unless the spec calls for the implementation to be the test.
+- **Each task ends in a green commit.** No half-finished states across task boundaries.
+- **Self-review before commit:** read the diff. Confirm only the intended files / lines changed. Run `go test ./...` from the repo root.
+
+---
+
+## Task 1: regression test for the changeset-deletion mutation race
+
+**Files:**
+- Modify: `internal/release/gosum_test.go`
+
+This task adds a failing test that demonstrates the bug. The fix lands in Task 2.
+
+- [ ] **Step 1: Read the existing test fixture.**
+
+Open `/tmp/monorel-src/internal/release/gosum_test.go` and skim `setupSubmoduleFixture` (around line 31). Note its shape: it builds two modules `a` and `b` under `repoDir`, with optional `aRequiresB`, and sets `GOMODCACHE` to a temp dir. It does NOT create a `.changeset/` directory or any consumed changesets. The new test will need to.
+
+- [ ] **Step 2: Add a new test that exercises `Apply` end-to-end with a consumed changeset.**
+
+Append to `internal/release/gosum_test.go`:
+
+```go
+// TestApply_RootChangesetDeletion_HashesMatchPublished pins the
+// regression for the loglayer-go v2.1.0 incident. The chore(release)
+// commit deletes consumed `.changeset/*.md` files. Those files live
+// inside the root module's source tree, so the root module's zip
+// hash differs between (a) the working tree at seed time (with the
+// changesets present) and (b) the chore(release) commit (without
+// them). Before the fix in Task 2, the affected sub-module's go.sum
+// would record (a)'s hash, which doesn't match what `git archive`
+// of the published tag produces.
+//
+// This test runs the full Apply pipeline and asserts that the
+// `h1:` for the in-plan root recorded in the affected sub-module's
+// go.sum equals the hash of `git archive` against the chore(release)
+// commit.
+func TestApply_RootChangesetDeletion_HashesMatchPublished(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("`go` not on PATH: %v", err)
+	}
+
+	repoDir := t.TempDir()
+	tmpModCache := t.TempDir()
+	t.Cleanup(func() {
+		filepath.WalkDir(tmpModCache, func(path string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			os.Chmod(path, 0o755)
+			return nil
+		})
+	})
+	t.Setenv("GOMODCACHE", tmpModCache)
+
+	// Layout:
+	//   <repoDir>/
+	//     go.mod              (module example.com/root, go 1.26)
+	//     root.go
+	//     .changeset/foo.md   (will be consumed by the plan)
+	//     sub/go.mod          (requires example.com/root)
+	//     sub/sub.go
+	mustWriteFile(t, filepath.Join(repoDir, "go.mod"),
+		"module example.com/root\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(repoDir, "root.go"),
+		"package root\n\nfunc Hello() string { return \"hi\" }\n")
+	mustWriteFile(t, filepath.Join(repoDir, ".changeset", "foo.md"),
+		"---\n\"root\": minor\n---\n\nbump\n")
+	mustWriteFile(t, filepath.Join(repoDir, "sub", "go.mod"),
+		"module example.com/sub\n\ngo 1.26\n\nrequire example.com/root v0.1.0\n")
+	mustWriteFile(t, filepath.Join(repoDir, "sub", "sub.go"),
+		"package sub\n\nimport \"example.com/root\"\n\nfunc Greet() string { return root.Hello() }\n")
+
+	repo := git.NewFake()
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"root": {TagPrefix: "", Path: "."},
+			"sub":  {TagPrefix: "sub", Path: "sub"},
+		},
+	}
+	rp := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{
+			{Config: cfg.Packages["root"], Tag: "v0.1.0", Bump: semver.Minor},
+			{Config: cfg.Packages["sub"], Tag: "sub/v0.1.0", Bump: semver.Minor},
+		},
+		Consumed: []changeset.Consumed{{Name: "foo"}},
+	}
+
+	opts := Options{
+		Plan:         rp,
+		Config:       cfg,
+		Repo:         repo,
+		RepoDir:      repoDir,
+		ChangesetDir: filepath.Join(repoDir, ".changeset"),
+		Today:        "2026-05-03",
+	}
+
+	if _, err := Apply(opts); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Read back the recorded hash for example.com/root in sub/go.sum.
+	subGoSum, err := os.ReadFile(filepath.Join(repoDir, "sub", "go.sum"))
+	if err != nil {
+		t.Fatalf("read sub/go.sum: %v", err)
+	}
+	recordedH1 := extractH1(t, subGoSum, "example.com/root v0.1.0")
+	if recordedH1 == "" {
+		t.Fatalf("sub/go.sum: missing h1: line for example.com/root v0.1.0\n%s", subGoSum)
+	}
+
+	// Compute what `git archive`'s hash would be against the working
+	// tree as of the chore(release) commit. Apply staged the deletion
+	// of .changeset/foo.md into the FakeRepo, so on disk it's still
+	// there. For the test to compare against the post-deletion shape,
+	// remove the file from the working tree manually here. (FakeRepo
+	// stages but doesn't commit; this is the test's stand-in for the
+	// real commit.)
+	if err := os.Remove(filepath.Join(repoDir, ".changeset", "foo.md")); err != nil {
+		t.Fatalf("remove staged-deleted changeset: %v", err)
+	}
+
+	expectedH1, err := dirhashOfRoot(repoDir)
+	if err != nil {
+		t.Fatalf("compute expected hash: %v", err)
+	}
+	if recordedH1 != expectedH1 {
+		t.Errorf("sub/go.sum recorded wrong h1: for example.com/root v0.1.0\n  recorded: %s\n  expected: %s",
+			recordedH1, expectedH1)
+	}
+}
+
+// extractH1 pulls the `h1:HASH=` value for the given "<module> <version>"
+// prefix from a go.sum file's bytes. Returns the empty string if the
+// line is absent.
+func extractH1(t *testing.T, goSum []byte, prefix string) string {
+	t.Helper()
+	want := []byte(prefix + " ")
+	for _, line := range bytes.Split(goSum, []byte("\n")) {
+		if !bytes.HasPrefix(line, want) {
+			continue
+		}
+		// Skip the /go.mod sub-hash; we want the full-zip hash.
+		if bytes.Contains(line, []byte("/go.mod ")) {
+			continue
+		}
+		// line looks like: example.com/root v0.1.0 h1:HASH=
+		parts := bytes.Fields(line)
+		if len(parts) < 3 {
+			continue
+		}
+		return string(parts[2])
+	}
+	return ""
+}
+
+// dirhashOfRoot computes Hash1 of the root module zip built from
+// repoDir, matching what `git archive` would produce for a published
+// version pointing at the working tree's current state. Used to
+// verify that monorel's recorded hash matches what consumers will
+// fetch.
+func dirhashOfRoot(repoDir string) (string, error) {
+	mv := module.Version{Path: "example.com/root", Version: "v0.1.0"}
+	tmpZip, err := os.CreateTemp("", "monorel-test-zip-*.zip")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpZip.Name())
+	defer tmpZip.Close()
+	if err := xzip.CreateFromDir(tmpZip, mv, repoDir); err != nil {
+		return "", err
+	}
+	if err := tmpZip.Close(); err != nil {
+		return "", err
+	}
+	return dirhash.HashZip(tmpZip.Name(), dirhash.Hash1)
+}
+```
+
+Add the imports to the existing import block at the top of `gosum_test.go`:
+
+```go
+import (
+	"bytes"                                  // NEW: for extractH1
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/mod/module"                // NEW: for dirhashOfRoot
+	"golang.org/x/mod/sumdb/dirhash"         // NEW
+	xzip "golang.org/x/mod/zip"              // NEW
+
+	"monorel.disaresta.com/changeset"
+	"monorel.disaresta.com/config"
+	"monorel.disaresta.com/internal/git"
+	"monorel.disaresta.com/plan"
+	"monorel.disaresta.com/semver"
+)
+```
+
+- [ ] **Step 3: Run the test, confirm it fails.**
+
+Run: `cd /tmp/monorel-src && go test ./internal/release -run TestApply_RootChangesetDeletion_HashesMatchPublished -v`
+
+Expected: FAIL with a hash mismatch like "recorded: h1:... ; expected: h1:..." (different hashes).
+
+If it errors instead of failing on the assertion (e.g., because of an Apply error), debug the fixture before proceeding. The test should reach the final hash comparison and fail there.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/gosum_test.go
+git commit -m "$(cat <<'EOF'
+test(release): regression for chore(release) changeset-deletion hash race
+
+The chore(release) commit deletes consumed `.changeset/*.md` files.
+Those files live inside the root module's source tree, so the root
+module's zip hash differs between (a) the working tree at seed time
+(with the changesets present) and (b) the chore(release) commit
+(without them). The affected sub-module's go.sum then records the
+wrong `h1:` for the in-plan root.
+
+Pin this regression with an end-to-end test that runs Apply and
+compares the recorded hash against `dirhash.HashZip` over the
+post-deletion working tree. The test fails on this commit; the next
+commit (apply-step reorder) makes it pass.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: reorder `applyStable` so consumed-changesets delete before tidy
+
+**Files:**
+- Modify: `internal/release/release.go:382-424`
+
+- [ ] **Step 1: Read `applyStable` to confirm the current order.**
+
+Open `/tmp/monorel-src/internal/release/release.go` and find `applyStable` (line ~379). Confirm the steps in order:
+
+1. CHANGELOG writes (lines 383-398).
+2. `rewriteSubmoduleGoMods` call (lines 403-405).
+3. `tidySubmoduleGoSums` call (lines 411-413).
+4. Consumed-changesets deletion (lines 416-422).
+
+- [ ] **Step 2: Move the consumed-changesets deletion ahead of `tidySubmoduleGoSums`.**
+
+Edit `internal/release/release.go`. The current shape is:
+
+```go
+	// Strip dev-only sibling replaces and pin sibling require
+	// versions in each released package's go.mod, so the published
+	// modules are clean for downstream consumers.
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		return err
+	}
+
+	// Run `go mod tidy` (offline, against a seeded local cache) in
+	// every released sub-module that requires an in-plan sibling, so
+	// the release commit's go.sum entries match what consumers will
+	// hash from the proxy after the tag pushes.
+	if err := tidySubmoduleGoSums(opts); err != nil {
+		return err
+	}
+
+	// Delete the consumed changesets. The planner's Consumed list
+	// dedupes multi-package changesets, so we hit each file once.
+	for _, cs := range opts.Plan.Consumed {
+		rel := filepath.Join(".changeset", cs.Name+".md")
+		if err := opts.Repo.Remove(rel); err != nil {
+			return fmt.Errorf("release: remove %s: %w", rel, err)
+		}
+	}
+	return nil
+}
+```
+
+Replace with (the deletion block moves up; the tidy call moves down):
+
+```go
+	// Strip dev-only sibling replaces and pin sibling require
+	// versions in each released package's go.mod, so the published
+	// modules are clean for downstream consumers.
+	if err := rewriteSubmoduleGoMods(opts); err != nil {
+		return err
+	}
+
+	// Delete the consumed changesets BEFORE seeding/tidy. The
+	// `.changeset/*.md` files live inside the root module's source
+	// tree; running tidy's seed step against a working tree that
+	// still has them produces a hash that doesn't match the
+	// chore(release) commit's hash (which lands without them). See
+	// docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md.
+	for _, cs := range opts.Plan.Consumed {
+		rel := filepath.Join(".changeset", cs.Name+".md")
+		if err := opts.Repo.Remove(rel); err != nil {
+			return fmt.Errorf("release: remove %s: %w", rel, err)
+		}
+	}
+
+	// Run `go mod tidy` (offline, against a seeded local cache) in
+	// every released sub-module that requires an in-plan sibling, so
+	// the release commit's go.sum entries match what consumers will
+	// hash from the proxy after the tag pushes.
+	if err := tidySubmoduleGoSums(opts); err != nil {
+		return err
+	}
+	return nil
+}
+```
+
+Also update the GoDoc on `applyStable` (line ~379) so the comment reflects the new order. Find:
+
+```go
+// applyStable writes CHANGELOG entries, rewrites go.mod files for
+// the released sub-modules, deletes consumed changesets, and stages
+// everything. Caller does the commit.
+```
+
+Replace with:
+
+```go
+// applyStable writes CHANGELOG entries, rewrites go.mod files for
+// the released sub-modules, deletes consumed changesets, then runs
+// offline tidy in every affected sub-module, and stages everything.
+// The deletion happens before tidy so the seed step inside tidy
+// hashes the working tree in its final commit shape (not a
+// transient state with changesets still present); see
+// docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md.
+// Caller does the commit.
+```
+
+Also update `tidySubmoduleGoSums`'s GoDoc in `gosum.go` line ~30:
+
+```go
+// Called from applyStable AFTER rewriteSubmoduleGoMods and BEFORE
+// the consumed-changesets deletion so all the file changes land in
+// the same release commit.
+```
+
+Replace with:
+
+```go
+// Called from applyStable AFTER rewriteSubmoduleGoMods AND AFTER
+// the consumed-changesets deletion. The deletion is upstream of the
+// seed step so the working tree already has its final commit shape;
+// otherwise the seed's hash wouldn't match what `git archive` of
+// the published tag produces. See
+// docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md.
+```
+
+- [ ] **Step 3: Run the regression test from Task 1.**
+
+Run: `cd /tmp/monorel-src && go test ./internal/release -run TestApply_RootChangesetDeletion_HashesMatchPublished -v`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the full release-package test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./internal/release/...`
+
+Expected: PASS for every test, including the existing ones. The reorder is a behavior-preserving refactor for the canonical "no consumed-changeset, no working-tree-mutation-after-seed" case (every existing test).
+
+- [ ] **Step 5: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/release.go internal/release/gosum.go
+git commit -m "$(cat <<'EOF'
+fix(release): delete consumed changesets before tidy seed step
+
+applyStable's order was: CHANGELOG writes -> rewriteSubmoduleGoMods
+-> tidySubmoduleGoSums (seed + tidy) -> consumed-changesets
+deletion -> commit. The seed step inside tidy zipped the working
+tree while consumed `.changeset/*.md` files were still on disk;
+the chore(release) commit landed without them; `git archive` of
+the published tag computed a different hash than the seed produced.
+Affected sub-modules' go.sum recorded the wrong `h1:` for the
+in-plan root, breaking every fresh-cache install with SECURITY
+ERROR.
+
+Move the consumed-changesets deletion ahead of tidy. The seed now
+zips the working tree in its final commit shape; recorded hashes
+match what `git archive` of the published tag produces.
+
+The previous commit's regression test now passes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: change `seedModuleCache` return type to `[]seededEntry`
+
+**Files:**
+- Modify: `internal/release/cacheseed.go`
+- Modify: `internal/release/gosum.go:65-69`
+
+This task changes the API in preparation for the fixpoint loop in Task 5. The fixpoint loop needs to clear and re-seed across iterations; the closure-based cleanup pattern doesn't compose well across iterations.
+
+- [ ] **Step 1: Edit `seedModuleCache` to return `[]seededEntry` instead of a closure.**
+
+Open `internal/release/cacheseed.go`. Find the function signature (line 41):
+
+```go
+func seedModuleCache(opts Options) (cleanup func(), err error) {
+```
+
+Replace with:
+
+```go
+func seedModuleCache(opts Options) (seeded []seededEntry, err error) {
+```
+
+Then replace the function body. The current body is:
+
+```go
+func seedModuleCache(opts Options) (cleanup func(), err error) {
+	mc, err := goModCache()
+	if err != nil {
+		return func() {}, fmt.Errorf("seed module cache: %w", err)
+	}
+
+	var seeded []seededEntry
+	cleanup = func() {
+		for _, e := range seeded {
+			_ = os.Remove(e.infoPath)
+			_ = os.Remove(e.modPath)
+			_ = os.Remove(e.zipPath)
+			_ = os.Remove(e.zipHashPath)
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	for _, r := range opts.Plan.Releases {
+		modDir := filepath.Join(opts.RepoDir, r.Config.Path)
+		modFilePath := filepath.Join(modDir, "go.mod")
+
+		modBytes, err := os.ReadFile(modFilePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return cleanup, fmt.Errorf("seed module cache: read %s: %w", modFilePath, err)
+		}
+
+		mf, err := readModFile(modFilePath)
+		if err != nil {
+			return cleanup, fmt.Errorf("seed module cache: %w", err)
+		}
+		if mf == nil {
+			continue
+		}
+
+		mv := module.Version{
+			Path:    mf.Module.Mod.Path,
+			Version: tagVersion(r.Tag),
+		}
+
+		entry, err := writeCacheEntry(mc, mv, modDir, modBytes, now)
+		seeded = append(seeded, entry)
+		if err != nil {
+			return cleanup, fmt.Errorf("seed module cache for %s@%s: %w", mv.Path, mv.Version, err)
+		}
+	}
+
+	return cleanup, nil
+}
+```
+
+Replace with the slice-returning version:
+
+```go
+func seedModuleCache(opts Options) (seeded []seededEntry, err error) {
+	mc, err := goModCache()
+	if err != nil {
+		return nil, fmt.Errorf("seed module cache: %w", err)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	for _, r := range opts.Plan.Releases {
+		modDir := filepath.Join(opts.RepoDir, r.Config.Path)
+		modFilePath := filepath.Join(modDir, "go.mod")
+
+		modBytes, err := os.ReadFile(modFilePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return seeded, fmt.Errorf("seed module cache: read %s: %w", modFilePath, err)
+		}
+
+		mf, err := readModFile(modFilePath)
+		if err != nil {
+			return seeded, fmt.Errorf("seed module cache: %w", err)
+		}
+		if mf == nil {
+			continue
+		}
+
+		mv := module.Version{
+			Path:    mf.Module.Mod.Path,
+			Version: tagVersion(r.Tag),
+		}
+
+		entry, err := writeCacheEntry(mc, mv, modDir, modBytes, now)
+		// Append unconditionally: writeCacheEntry returns its
+		// (partially-populated) entry on error too, and the caller
+		// uses the slice to clean up whatever was written before
+		// failure. Empty fields in entry round-trip safely through
+		// os.Remove via clearSeededEntries.
+		seeded = append(seeded, entry)
+		if err != nil {
+			return seeded, fmt.Errorf("seed module cache for %s@%s: %w", mv.Path, mv.Version, err)
+		}
+	}
+
+	return seeded, nil
+}
+```
+
+Update the GoDoc just above the function (lines 27-40) to reflect the new return type:
+
+```go
+// seedModuleCache writes the four cache files (.info, .mod, .zip,
+// .ziphash) for every in-plan released package into the developer's
+// Go module cache, in the layout `go mod tidy` expects when running
+// offline. Returns a slice of [seededEntry] tracking every file
+// written; callers pass it to [clearSeededEntries] to remove the
+// entries when done. The slice is populated even on error (whatever
+// was written before the failure) so cleanup can still run.
+//
+// The cleanup is best-effort: per-entry remove failures are not
+// returned, since cache entries are content-addressed and a stale
+// leftover is inert (the next normal fetch overwrites it).
+//
+// Skips packages whose Path doesn't contain a go.mod (e.g. a
+// pure-changelog package), and packages whose go.mod parse fails
+// (those bubble out of the rewriter earlier).
+```
+
+- [ ] **Step 2: Add `clearSeededEntries` helper.**
+
+Append to `internal/release/cacheseed.go` (after `seedModuleCache`, before `writeCacheEntry`):
+
+```go
+// clearSeededEntries removes every cache file in entries. Called by
+// the orchestrator at the end of [tidySubmoduleGoSums] (and between
+// iterations of the fixpoint loop). Best-effort: per-file remove
+// failures are silently ignored, since cache entries are
+// content-addressed and a stale leftover is inert.
+func clearSeededEntries(entries []seededEntry) {
+	for _, e := range entries {
+		_ = os.Remove(e.infoPath)
+		_ = os.Remove(e.modPath)
+		_ = os.Remove(e.zipPath)
+		_ = os.Remove(e.zipHashPath)
+	}
+}
+```
+
+- [ ] **Step 3: Update the single caller in `gosum.go`.**
+
+Open `internal/release/gosum.go` and find the call (line 65-69):
+
+```go
+	// 4. Seed the cache with in-plan releases.
+	cleanup, err := seedModuleCache(opts)
+	defer cleanup()
+	if err != nil {
+		return err
+	}
+```
+
+Replace with:
+
+```go
+	// 4. Seed the cache with in-plan releases.
+	seeded, err := seedModuleCache(opts)
+	defer clearSeededEntries(seeded)
+	if err != nil {
+		return err
+	}
+```
+
+- [ ] **Step 4: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS. The change is a refactor; behavior is unchanged.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/cacheseed.go internal/release/gosum.go
+git commit -m "$(cat <<'EOF'
+refactor(release): seedModuleCache returns slice instead of cleanup closure
+
+Preparation for the fixpoint loop in tidySubmoduleGoSums. The loop
+needs to clear and re-seed the cache across iterations; a cleanup
+closure doesn't compose well with that. Return the []seededEntry
+directly so the orchestrator can pass it to clearSeededEntries
+explicitly, and clear-then-re-seed inside an iteration is a single
+function-call pair rather than a closure dance.
+
+Behavior unchanged. The single caller (tidySubmoduleGoSums) gets a
+two-line update; no other call sites exist (verified via grep).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: add `readGoSums`, `goSumsChanged`, `stageAffected`, `errFixpointNotReached`
+
+**Files:**
+- Modify: `internal/release/gosum.go`
+
+This task adds the helpers and error type the fixpoint loop will use. Loop replacement comes in Task 5.
+
+- [ ] **Step 1: Append the helpers to `internal/release/gosum.go`.**
+
+Add to the end of the file (after `managedImportPaths`):
+
+```go
+// readGoSums reads the go.sum bytes for every sub-module path in
+// affected. Missing files are recorded as nil byte slices (a
+// sub-module that hasn't yet been tidied may not have a go.sum
+// file). Used by [tidySubmoduleGoSums]'s fixpoint loop to detect
+// whether the most recent tidy iteration mutated any go.sum.
+func readGoSums(repoDir string, affected []string) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(affected))
+	for _, sub := range affected {
+		path := filepath.Join(repoDir, sub, "go.sum")
+		b, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				out[sub] = nil
+				continue
+			}
+			return nil, fmt.Errorf("readGoSums: %s: %w", path, err)
+		}
+		out[sub] = b
+	}
+	return out, nil
+}
+
+// goSumsChanged reports whether before and after differ on any key.
+// Caller passes snapshots from [readGoSums]; both maps must have the
+// same key set.
+func goSumsChanged(before, after map[string][]byte) bool {
+	for k, b := range before {
+		if !bytes.Equal(b, after[k]) {
+			return true
+		}
+	}
+	return false
+}
+
+// stageAffected stages each affected sub-module's go.mod and go.sum
+// in the repo. Idempotent: missing files are skipped; non-Stat
+// failures bubble up. Used by [tidySubmoduleGoSums] after the
+// fixpoint loop converges.
+func stageAffected(opts Options, affected []string) error {
+	for _, sub := range affected {
+		for _, name := range []string{"go.mod", "go.sum"} {
+			rel := filepath.Join(sub, name)
+			abs := filepath.Join(opts.RepoDir, rel)
+			if _, err := os.Stat(abs); os.IsNotExist(err) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("tidy: stat %s: %w", abs, err)
+			}
+			if err := opts.Repo.Add(rel); err != nil {
+				return fmt.Errorf("tidy: stage %s: %w", rel, err)
+			}
+		}
+	}
+	return nil
+}
+
+// errFixpointNotReached is returned by [tidySubmoduleGoSums] when
+// the seed-and-tidy loop fails to converge within maxTidyIterations.
+// The error carries the per-iteration go.sum diffs as a diagnostic
+// payload so the maintainer can see exactly which sub-module's
+// go.sum kept changing across iterations. This typically indicates
+// a monorel bug (cycle, non-determinism); the message hints the
+// maintainer to file an issue.
+type errFixpointNotReached struct {
+	iterations int
+	finalDiffs map[string][2][]byte // per sub-module: [0]=before, [1]=after for the last iteration
+}
+
+func (e *errFixpointNotReached) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "tidy did not converge after %d iterations; this indicates a monorel bug.\n",
+		e.iterations)
+	fmt.Fprintf(&b, "Please file an issue at https://github.com/disaresta-org/monorel/issues with the following diffs:\n\n")
+	for sub, ba := range e.finalDiffs {
+		if bytes.Equal(ba[0], ba[1]) {
+			continue
+		}
+		fmt.Fprintf(&b, "==> %s/go.sum (last iteration's diff):\n", sub)
+		fmt.Fprintf(&b, "BEFORE:\n%s\n", ba[0])
+		fmt.Fprintf(&b, "AFTER:\n%s\n", ba[1])
+	}
+	return b.String()
+}
+```
+
+Add `bytes` to the import block at the top of `gosum.go`. The current imports are:
+
+```go
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/mod/module"
+)
+```
+
+Replace with:
+
+```go
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/module"
+)
+```
+
+- [ ] **Step 2: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS. The helpers aren't called yet but they compile cleanly; existing tests are unaffected.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/gosum.go
+git commit -m "$(cat <<'EOF'
+refactor(release): add helpers for tidy fixpoint loop
+
+Adds readGoSums, goSumsChanged, stageAffected, and the
+errFixpointNotReached error type. None of them is called yet; the
+fixpoint loop in the next commit wires them up.
+
+Helpers extracted now (rather than inlined inside the loop) so the
+loop body stays focused on orchestration and each helper has its own
+test surface in the gosum_test.go suite.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: replace `tidySubmoduleGoSums` body with iterate-to-fixpoint
+
+**Files:**
+- Modify: `internal/release/gosum.go`
+
+- [ ] **Step 1: Replace the seed/tidy/stage section with the fixpoint loop.**
+
+Open `internal/release/gosum.go` and find `tidySubmoduleGoSums`. The current shape after Task 3 is:
+
+```go
+func tidySubmoduleGoSums(opts Options) error {
+	if opts.PreState != nil {
+		return nil
+	}
+	if opts.Plan == nil || len(opts.Plan.Releases) == 0 {
+		return nil
+	}
+
+	// 1. Build the in-plan module set so we can detect sibling
+	//    requires in each sub-module's go.mod.
+	inPlan, err := inPlanSiblings(opts)
+	if err != nil {
+		return err
+	}
+
+	// 2. Determine which sub-modules to tidy (skip ones with no
+	//    in-plan sibling requires; nothing for tidy to add).
+	affected, err := affectedSubmodules(opts, inPlan)
+	if err != nil {
+		return err
+	}
+	if len(affected) == 0 {
+		return nil
+	}
+
+	// 3. Pre-flight: confirm out-of-plan managed siblings used by
+	//    the affected sub-modules are in the developer's cache.
+	if err := preflightOutOfPlanCache(opts, affected, inPlan); err != nil {
+		return err
+	}
+
+	// 4. Seed the cache with in-plan releases.
+	seeded, err := seedModuleCache(opts)
+	defer clearSeededEntries(seeded)
+	if err != nil {
+		return err
+	}
+
+	// 5. Run tidy in each affected sub-module. Hard-fail on the
+	//    first failure; staging happens only after all succeed.
+	for _, sub := range affected {
+		modDir := filepath.Join(opts.RepoDir, sub)
+		if err := runOfflineTidy(modDir); err != nil {
+			return err
+		}
+	}
+
+	// 6. Stage every (potentially) modified go.mod / go.sum.
+	for _, sub := range affected {
+		for _, name := range []string{"go.mod", "go.sum"} {
+			rel := filepath.Join(sub, name)
+			abs := filepath.Join(opts.RepoDir, rel)
+			if _, err := os.Stat(abs); os.IsNotExist(err) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("tidy: stat %s: %w", abs, err)
+			}
+			if err := opts.Repo.Add(rel); err != nil {
+				return fmt.Errorf("tidy: stage %s: %w", rel, err)
+			}
+		}
+	}
+	return nil
+}
+```
+
+Replace steps 4-6 (everything from the seed call through the return) with the fixpoint loop:
+
+```go
+	// 4. Iterate seed-and-tidy to fixpoint. Each iteration zips
+	//    every in-plan module's working tree, seeds the cache with
+	//    the resulting hashes, and runs offline tidy in each
+	//    affected sub-module. If any sub-module's go.sum was
+	//    mutated by the iteration's tidy, the working tree changed
+	//    too, so the next iteration re-seeds and re-tidies. The
+	//    loop converges when no go.sum is mutated; at that point
+	//    every recorded h1: matches the seeded hash, which matches
+	//    the working-tree hash, which is what `git archive` of the
+	//    published tag will produce.
+	//
+	//    Iteration cap defends against cycles/non-determinism. The
+	//    practical bound is the depth of the in-plan sibling dep
+	//    graph; a typical monorepo converges in 1-3 iterations.
+	const maxTidyIterations = 10
+	var seeded []seededEntry
+	defer func() { clearSeededEntries(seeded) }()
+
+	var lastDiffs map[string][2][]byte
+	for i := 0; i < maxTidyIterations; i++ {
+		clearSeededEntries(seeded)
+		seeded, err = seedModuleCache(opts)
+		if err != nil {
+			return err
+		}
+
+		before, err := readGoSums(opts.RepoDir, affected)
+		if err != nil {
+			return err
+		}
+
+		for _, sub := range affected {
+			modDir := filepath.Join(opts.RepoDir, sub)
+			if err := runOfflineTidy(modDir); err != nil {
+				return err
+			}
+		}
+
+		after, err := readGoSums(opts.RepoDir, affected)
+		if err != nil {
+			return err
+		}
+
+		if !goSumsChanged(before, after) {
+			// Fixpoint reached.
+			return stageAffected(opts, affected)
+		}
+
+		// Capture the diff for diagnostic in case fixpoint never
+		// converges. Overwritten each iteration; we only emit the
+		// final iteration's diff if we exit via the cap.
+		lastDiffs = make(map[string][2][]byte, len(before))
+		for k := range before {
+			lastDiffs[k] = [2][]byte{before[k], after[k]}
+		}
+	}
+
+	return &errFixpointNotReached{
+		iterations: maxTidyIterations,
+		finalDiffs: lastDiffs,
+	}
+}
+```
+
+- [ ] **Step 2: Run the existing tests.**
+
+Run: `cd /tmp/monorel-src && go test ./internal/release -v`
+
+Expected: PASS for every existing test. The fixpoint loop converges in 1 iteration when no cross-sibling dep mutation cascades, which is what every existing test fixture exercises. The new regression test from Task 1 also continues to pass (Task 2's reorder fixed the canonical case; the loop adds the cross-sibling case for free).
+
+- [ ] **Step 3: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/gosum.go
+git commit -m "$(cat <<'EOF'
+fix(release): iterate seed-and-tidy to fixpoint
+
+Replaces the single-pass seed-and-tidy in tidySubmoduleGoSums with
+an iterate-to-fixpoint loop. Each iteration re-seeds in-plan modules
+from the current working tree (so any go.sum mutations from the
+previous iteration's tidy are reflected in the seeded hash), then
+re-runs tidy. Convergence: when no affected sub-module's go.sum
+changed during the iteration, every recorded h1: matches what
+`git archive` of the published tag will produce.
+
+Closes the cross-sibling cascade variant of the wrong-h1: bug. The
+canonical changeset-deletion variant was fixed by the previous
+commit (applyStable reorder); this commit handles cases where a
+sub-module's own tidy mutates its own go.sum and another in-plan
+sibling depends on it.
+
+Iteration cap: 10. Practical bound is dep-graph depth; typical
+monorepos converge in 1-3. Cap defends against cycles or
+non-determinism with a clear errFixpointNotReached error.
+
+Existing tests pass unchanged (they all converge in 1 iteration).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: cross-sibling cascade regression test
+
+**Files:**
+- Modify: `internal/release/gosum_test.go`
+
+This task adds a test for the second variant of the wrong-h1: bug: an in-plan sub-module that other in-plan siblings depend on. Single-pass tidy would record the pre-tidy hash for the dependent sibling; the fixpoint loop converges to the post-tidy hash.
+
+- [ ] **Step 1: Append the test to `internal/release/gosum_test.go`.**
+
+```go
+// TestApply_CrossSiblingCascade_HashesConvergeToPublished pins the
+// regression for the cross-sibling cascade variant of the wrong-h1:
+// bug. Three in-plan modules A, B, C: A is the root; B requires A
+// and is required by C; C requires both A and B. Single-pass
+// seed-and-tidy would record B's pre-tidy hash in C's go.sum, since
+// B's own tidy modifies B's go.sum after C's tidy ran against the
+// seeded (pre-modification) hash.
+//
+// The fixpoint loop converges: every recorded h1: equals the hash
+// of `git archive` against the published commit.
+func TestApply_CrossSiblingCascade_HashesConvergeToPublished(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("`go` not on PATH: %v", err)
+	}
+
+	repoDir := t.TempDir()
+	tmpModCache := t.TempDir()
+	t.Cleanup(func() {
+		filepath.WalkDir(tmpModCache, func(path string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			os.Chmod(path, 0o755)
+			return nil
+		})
+	})
+	t.Setenv("GOMODCACHE", tmpModCache)
+
+	// Modules:
+	//   a/  (example.com/a, no deps)
+	//   b/  (example.com/b, requires a)
+	//   c/  (example.com/c, requires a AND b)
+	mustWriteFile(t, filepath.Join(repoDir, "a/go.mod"),
+		"module example.com/a\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(repoDir, "a/a.go"),
+		"package a\n\nfunc Hello() string { return \"a\" }\n")
+
+	mustWriteFile(t, filepath.Join(repoDir, "b/go.mod"),
+		"module example.com/b\n\ngo 1.26\n\nrequire example.com/a v0.1.0\n")
+	mustWriteFile(t, filepath.Join(repoDir, "b/b.go"),
+		"package b\n\nimport \"example.com/a\"\n\nfunc Hello() string { return a.Hello() + \"-b\" }\n")
+
+	mustWriteFile(t, filepath.Join(repoDir, "c/go.mod"),
+		"module example.com/c\n\ngo 1.26\n\nrequire (\n\texample.com/a v0.1.0\n\texample.com/b v0.1.0\n)\n")
+	mustWriteFile(t, filepath.Join(repoDir, "c/c.go"),
+		"package c\n\nimport (\n\t\"example.com/a\"\n\t\"example.com/b\"\n)\n\nfunc Hello() string { return a.Hello() + \"-\" + b.Hello() }\n")
+
+	repo := git.NewFake()
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"a": {TagPrefix: "a", Path: "a"},
+			"b": {TagPrefix: "b", Path: "b"},
+			"c": {TagPrefix: "c", Path: "c"},
+		},
+	}
+	rp := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{
+			{Config: cfg.Packages["a"], Tag: "a/v0.1.0", Bump: semver.Minor},
+			{Config: cfg.Packages["b"], Tag: "b/v0.1.0", Bump: semver.Minor},
+			{Config: cfg.Packages["c"], Tag: "c/v0.1.0", Bump: semver.Minor},
+		},
+	}
+
+	opts := Options{
+		Plan:         rp,
+		Config:       cfg,
+		Repo:         repo,
+		RepoDir:      repoDir,
+		ChangesetDir: filepath.Join(repoDir, ".changeset"),
+		Today:        "2026-05-03",
+	}
+
+	if _, err := Apply(opts); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Compute expected hashes after Apply has staged everything
+	// (including b's go.sum mutations and c's go.sum mutations).
+	// `dirhash` over each module's directory matches what
+	// `git archive` of the eventual tag will produce.
+	expectedA, err := dirhashOfModule(repoDir, "a", "example.com/a", "v0.1.0")
+	if err != nil {
+		t.Fatalf("hash a: %v", err)
+	}
+	expectedB, err := dirhashOfModule(repoDir, "b", "example.com/b", "v0.1.0")
+	if err != nil {
+		t.Fatalf("hash b: %v", err)
+	}
+
+	// c/go.sum should record A's actual hash AND B's actual hash.
+	cGoSum, err := os.ReadFile(filepath.Join(repoDir, "c", "go.sum"))
+	if err != nil {
+		t.Fatalf("read c/go.sum: %v", err)
+	}
+	if got := extractH1(t, cGoSum, "example.com/a v0.1.0"); got != expectedA {
+		t.Errorf("c/go.sum recorded wrong h1: for example.com/a v0.1.0\n  got:  %s\n  want: %s\n  full go.sum:\n%s",
+			got, expectedA, cGoSum)
+	}
+	if got := extractH1(t, cGoSum, "example.com/b v0.1.0"); got != expectedB {
+		t.Errorf("c/go.sum recorded wrong h1: for example.com/b v0.1.0\n  got:  %s\n  want: %s\n  full go.sum:\n%s",
+			got, expectedB, cGoSum)
+	}
+
+	// b/go.sum should record A's actual hash.
+	bGoSum, err := os.ReadFile(filepath.Join(repoDir, "b", "go.sum"))
+	if err != nil {
+		t.Fatalf("read b/go.sum: %v", err)
+	}
+	if got := extractH1(t, bGoSum, "example.com/a v0.1.0"); got != expectedA {
+		t.Errorf("b/go.sum recorded wrong h1: for example.com/a v0.1.0\n  got:  %s\n  want: %s",
+			got, expectedA)
+	}
+}
+
+// dirhashOfModule computes Hash1 of a sub-module's zip built from
+// repoDir/sub. Like dirhashOfRoot but for an arbitrary sub-module.
+func dirhashOfModule(repoDir, sub, importPath, version string) (string, error) {
+	mv := module.Version{Path: importPath, Version: version}
+	tmpZip, err := os.CreateTemp("", "monorel-test-zip-*.zip")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpZip.Name())
+	defer tmpZip.Close()
+	if err := xzip.CreateFromDir(tmpZip, mv, filepath.Join(repoDir, sub)); err != nil {
+		return "", err
+	}
+	if err := tmpZip.Close(); err != nil {
+		return "", err
+	}
+	return dirhash.HashZip(tmpZip.Name(), dirhash.Hash1)
+}
+```
+
+- [ ] **Step 2: Run the new test.**
+
+Run: `cd /tmp/monorel-src && go test ./internal/release -run TestApply_CrossSiblingCascade_HashesConvergeToPublished -v`
+
+Expected: PASS. The fixpoint loop from Task 5 handles the cascade.
+
+- [ ] **Step 3: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/gosum_test.go
+git commit -m "$(cat <<'EOF'
+test(release): regression for cross-sibling cascade variant
+
+Three-module fixture: a (root), b (requires a), c (requires a and
+b). Without the fixpoint loop, c/go.sum would record b's pre-tidy
+hash (since b's own tidy mutates b/go.sum after c's tidy ran with
+the seeded pre-tidy hash). With the loop, every recorded h1: equals
+the hash of `git archive` against the published commit.
+
+This complements Task 1's regression test: that test covers the
+canonical "root .changeset deletion" variant; this one covers the
+cross-sibling cascade variant. Both are needed because the fix has
+two parts: applyStable reorder (canonical) + fixpoint loop
+(cascade).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: fixpoint-not-reached diagnostic test
+
+**Files:**
+- Modify: `internal/release/gosum_test.go`
+- Modify: `internal/release/gosum.go` (add a test hook)
+
+The fixpoint-not-reached error is hard to trigger with real tidy because monorel's tidy is deterministic. To test the diagnostic path, expose a small test hook that lets the test inject non-determinism.
+
+- [ ] **Step 1: Add the hook to `gosum.go`.**
+
+Append to `internal/release/gosum.go` after the helpers added in Task 4:
+
+```go
+// tidyHook is a per-iteration test hook used by the fixpoint loop
+// to inject non-determinism (or any other behavior) for testing
+// errFixpointNotReached. Production code never sets it; the only
+// caller is the gosum_test.go suite. nil means "no-op."
+var tidyHook func(iteration int) error
+```
+
+Then modify the fixpoint loop in `tidySubmoduleGoSums` to call the hook. The current loop body is:
+
+```go
+	for i := 0; i < maxTidyIterations; i++ {
+		clearSeededEntries(seeded)
+		seeded, err = seedModuleCache(opts)
+		if err != nil {
+			return err
+		}
+
+		before, err := readGoSums(opts.RepoDir, affected)
+		if err != nil {
+			return err
+		}
+
+		for _, sub := range affected {
+			modDir := filepath.Join(opts.RepoDir, sub)
+			if err := runOfflineTidy(modDir); err != nil {
+				return err
+			}
+		}
+        // ...
+```
+
+After the inner `runOfflineTidy` loop and before the `after` snapshot, add:
+
+```go
+		if tidyHook != nil {
+			if err := tidyHook(i); err != nil {
+				return err
+			}
+		}
+```
+
+So the loop becomes:
+
+```go
+	for i := 0; i < maxTidyIterations; i++ {
+		clearSeededEntries(seeded)
+		seeded, err = seedModuleCache(opts)
+		if err != nil {
+			return err
+		}
+
+		before, err := readGoSums(opts.RepoDir, affected)
+		if err != nil {
+			return err
+		}
+
+		for _, sub := range affected {
+			modDir := filepath.Join(opts.RepoDir, sub)
+			if err := runOfflineTidy(modDir); err != nil {
+				return err
+			}
+		}
+
+		if tidyHook != nil {
+			if err := tidyHook(i); err != nil {
+				return err
+			}
+		}
+
+		after, err := readGoSums(opts.RepoDir, affected)
+		if err != nil {
+			return err
+		}
+
+		if !goSumsChanged(before, after) {
+			return stageAffected(opts, affected)
+		}
+
+		lastDiffs = make(map[string][2][]byte, len(before))
+		for k := range before {
+			lastDiffs[k] = [2][]byte{before[k], after[k]}
+		}
+	}
+```
+
+- [ ] **Step 2: Add the test.**
+
+Append to `internal/release/gosum_test.go`:
+
+```go
+// TestTidySubmoduleGoSums_FixpointNotReached_SurfacesDiagnosticError
+// pins the diagnostic path. Inject a hook that mutates an affected
+// sub-module's go.sum on every iteration so the loop never
+// converges; assert it returns errFixpointNotReached after
+// maxTidyIterations and the message includes the per-iteration
+// diff payload.
+func TestTidySubmoduleGoSums_FixpointNotReached_SurfacesDiagnosticError(t *testing.T) {
+	opts, _ := setupSubmoduleFixture(t, true /* aRequiresB */)
+
+	// Inject non-determinism: append a unique line to a/go.sum
+	// after each tidy iteration. The next iteration's "before"
+	// snapshot will see the appended line; tidy may or may not
+	// remove it (depending on whether it parses as a valid sum
+	// line); either way, before != after, so the loop never
+	// converges.
+	originalHook := tidyHook
+	t.Cleanup(func() { tidyHook = originalHook })
+	tidyHook = func(iteration int) error {
+		path := filepath.Join(opts.RepoDir, "a", "go.sum")
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = fmt.Fprintf(f, "# fixpoint-test marker iteration=%d\n", iteration)
+		return err
+	}
+
+	err := tidySubmoduleGoSums(opts)
+	if err == nil {
+		t.Fatal("tidySubmoduleGoSums: want errFixpointNotReached, got nil")
+	}
+	var fpErr *errFixpointNotReached
+	if !errors.As(err, &fpErr) {
+		t.Fatalf("tidySubmoduleGoSums: want *errFixpointNotReached, got %T: %v", err, err)
+	}
+	if fpErr.iterations != 10 {
+		t.Errorf("iterations: got %d, want 10", fpErr.iterations)
+	}
+	msg := fpErr.Error()
+	if !strings.Contains(msg, "did not converge after 10 iterations") {
+		t.Errorf("error message missing convergence header: %q", msg)
+	}
+	if !strings.Contains(msg, "monorel/issues") {
+		t.Errorf("error message missing issue-filing hint: %q", msg)
+	}
+	if !strings.Contains(msg, "BEFORE:") || !strings.Contains(msg, "AFTER:") {
+		t.Errorf("error message missing diff payload: %q", msg)
+	}
+}
+```
+
+Add the `errors` import to `gosum_test.go` if not already present.
+
+- [ ] **Step 3: Run the new test.**
+
+Run: `cd /tmp/monorel-src && go test ./internal/release -run TestTidySubmoduleGoSums_FixpointNotReached_SurfacesDiagnosticError -v`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/gosum.go internal/release/gosum_test.go
+git commit -m "$(cat <<'EOF'
+test(release): pin errFixpointNotReached diagnostic path
+
+Adds a test-only tidyHook that lets the test inject non-determinism
+(by appending unique markers to an affected sub-module's go.sum each
+iteration). Confirms that tidySubmoduleGoSums returns
+*errFixpointNotReached with the iteration count, the issue-filing
+hint, and the per-iteration diff payload.
+
+Production code never sets the hook (it's nil by default and only
+mutated from gosum_test.go).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: add `primeModuleCache` and `primeCacheEnv`
+
+**Files:**
+- Modify: `internal/release/tidy.go`
+
+This task adds the cache-priming helper but doesn't wire it into `tidySubmoduleGoSums` yet. Wiring is Task 9.
+
+- [ ] **Step 1: Append `primeModuleCache` and `primeCacheEnv` to `tidy.go`.**
+
+Open `internal/release/tidy.go`. After the existing `offlineTidyEnv` (line 81), append:
+
+```go
+// primeModuleCache populates the local module cache with the
+// third-party deps modDir's go.mod transitively requires. Subsequent
+// offline tidy with GOPROXY=off can resolve those deps from the
+// cache without reaching out to the network.
+//
+// Uses the inherited GOPROXY (typically https://proxy.golang.org,direct)
+// and GOSUMDB so go.sum hashes are verified during download. Does
+// NOT mutate go.sum: `go mod download` reads go.sum, downloads the
+// listed modules, and writes nothing. The download is bounded by the
+// existing entries in go.sum: any module not already pinned wouldn't
+// be downloaded (tidy adds pins later, after the in-plan siblings
+// are seeded).
+//
+// PATH, HOME, USER, TMPDIR, LANG, LC_*, GOMODCACHE, GOCACHE, GOPROXY,
+// GOSUMDB pass through.
+func primeModuleCache(modDir string) error {
+	cmd := exec.Command("go", "mod", "download")
+	cmd.Dir = modDir
+	cmd.Env = primeCacheEnv()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("prime module cache in %s: %w\n%s\n\n"+
+			"Hint: this typically means GOPROXY isn't reachable from this environment. "+
+			"Confirm `GOPROXY` is a real proxy URL (e.g. https://proxy.golang.org,direct), "+
+			"or set `GOPROXY=direct` to fetch straight from the source repo",
+			modDir, err, out)
+	}
+	return nil
+}
+
+// primeCacheEnv builds the env slice for the prime-cache subprocess.
+// Mirrors offlineTidyEnv's "scratch env, no caller GOFLAGS leak"
+// shape, but inherits GOPROXY and GOSUMDB so download can fetch from
+// the network.
+func primeCacheEnv() []string {
+	inherit := []string{
+		"PATH",
+		"HOME",
+		"USER",
+		"TMPDIR",
+		"LANG",
+		"GOMODCACHE",
+		"GOCACHE",
+		"GOPROXY",
+		"GOSUMDB",
+	}
+	env := make([]string, 0, len(inherit)+8)
+	for _, k := range inherit {
+		if v, ok := os.LookupEnv(k); ok {
+			env = append(env, k+"="+v)
+		}
+	}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "LC_") {
+			env = append(env, e)
+		}
+	}
+	env = append(env,
+		"GOWORK=off",
+		"GOFLAGS=",
+		"GOTOOLCHAIN=local",
+	)
+	return env
+}
+```
+
+- [ ] **Step 2: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS. The new helper isn't called yet; existing tests are unaffected.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/tidy.go
+git commit -m "$(cat <<'EOF'
+feat(release): add primeModuleCache helper
+
+monorel's offline tidy runs with GOPROXY=off, which means it can
+only resolve modules already in the local cache. In-plan siblings
+are seeded explicitly; managed-but-not-in-plan siblings are
+pre-flight-checked. Third-party deps (anything not in
+monorel.toml) must already be in GOMODCACHE from prior dev work.
+
+On a fresh CI runner, GOMODCACHE is empty and tidy fails with
+"module lookup disabled by GOPROXY=off." Add a primeModuleCache
+helper that runs `go mod download` (with the inherited GOPROXY)
+to populate the cache before the offline tidy runs. The
+GOPROXY=off-during-tidy invariant is preserved.
+
+Helper not called yet; the next commit wires it into
+tidySubmoduleGoSums.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: wire `primeModuleCache` into `tidySubmoduleGoSums`
+
+**Files:**
+- Modify: `internal/release/gosum.go`
+
+- [ ] **Step 1: Add the prime-cache step before the seed.**
+
+Open `internal/release/gosum.go` and find `tidySubmoduleGoSums`. After the pre-flight check (the `preflightOutOfPlanCache` call, around line 60-62) and before the fixpoint loop's `var seeded []seededEntry` declaration, insert:
+
+```go
+	// 4. Prime the module cache with third-party deps each affected
+	//    sub-module transitively requires. Tidy under GOPROXY=off
+	//    can only resolve from the cache; managed siblings are
+	//    seeded by the loop below, but third-party deps depend on
+	//    the cache being warm. Dev cache is usually warm from prior
+	//    builds; fresh CI runner cache isn't. Populate the cache
+	//    explicitly so the offline tidy that follows resolves
+	//    every transitive dep from the cache.
+	for _, sub := range affected {
+		modDir := filepath.Join(opts.RepoDir, sub)
+		if err := primeModuleCache(modDir); err != nil {
+			return err
+		}
+	}
+
+```
+
+The new call slots between step 3 (`preflightOutOfPlanCache`) and step 4 (the fixpoint loop). Renumber the comment markers in the function: the existing "// 4." comment on the seed-and-tidy loop becomes "// 5.".
+
+- [ ] **Step 2: Run the existing tests.**
+
+Run: `cd /tmp/monorel-src && go test ./internal/release -v`
+
+Expected: PASS. The existing tests use a fixture where third-party deps aren't required, so `go mod download` is a no-op for them. (If any existing test fails at this step because its fixture *does* implicitly depend on a third-party module that isn't cached, that test was already running with a pre-warmed dev cache; we'll catch and address it here.)
+
+- [ ] **Step 3: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/gosum.go
+git commit -m "$(cat <<'EOF'
+fix(release): prime module cache before offline tidy
+
+Calls primeModuleCache for each affected sub-module before the
+seed-and-tidy fixpoint loop. Third-party deps land in GOMODCACHE
+via `go mod download` with the inherited GOPROXY, so the offline
+tidy that follows (with GOPROXY=off) can resolve them from the
+cache.
+
+Fixes "module lookup disabled by GOPROXY=off" failures on fresh CI
+runners.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: cold-cache regression test for cache priming
+
+**Files:**
+- Modify: `internal/release/gosum_test.go`
+
+- [ ] **Step 1: Append the test.**
+
+```go
+// TestTidySubmoduleGoSums_PrimesThirdPartyDeps_FromColdCache pins
+// the regression for the fresh-CI-runner case. An affected
+// sub-module requires a third-party module not in monorel.toml's
+// managed set. With a fresh GOMODCACHE (default for
+// setupSubmoduleFixture), offline tidy with GOPROXY=off would fail
+// without the prime-cache step. With it, tidy succeeds because the
+// cache is populated before tidy runs.
+func TestTidySubmoduleGoSums_PrimesThirdPartyDeps_FromColdCache(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("`go` not on PATH: %v", err)
+	}
+	if testing.Short() {
+		t.Skip("network-bound: requires GOPROXY reachability for go mod download")
+	}
+
+	repoDir := t.TempDir()
+	tmpModCache := t.TempDir()
+	t.Cleanup(func() {
+		filepath.WalkDir(tmpModCache, func(path string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			os.Chmod(path, 0o755)
+			return nil
+		})
+	})
+	t.Setenv("GOMODCACHE", tmpModCache)
+
+	// a/ requires example.com/b (in-plan, will be seeded) AND
+	// gopkg.in/yaml.v3 (third-party). Without primeModuleCache,
+	// tidy under GOPROXY=off would fail on yaml.v3 since it's not
+	// in the fresh GOMODCACHE.
+	mustWriteFile(t, filepath.Join(repoDir, "a/go.mod"),
+		"module example.com/a\n\ngo 1.26\n\nrequire (\n\texample.com/b v0.1.0\n\tgopkg.in/yaml.v3 v3.0.1\n)\n")
+	mustWriteFile(t, filepath.Join(repoDir, "a/a.go"),
+		"package a\n\nimport (\n\t\"example.com/b\"\n\t_ \"gopkg.in/yaml.v3\"\n)\n\nfunc Greet() string { return b.Hello() }\n")
+	// Pre-populate a's go.sum with the yaml.v3 hash so tidy doesn't
+	// have to write it (which would require sum verification). The
+	// hash is the public proxy hash for yaml.v3 v3.0.1.
+	mustWriteFile(t, filepath.Join(repoDir, "a/go.sum"),
+		"gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=\n"+
+			"gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=\n")
+
+	mustWriteFile(t, filepath.Join(repoDir, "b/go.mod"),
+		"module example.com/b\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(repoDir, "b/b.go"),
+		"package b\n\nfunc Hello() string { return \"hi\" }\n")
+
+	repo := git.NewFake()
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"a": {TagPrefix: "a", Path: "a"},
+			"b": {TagPrefix: "b", Path: "b"},
+		},
+	}
+	rp := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{
+			{Config: cfg.Packages["a"], Tag: "a/v0.1.0", Bump: semver.Minor},
+			{Config: cfg.Packages["b"], Tag: "b/v0.1.0", Bump: semver.Minor},
+		},
+	}
+
+	opts := Options{
+		Plan:         rp,
+		Config:       cfg,
+		Repo:         repo,
+		RepoDir:      repoDir,
+		ChangesetDir: filepath.Join(repoDir, ".changeset"),
+		Today:        "2026-05-03",
+	}
+
+	if err := tidySubmoduleGoSums(opts); err != nil {
+		t.Fatalf("tidySubmoduleGoSums: %v", err)
+	}
+
+	// Sanity: a/go.sum now has both example.com/b and yaml.v3 entries.
+	aGoSum, err := os.ReadFile(filepath.Join(repoDir, "a", "go.sum"))
+	if err != nil {
+		t.Fatalf("read a/go.sum: %v", err)
+	}
+	if !bytes.Contains(aGoSum, []byte("example.com/b v0.1.0")) {
+		t.Errorf("a/go.sum: missing example.com/b v0.1.0:\n%s", aGoSum)
+	}
+	if !bytes.Contains(aGoSum, []byte("gopkg.in/yaml.v3 v3.0.1")) {
+		t.Errorf("a/go.sum: missing gopkg.in/yaml.v3 v3.0.1:\n%s", aGoSum)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test.**
+
+Run: `cd /tmp/monorel-src && go test ./internal/release -run TestTidySubmoduleGoSums_PrimesThirdPartyDeps_FromColdCache -v`
+
+Expected: PASS. The test downloads `gopkg.in/yaml.v3` from the public proxy via the prime-cache step, then offline tidy resolves it from the cache.
+
+If the test runs in an environment without network access, the test skips via `testing.Short()` (run with `go test -short`). For the standard `go test`, network access is assumed.
+
+- [ ] **Step 3: Run the full repo test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add internal/release/gosum_test.go
+git commit -m "$(cat <<'EOF'
+test(release): regression for fresh-CI-runner cold-cache case
+
+A two-module fixture where a's go.mod requires both an in-plan
+sibling (example.com/b) and a third-party module (gopkg.in/yaml.v3).
+With a fresh GOMODCACHE and no priming, offline tidy under
+GOPROXY=off would fail on yaml.v3.
+
+This pins the regression so a future change to the cache-management
+flow that drops the priming step would surface here rather than only
+in real CI runs.
+
+Skips under `go test -short` since the test requires GOPROXY
+reachability.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: ci/github/README.md updates (concerns #3 and #4)
+
+**Files:**
+- Modify: `ci/github/README.md`
+
+- [ ] **Step 1: Add inline comments above each `actions/setup-go@v5` step.**
+
+Open `ci/github/README.md`. Find the first example workflow (`release-pr.yml`, around lines 26-49). The current setup-go step is:
+
+```yaml
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+```
+
+Replace with:
+
+```yaml
+      # monorel runs `go mod tidy` with GOTOOLCHAIN=local during release,
+      # so Go must already be installed at a version satisfying every
+      # released sub-module's `go` directive (the highest one wins).
+      # `go-version-file: go.mod` reads the root module's go.mod; if a
+      # sub-module declares a higher floor, pin `go-version` explicitly.
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+```
+
+Apply the identical comment block to the second example workflow (`release.yml`, around lines 51-74).
+
+- [ ] **Step 2: Strengthen the "Requirements" → "go on PATH" bullet.**
+
+Find the bullet (around line 78). The current text is:
+
+```markdown
+- **`go` on `PATH`.** monorel's `apply` step runs `go mod tidy` (offline, against a seeded local cache) in every released sub-module that requires an in-plan sibling, so the release commit's `go.sum` is canonically clean for the proxy-published state. The runner needs a `go` binary whose version satisfies every released module's `go` directive; use `actions/setup-go@v5` with `go-version-file: go.mod` (or pin `go-version` explicitly) to install the right version. GitHub-hosted runners include a recent Go by default, but pinning is safer than relying on the runner's pre-installed version, especially when modules use a recent `go` directive.
+```
+
+Replace with:
+
+```markdown
+- **`go` on `PATH`.** monorel's `apply` step runs `go mod tidy` (offline, against a seeded local cache) in every released sub-module that requires an in-plan sibling, so the release commit's `go.sum` is canonically clean for the proxy-published state. The runner needs a `go` binary whose version satisfies every released module's `go` directive; use `actions/setup-go@v5` with `go-version-file: go.mod` (or pin `go-version` explicitly) to install the right version. GitHub-hosted runners include a recent Go by default, but pinning is safer than relying on the runner's pre-installed version, especially when modules use a recent `go` directive.
+
+  If the runner's Go is older than the highest sub-module's `go` directive, tidy fails with `go.mod requires go >= X.Y; running Z; GOTOOLCHAIN=local`. The fix is always to bump the runner's Go (raise the `go-version`), not to remove `GOTOOLCHAIN=local` from monorel's tidy step (the env var is part of monorel's offline-tidy determinism guarantee).
+
+  See [Avoiding the chore(release) CI race](../../docs/src/workflows.md#avoiding-the-chorerelease-ci-race) for the related skip-filter pattern other workflows on the same branch should apply.
+```
+
+- [ ] **Step 3: Add a "## Recipes" section.**
+
+Append to the end of `ci/github/README.md`:
+
+```markdown
+## Recipes
+
+### Skipping CI on chore(release) commits
+
+The release commit `chore(release): ...` is created by the always-open release PR's merge. On the same push event, `release.yml` (using this action with `command: release`) creates and pushes per-package tags. Any *other* workflow that runs on the same push and resolves Go module versions will race the tag-push and may transiently fail with:
+
+```
+go: example.com/foo/v2: reading example.com/foo/go.mod at revision v2.1.0: unknown revision v2.1.0
+```
+
+To avoid the phantom failure, skip the workflow on `chore(release):` commits. The skip filter:
+
+```yaml
+jobs:
+  test:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    # ... rest of job ...
+```
+
+Apply the filter to every job (`test`, `staticcheck`, `govulncheck`, etc.) that runs `go mod tidy` or anything else that resolves the new versions. Pull-request triggers stay always-on; only push-to-main runs are skipped, and only when the head commit is the release-PR merge.
+
+The `release.yml` workflow that runs the actual release pipeline does NOT need this filter; its own `if:` clause is the *opposite* shape (only run on `chore(release):` commits), so it's already mutually exclusive with the skip pattern above.
+
+For non-GitHub-Actions CI systems, see the [universal recipe](../../docs/src/workflows.md#avoiding-the-chorerelease-ci-race) covering GitHub / GitLab / Gitea filter syntax.
+```
+
+- [ ] **Step 4: Build docs to confirm no link breaks.**
+
+Run: `cd /tmp/monorel-src/docs && bun run docs:build 2>&1 | tail -5`
+
+Expected: clean build. If links to `../../docs/src/workflows.md` 404 because that section doesn't exist yet, that's expected; Task 12 adds it. If the build fails for any other reason, debug.
+
+For now, accept that the cross-link to `workflows.md` is a forward reference that resolves once Task 12 lands.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add ci/github/README.md
+git commit -m "$(cat <<'EOF'
+docs(ci/github): inline comments on setup-go + Recipes section
+
+Three additions to ci/github/README.md addressing concerns #3 and
+#4 from issue #54:
+
+- Inline comments above the `actions/setup-go@v5` step in both
+  example workflows explaining the GOTOOLCHAIN=local rationale and
+  the `go-version-file: go.mod` choice (so a casual reader doesn't
+  strip the step).
+- Strengthened "Requirements" -> "go on PATH" bullet calling out
+  the failure mode and pointing at the universal recipe.
+- New "## Recipes" section with the GitHub-Actions if-clause snippet
+  for skipping CI on chore(release) commits, plus a forward link
+  to docs/src/workflows.md for non-GitHub CI systems (added in the
+  next commit).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: docs/src/workflows.md universal sections
+
+**Files:**
+- Modify: `docs/src/workflows.md`
+
+- [ ] **Step 1: Add the two new sections at the end of `workflows.md`.**
+
+Open `/tmp/monorel-src/docs/src/workflows.md`. Append (after the existing "## See also" or whatever the last section is):
+
+```markdown
+## CI environment requirements
+
+Any CI system invoking `monorel release` (GitHub Actions, GitLab CI, Gitea Actions, CircleCI, Drone, self-hosted runners) must provide the following:
+
+- **Go installed at a version compatible with every released sub-module's `go` directive.** monorel runs `go mod tidy` with `GOTOOLCHAIN=local` during release; the env var is intentional and part of the offline-tidy determinism guarantee. Auto-toolchain-download is blocked. Pin the runner's Go to the highest floor explicitly (or use `go-version-file: go.mod` if the root module's `go` directive matches the highest sub-module floor).
+- **`GOPROXY` set to a real proxy or `direct`.** monorel's release pipeline includes a "prime cache" step that runs `go mod download` (with the inherited `GOPROXY`) to populate the local module cache for third-party deps. The offline tidy that follows uses `GOPROXY=off` regardless of this setting; only the priming step honors `GOPROXY`. If `GOPROXY` is empty or missing, `go mod download` falls back to its default (`https://proxy.golang.org,direct`), which is what most CI systems already provide implicitly.
+- **Push permissions for tags.** The `release` command runs `git push --follow-tags` to publish the per-package tags created by `monorel release`. The runner's git config needs commit + push credentials.
+- **Provider API token.** For the `pr` command (always-open release PR maintenance) and the `publish` step inside `release`, the provider API token needs `contents: write` and `pull-requests: write` (GitHub naming; equivalent on GitLab / Gitea).
+
+For GitHub Actions, see [`ci/github/README.md`](../../ci/github/README.md) for the canonical workflow examples that satisfy these requirements.
+
+For GitLab CI, the equivalent setup is a `before_script:` block that installs Go (e.g., via the `golang:1.25` image or a `gimme` install) and a `rules:` clause on each job (see "Avoiding the chore(release) CI race" below). The token requirement maps to `CI_JOB_TOKEN` for read-only access plus a project access token for push/release operations.
+
+For Gitea Actions, the syntax matches GitHub Actions (Gitea Actions is API-compatible). Substitute `disaresta-org/monorel/ci/github@<version>` references with whatever path your Gitea instance uses for the same action.
+
+## Avoiding the chore(release) CI race
+
+The release commit `chore(release): ...` (created when the always-open release PR is merged) updates module `go.mod` files to require new in-plan sibling versions. The matching tags are created and pushed by the workflow running `monorel release` on the same push. Any *other* workflow that fires on the same push and resolves Go module versions will race the tag push and may transiently fail with:
+
+```
+go: example.com/foo/v2: reading example.com/foo/go.mod at revision v2.1.0: unknown revision v2.1.0
+```
+
+The release succeeds and the tags get pushed, but the racing workflow's red mark stays in the UI. The fix is to skip the racing workflow when the head commit subject begins with `chore(release):`. The principle is universal; the syntax varies per CI system.
+
+### GitHub Actions / Gitea Actions
+
+Same syntax: an `if:` clause on each job that runs Go module resolution.
+
+```yaml
+jobs:
+  test:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    # ... rest of job ...
+```
+
+See [`ci/github/README.md`](../../ci/github/README.md#skipping-ci-on-chorerelease-commits) for the full GitHub Actions snippet.
+
+### GitLab CI
+
+Use a `rules:` clause on each job:
+
+```yaml
+test:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_TITLE =~ /^chore\(release\):/'
+      when: never
+    - when: on_success
+  script:
+    - go test ./...
+```
+
+The two-clause `rules` first allows merge-request runs through unconditionally, then explicitly drops `chore(release):` push runs on the default branch, then defaults to running.
+
+### Other CI systems
+
+The principle is universal: skip the workflow when the head commit subject starts with `chore(release):`. Most CI systems support a per-job filter on commit message; the exact key varies (`commit.message`, `CI_COMMIT_MESSAGE`, `BUILDKITE_MESSAGE`, etc.). Apply the same `^chore(release):` regex check.
+
+The release-pipeline workflow itself (the one running `monorel release`) does NOT need this filter; its own filter is the *opposite* shape (only run on `chore(release):`), so it's mutually exclusive with the skip pattern above.
+```
+
+- [ ] **Step 2: Build docs to confirm clean.**
+
+Run: `cd /tmp/monorel-src/docs && bun run docs:build 2>&1 | tail -5`
+
+Expected: clean build. The cross-links between `ci/github/README.md` and `docs/src/workflows.md` should now both resolve.
+
+- [ ] **Step 3: Run the full repo test suite to confirm nothing regressed (defensive — docs changes shouldn't affect tests, but a sanity check is cheap).**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add docs/src/workflows.md
+git commit -m "$(cat <<'EOF'
+docs(workflows): CI environment requirements + chore(release) recipe
+
+Two new sections in docs/src/workflows.md, both CI-agnostic:
+
+- "## CI environment requirements" lists the universal requirements
+  for any CI invoking `monorel release` (Go version, GOPROXY, push
+  permissions, provider API token). Cross-links to ci/github/README.md
+  for the GitHub-specific implementation; gives GitLab CI / Gitea
+  Actions guidance for the others.
+- "## Avoiding the chore(release) CI race" describes the race and
+  shows per-CI filter syntax for GitHub Actions, GitLab CI, and a
+  generic principle for other systems.
+
+Closes the loop on concerns #3 and #4 of issue #54: ci/github/README.md
+covers GitHub Actions; this doc covers everyone else.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Read the existing CHANGELOG to confirm the entry format.**
+
+Open `/tmp/monorel-src/CHANGELOG.md` and look at the top entry. monorel's CHANGELOG follows Keep-a-Changelog format with sections like `### Added`, `### Changed`, `### Fixed`. Entries are appended above the most recent release.
+
+- [ ] **Step 2: Add the entry.**
+
+Find the heading for the current pre-release "Unreleased" section (or create one if it doesn't exist; monorel's `monorel release` command writes this). Add bullets covering the four concerns:
+
+```markdown
+## [Unreleased]
+
+### Fixed
+
+- `release/cacheseed`: write the correct `h1:` hash for in-plan modules. Previously, the seed step zipped the working tree before consumed `.changeset/*.md` files were deleted; the resulting hash didn't match what `git archive` of the published tag produced, breaking every fresh-cache install with `SECURITY ERROR: checksum mismatch`. The fix reorders `applyStable` so the deletion happens before the seed, and replaces the single-pass seed-and-tidy with iterate-to-fixpoint to handle the cross-sibling cascade variant of the same class of bug. Surfaced by [`loglayer/loglayer-go#76` and follow-ups](https://github.com/loglayer/loglayer-go/pull/76); see [issue #54](https://github.com/disaresta-org/monorel/issues/54).
+- `release/tidy`: prime the module cache for third-party deps before offline tidy runs. Fresh CI runners with empty `GOMODCACHE` previously failed with `module lookup disabled by GOPROXY=off`; the new `primeModuleCache` step runs `go mod download` (with the inherited `GOPROXY`) before tidy.
+
+### Documentation
+
+- `ci/github/README.md`: inline comments on `actions/setup-go@v5` in both example workflows explaining the `GOTOOLCHAIN=local` rationale and the `go-version-file: go.mod` choice. New "## Recipes → Skipping CI on chore(release) commits" section with the if-clause snippet for consumer workflows on the same push.
+- `docs/src/workflows.md`: new CI-agnostic sections "CI environment requirements" (universal version of the prerequisite story) and "Avoiding the chore(release) CI race" (filter syntax for GitHub Actions, GitLab CI, Gitea Actions, and a generic principle for others).
+```
+
+If `CHANGELOG.md` doesn't currently have an `## [Unreleased]` heading, add it above the most recent versioned heading.
+
+- [ ] **Step 3: Build docs (CHANGELOG is sometimes embedded in the docs site).**
+
+Run: `cd /tmp/monorel-src/docs && bun run docs:build 2>&1 | tail -5`
+
+Expected: clean build.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs(changelog): entry for issue #54 four-concern fix package
+
+Three bullets covering the cacheseed wrong-hash fix, the cache
+priming fix, and the docs additions for toolchain prerequisites
+and the chore(release) CI race.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: changeset entry
+
+**Files:**
+- Create: `.changeset/cacheseed-fixpoint-and-pipeline-fixes.md`
+
+- [ ] **Step 1: Write the changeset.**
+
+Create `/tmp/monorel-src/.changeset/cacheseed-fixpoint-and-pipeline-fixes.md`:
+
+```markdown
+---
+"monorel.disaresta.com": minor
+---
+
+Fix `cacheseed` writing the wrong h1: hash for released sub-modules
+(would silently produce broken go.sum entries on every release; see
+[`loglayer/loglayer-go`'s v2.1.0 incident](https://github.com/loglayer/loglayer-go/pull/76)).
+Reorder `applyStable` so all working-tree mutations happen before
+the seed step, and replace the single-pass seed-and-tidy with
+iterate-to-fixpoint to handle cross-sibling dep chains.
+
+Add a `go mod download` priming step before offline tidy so fresh
+CI runners (with empty `GOMODCACHE`) can resolve third-party deps.
+The `GOPROXY=off` invariant during tidy is preserved.
+
+Document the `actions/setup-go` prerequisite (sub-modules with
+`go 1.25.0` directives need a 1.25+ runner since `GOTOOLCHAIN=local`
+during tidy blocks auto-download) and the `chore(release):`-commit
+skip filter recipe. See [issue #54](https://github.com/disaresta-org/monorel/issues/54).
+```
+
+- [ ] **Step 2: Run `monorel preview` (if installed) to confirm the changeset parses.**
+
+Run: `cd /tmp/monorel-src && go run . preview --upsert=false 2>&1 | tail -10`
+
+Expected: monorel's preview command prints the rendered plan including the new changeset. If `go run . preview` errors, check that the changeset frontmatter package key (`monorel.disaresta.com`) matches what's in `monorel.toml`'s `[packages]` table.
+
+If monorel isn't trivially runnable in the test environment, skip this step; the changeset format is documented and a malformed file would be caught by CI's release-pr workflow.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+cd /tmp/monorel-src
+git add .changeset/cacheseed-fixpoint-and-pipeline-fixes.md
+git commit -m "$(cat <<'EOF'
+chore: changeset for cacheseed-fixpoint and pipeline fixes
+
+Names monorel.disaresta.com at :minor for the four-concern fix
+package addressing issue #54.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite.**
+
+Run: `cd /tmp/monorel-src && go test ./...`
+
+Expected: PASS for every package.
+
+- [ ] **Step 2: Run any project-wide linters monorel uses.**
+
+Run: `cd /tmp/monorel-src && go vet ./...`
+
+Expected: no findings.
+
+If monorel has staticcheck or other linters in CI, run them locally:
+
+Run: `cd /tmp/monorel-src && command -v staticcheck >/dev/null && staticcheck ./... || echo "staticcheck not installed; skip"`
+
+- [ ] **Step 3: Build the docs site.**
+
+Run: `cd /tmp/monorel-src/docs && bun run docs:build 2>&1 | tail -5`
+
+Expected: clean build with all cross-links resolving.
+
+- [ ] **Step 4: Inspect the branch's full diff.**
+
+Run: `cd /tmp/monorel-src && git log --oneline main..HEAD && git diff --stat main..HEAD`
+
+Expected: 14 commits (Tasks 1-14), each focused; total diff covers `internal/release/{release,gosum,cacheseed,tidy}.go`, `internal/release/gosum_test.go`, `ci/github/README.md`, `docs/src/workflows.md`, `CHANGELOG.md`, `.changeset/cacheseed-fixpoint-and-pipeline-fixes.md`. No other files touched.
+
+- [ ] **Step 5: Push the branch.**
+
+Run: `cd /tmp/monorel-src && git push -u origin fix/cacheseed-fixpoint`
+
+If a pre-push hook surfaces any drift (it shouldn't given the test runs were clean, but it's a hygiene check), address it before opening the PR.
+
+- [ ] **Step 6: Open the PR.**
+
+```bash
+cd /tmp/monorel-src
+git fetch origin main
+git rebase origin/main  # ensure no conflicts; force-push if rebase produces commits
+gh pr create --title "fix: address issue #54 (cacheseed wrong-hash + pipeline robustness)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #54. Four-concern fix package addressing problems surfaced by
+[`loglayer/loglayer-go`'s v2.1.0 release](https://github.com/loglayer/loglayer-go/pull/76):
+
+- **Critical**: `release/cacheseed` writes the correct `h1:` hash for in-plan modules. Reorders `applyStable` so consumed-changeset deletion happens before the seed step. Replaces single-pass seed-and-tidy with iterate-to-fixpoint to handle cross-sibling dep chains.
+- **Cache priming**: new `primeModuleCache` step before offline tidy so fresh CI runners can resolve third-party deps.
+- **Toolchain docs**: inline comments on `actions/setup-go` in `ci/github/README.md` examples; strengthened "Requirements" bullet.
+- **chore(release) race docs**: new `## Recipes` section in `ci/github/README.md` plus universal sections in `docs/src/workflows.md`.
+
+## Test plan
+
+- [x] `go test ./...` passes (existing + 4 new regression tests)
+- [x] `go vet ./...` clean
+- [x] `bun run docs:build` clean
+- [x] Manually walked through `applyStable` reorder against the spec at `docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md`
+
+## Commits
+
+14 atomic commits (TDD-style). Reviewable as commit-by-commit; can squash-merge to land as the spec's "three commits" if you prefer the bundled history.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (run before submitting the PR)
+
+- [ ] **Spec coverage:** every concern in `docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md` maps to at least one task. Spot-check:
+  - Concern #1 reorder: Task 2.
+  - Concern #1 fixpoint: Tasks 3-7.
+  - Concern #2: Tasks 8-10.
+  - Concern #3 README: Task 11.
+  - Concern #3 universal: Task 12.
+  - Concern #4 README: Task 11.
+  - Concern #4 universal: Task 12.
+  - CHANGELOG: Task 13.
+  - Changeset: Task 14.
+- [ ] **API consistency:** `seedModuleCache` returns `[]seededEntry` everywhere it's referenced. `clearSeededEntries`, `readGoSums`, `goSumsChanged`, `stageAffected`, `errFixpointNotReached` all match across tasks.
+- [ ] **No em dashes** in any added prose (per the project's documentation rule). The plan above is the exception (it's an internal scaffolding doc); the docs the plan tells the engineer to write are em-dash-free.
+- [ ] **Conventional Commits** on every commit subject.

--- a/docs/superpowers/plans/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes.md
+++ b/docs/superpowers/plans/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes.md
@@ -1901,7 +1901,7 @@ Run: `cd /tmp/monorel-src/docs && bun run docs:build 2>&1 | tail -5`
 
 Expected: clean build. The cross-links between `ci/github/README.md` and `docs/src/workflows.md` should now both resolve.
 
-- [ ] **Step 3: Run the full repo test suite to confirm nothing regressed (defensive — docs changes shouldn't affect tests, but a sanity check is cheap).**
+- [ ] **Step 3: Run the full repo test suite to confirm nothing regressed (defensive: docs changes shouldn't affect tests, but a sanity check is cheap).**
 
 Run: `cd /tmp/monorel-src && go test ./...`
 

--- a/docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md
+++ b/docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md
@@ -1,0 +1,443 @@
+# cacheseed fixpoint + release-pipeline fix package
+
+**Date:** 2026-05-03
+**Status:** Approved (ready for implementation plan)
+**Scope:** Four coordinated changes to address [issue #54](https://github.com/disaresta-org/monorel/issues/54). Single PR, three commits.
+
+## Motivation
+
+Issue #54 surfaced four distinct problems in monorel's release pipeline, all of which bit `loglayer/loglayer-go`'s v2.1.0 release in sequence:
+
+1. **`cacheseed.go` writes the wrong `h1:` hash to released sub-modules' `go.sum` files.** The seed zips the working tree before all working-tree mutations have been applied; the chore(release) commit then includes mutations the seed didn't see, so the proxy's hash for the published version differs from the seeded hash. Every fresh-cache install of a monorel-driven release fails with `SECURITY ERROR: checksum mismatch`. **Critical.**
+
+2. **Offline tidy assumes a primed module cache** but only seeds in-plan siblings and pre-flight-checks managed-but-not-in-plan siblings. Third-party deps (anything not in `monorel.toml`) must already be in `GOMODCACHE`. On fresh CI runners, they aren't, and `GOPROXY=off` blocks fetching. Tidy fails with "module lookup disabled by GOPROXY=off."
+
+3. **`GOTOOLCHAIN=local`** during offline tidy blocks Go's auto-toolchain-download. Consumers whose sub-modules require a Go version newer than the runner's pre-installed Go hit a `go.mod requires go >= X.Y` error. The action's README doesn't document the prerequisite.
+
+4. **CI race on `chore(release):` commits.** The release commit updates module `go.mod` files to require new versions; the corresponding tags are pushed by `release.yml` on the same push. Any other workflow that fires on the same push and resolves Go modules races the tag push and surfaces a phantom CI failure. No upstream documentation explains the workflow filter consumers need.
+
+Concern #1 is the only true code bug in monorel's released code (it produces invalid releases). #2 is also a code bug but with a narrower failure surface (fresh CI runners). #3 and #4 are documentation gaps that surface as flaky CI for adopters.
+
+The previous spec at `docs/superpowers/specs/2026-05-03-tidy-gosum-design.md` introduced the offline-tidy + cache-seeding flow; this spec extends it to handle (1) the working-tree mutation race and (2) the third-party cache priming, plus the documentation additions for (3) and (4).
+
+## Architecture overview
+
+Three commits, all in one PR:
+
+1. **Commit 1, cacheseed fixpoint** (concern #1): reorder `applyStable` so all working-tree mutations happen before `tidySubmoduleGoSums`, and replace the single-pass seed-and-tidy inside it with iterate-to-fixpoint.
+2. **Commit 2, cache priming** (concern #2): add a `primeModuleCache` step before the seed, populating third-party deps via `go mod download` with the inherited `GOPROXY`.
+3. **Commit 3, docs** (concerns #3 + #4): inline-comment the existing example workflows in `ci/github/README.md` and strengthen its "Requirements" section; add a new "Recipes" section there for the chore(release) skip filter; add CI-agnostic "CI environment requirements" and "Avoiding the chore(release) CI race" sections to `docs/src/workflows.md`.
+
+Each commit ships independently. The order is significant only because (2) layers on the call site (1) introduces; the reverse order would require an interim state.
+
+## Concern #1: cacheseed wrong-hash bug
+
+### Root cause
+
+`internal/release/release.go:382-424` (`applyStable`) orders the chore(release)-commit composition steps as:
+
+1. CHANGELOG writes (lines 383-398).
+2. `rewriteSubmoduleGoMods` (lines 403-405): rewrites sub-modules' `go.mod` files.
+3. `tidySubmoduleGoSums` (lines 411-413): seeds in-plan modules into the local cache, then runs offline tidy in each affected sub-module.
+4. Consumed-changesets deletion (lines 416-422): `opts.Repo.Remove(".changeset/<consumed>.md")` for each consumed changeset.
+
+Step 3's seed (`internal/release/cacheseed.go:144`) runs `xzip.CreateFromDir(modDir)` against the working tree. At that moment, the consumed `.changeset/*.md` files are still on disk (step 4 hasn't run). They live inside the **root module's source tree** (the repo root is the root module's `modDir`), so they're part of the root module's zip per Go's module-zip rules. The hash monorel writes to the seeded cache is `hash(working-tree-with-consumed-changesets)`.
+
+After step 4, the working tree no longer has those files. The chore(release) commit lands without them. The release tag points at the chore(release) commit. `git archive` of the tag (= what the proxy serves) computes `hash(working-tree-without-consumed-changesets)` ≠ the seeded hash.
+
+Step 3's offline tidy in each affected sub-module reads the seeded `.ziphash` to populate the sub-module's own `go.sum` `h1:` lines for in-plan siblings. So every affected sub-module's `go.sum` records the wrong hash. Downstream consumers fetching the in-plan sibling at the published version hit `SECURITY ERROR: checksum mismatch`.
+
+The bug surfaces only when an in-plan module's source tree contains files that mutate between seed and commit. The canonical case is the root module + repo-level `.changeset/`, but the same class of bug exists for any working-tree mutation between seed and commit.
+
+A second, latent variant: tidy in step 3 mutates affected sub-modules' own `go.sum` files. Each affected sub-module's working tree thus differs from what the seed captured. If any sibling requires another in-plan sibling, that sibling's tidy would record the pre-mutation hash. None of loglayer-go's release exposes this case (the dep graph is "everything depends on root, no sibling depends on a sibling"), but a future cross-sibling release would. The fixpoint loop addresses both variants.
+
+### Fix part 1: reorder `applyStable`
+
+Move the consumed-changesets deletion (currently lines 416-422) to run between `rewriteSubmoduleGoMods` and `tidySubmoduleGoSums`. The block move is mechanical; no other changes to `applyStable`.
+
+```go
+// Before:                              // After:
+1. CHANGELOG writes                     1. CHANGELOG writes
+2. rewriteSubmoduleGoMods               2. rewriteSubmoduleGoMods
+3. tidySubmoduleGoSums                  3. consumed-changesets deletion  ← MOVED
+4. consumed-changesets deletion         4. tidySubmoduleGoSums
+```
+
+Update the GoDoc comments on `tidySubmoduleGoSums` (`gosum.go:30-31`) and the move-source comment in `applyStable` to reflect the new order.
+
+### Fix part 2: iterate-to-fixpoint inside `tidySubmoduleGoSums`
+
+Replace the single-pass seed-and-tidy with a fixpoint loop. The convergence story:
+
+- Each iteration re-seeds in-plan modules from the **current** working tree (which captures any mutations the previous iteration's tidy made).
+- Each iteration re-runs offline tidy in every affected sub-module.
+- Convergence: when no affected sub-module's `go.sum` changed during this iteration's tidy, every recorded `h1:` matches the seeded hash, which matches the working-tree hash, which is what the chore(release) commit will publish.
+- Bound: ≤ depth of the in-plan sibling dep graph. Hard cap at 10 iterations catches genuine bugs (cycles, non-determinism) before they runaway-loop.
+
+```go
+// internal/release/gosum.go (replacing the body of tidySubmoduleGoSums
+// from the seed/tidy pass downward):
+
+const maxTidyIterations = 10
+
+for i := 0; i < maxTidyIterations; i++ {
+    if err := clearSeededEntries(seeded); err != nil {
+        return err
+    }
+    cleanup, err := seedModuleCache(opts)
+    if err != nil {
+        cleanup()
+        return err
+    }
+    seeded = cleanup // capture for next iteration's clear
+
+    before, err := readGoSums(opts.RepoDir, affected)
+    if err != nil {
+        return err
+    }
+
+    for _, sub := range affected {
+        modDir := filepath.Join(opts.RepoDir, sub)
+        if err := runOfflineTidy(modDir); err != nil {
+            return err
+        }
+    }
+
+    after, err := readGoSums(opts.RepoDir, affected)
+    if err != nil {
+        return err
+    }
+
+    if !goSumsChanged(before, after) {
+        // Fixpoint reached. Stage and return.
+        return stageAffected(opts, affected)
+    }
+}
+
+return errFixpointNotReached(opts.RepoDir, affected, /* per-iteration diffs */)
+```
+
+The exact API for `seedModuleCache`'s cleanup will be reshaped: instead of returning `func()`, it returns `[]seededEntry` so the loop can clear before re-seeding (rather than accumulating LIFO-deferred cleanups).
+
+### New helpers (all in `gosum.go` or `cacheseed.go`)
+
+- `clearSeededEntries(entries []seededEntry) error` (cacheseed.go): explicit cleanup of previous iteration's seed cache files. Replaces the `cleanup` closure pattern.
+- `readGoSums(repoDir string, paths []string) (map[string][]byte, error)` (gosum.go): snapshot every affected sub-module's `go.sum` file bytes.
+- `goSumsChanged(before, after map[string][]byte) bool` (gosum.go): byte-equal comparison of two snapshots.
+- `stageAffected(opts Options, paths []string) error` (gosum.go): staging step, factored out of the existing inline loop at lines 80-94.
+- `errFixpointNotReached` type (gosum.go): error carrying per-iteration `goSumsChanged` diffs as a diagnostic payload. The orchestrator surfaces it with a "this is likely a monorel bug; please file an issue with the diff below" hint, matching the existing error UX in `preflightOutOfPlanCache` (lines 195-201).
+
+### `seedModuleCache` API change
+
+Change the return type from `(func(), error)` to `([]seededEntry, error)`. The fixpoint loop passes the previous iteration's `[]seededEntry` to `clearSeededEntries` before the next `seedModuleCache` call. Callers outside `tidySubmoduleGoSums` (test code, possibly future callers) get a `clearSeededEntries(seeded)` call to invoke explicitly.
+
+The existing single test caller pattern (`cleanup, err := seedModuleCache(opts); defer cleanup()`) becomes `seeded, err := seedModuleCache(opts); defer clearSeededEntries(seeded)`.
+
+## Concern #2: cache priming for offline tidy
+
+### Root cause
+
+`internal/release/tidy.go:74` sets `GOPROXY=off` for the offline-tidy subprocess. The doc comment at lines 15-18 explains the rationale: "rely on the seeded cache for in-plan siblings; out-of-plan managed siblings are confirmed by `preflightOutOfPlanCache`." But this only covers monorel-managed modules. Third-party deps (anything not declared in `monorel.toml`'s `[packages]` table) must already be present in `GOMODCACHE` from prior `go build` / `go test` work.
+
+On a fresh GitHub runner, `GOMODCACHE` is empty (or has only Go's pre-installed standard-library tooling). Tidy fails with:
+
+```
+go: <sub-module> imports
+    github.com/some/third-party-dep: module lookup disabled by GOPROXY=off
+```
+
+The fix needs to ensure third-party deps are in `GOMODCACHE` before offline tidy runs.
+
+### Fix
+
+Add a `primeModuleCache` step inside `tidySubmoduleGoSums`, between the existing pre-flight check (`preflightOutOfPlanCache`) and the seed step (`seedModuleCache`):
+
+```go
+// internal/release/gosum.go:
+
+// 3. Pre-flight: confirm out-of-plan managed siblings are cached.
+if err := preflightOutOfPlanCache(opts, affected, inPlan); err != nil {
+    return err
+}
+
+// NEW. 4. Prime the module cache with third-party deps.
+for _, sub := range affected {
+    modDir := filepath.Join(opts.RepoDir, sub)
+    if err := primeModuleCache(modDir); err != nil {
+        return err
+    }
+}
+
+// 5. Seed the cache with in-plan releases.
+// ... (fixpoint loop from concern #1)
+```
+
+The new helper lives in `tidy.go` next to `runOfflineTidy`:
+
+```go
+// primeModuleCache populates the local module cache with the
+// third-party deps modDir's go.mod transitively requires. Subsequent
+// offline tidy with GOPROXY=off can resolve those deps from the cache
+// without reaching out to the network.
+//
+// Uses the inherited GOPROXY (typically https://proxy.golang.org,direct)
+// and GOSUMDB so go.sum hashes are verified during download. Does NOT
+// mutate go.sum: `go mod download` reads go.sum, downloads the listed
+// modules, and writes nothing.
+//
+// PATH, HOME, USER, TMPDIR, LANG, LC_*, GOMODCACHE, GOCACHE, GOPROXY,
+// GOSUMDB pass through.
+func primeModuleCache(modDir string) error {
+    cmd := exec.Command("go", "mod", "download")
+    cmd.Dir = modDir
+    cmd.Env = primeCacheEnv()
+
+    out, err := cmd.CombinedOutput()
+    if err != nil {
+        return fmt.Errorf("prime module cache in %s: %w\n%s", modDir, err, out)
+    }
+    return nil
+}
+
+func primeCacheEnv() []string {
+    inherit := []string{
+        "PATH", "HOME", "USER", "TMPDIR", "LANG",
+        "GOMODCACHE", "GOCACHE",
+        "GOPROXY", "GOSUMDB",  // NEW vs offlineTidyEnv
+    }
+    env := make([]string, 0, len(inherit)+4)
+    for _, k := range inherit {
+        if v, ok := os.LookupEnv(k); ok {
+            env = append(env, k+"="+v)
+        }
+    }
+    for _, e := range os.Environ() {
+        if strings.HasPrefix(e, "LC_") {
+            env = append(env, e)
+        }
+    }
+    env = append(env,
+        "GOWORK=off",         // ignore workspace, mirroring offlineTidyEnv
+        "GOFLAGS=",           // clear caller's flags, mirroring offlineTidyEnv
+        "GOTOOLCHAIN=local",  // same toolchain policy as offlineTidyEnv
+    )
+    return env
+}
+```
+
+The key differences vs `offlineTidyEnv`:
+- `GOPROXY` is inherited (not forced to `off`).
+- `GOSUMDB` is inherited (so `go mod download` still verifies against the public checksum database for newly-fetched modules; `go.sum` provides the project-level guarantee).
+
+### Why not just loosen `GOPROXY=off` during tidy?
+
+That alternative is simpler (one-line removal) but loses the documented determinism guarantee at `tidy.go:15-18`. Tidy with a network-enabled `GOPROXY` could resolve modules differently across re-runs (e.g., if a sibling tag is published mid-run). Keeping `GOPROXY=off` during tidy preserves "tidy reads only from the explicit cache, never from the network" as a hard guarantee. The cost is one extra subprocess per affected sub-module during release, which is negligible (≤ a few seconds total for typical releases).
+
+### Tests
+
+New test in `gosum_test.go`:
+
+- `TestTidySubmoduleGoSums_PrimesThirdPartyDeps`: build a fixture where an affected sub-module requires a third-party dep (e.g., `github.com/davecgh/go-spew` from `golang.org/x/mod`'s test fixtures or a real public module). Run with a fresh `GOMODCACHE`. Confirm `tidySubmoduleGoSums` succeeds.
+
+## Concern #3: Toolchain documentation
+
+### Root cause
+
+`internal/release/tidy.go:78` sets `GOTOOLCHAIN=local` for the offline-tidy subprocess. The rationale (line 27): "don't auto-download a different toolchain." This is a deliberate, defensible choice: catch toolchain mismatches loudly rather than silently inflate cache size with auto-downloads.
+
+The action's existing example workflows in `ci/github/README.md` (lines 26-49 and 51-74) already include `actions/setup-go@v5 with go-version-file: go.mod`. The existing "Requirements" section (line 78) already explains that the runner needs a Go binary satisfying every released module's `go` directive. The loglayer-go failure was a workflow that didn't follow the example: it had `actions/checkout@v4` followed directly by `disaresta-org/monorel/ci/github@v0.11.0` with no `setup-go` between them. Consumers who skip the existing setup-go step or who use `go-version-file: go.mod` against a root with a lower `go` directive than its sub-modules will hit the same failure.
+
+The doc gap is therefore narrower than concerns #1 and #2: the existing example is correct but its rationale isn't visible enough at the point where someone copy-pastes from it. And the requirement is universal (it bites any CI system, not just GitHub Actions) but is currently documented only in the GitHub-specific README.
+
+### Fix
+
+Documentation only. Two layers.
+
+**`ci/github/README.md`: inline comments on the existing examples.** Add a comment above `actions/setup-go@v5` in each example workflow explaining the rationale, so a casual reader doesn't strip the step. Clarify the `go-version-file: go.mod` choice:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
+# monorel runs `go mod tidy` with GOTOOLCHAIN=local during release,
+# so Go must already be installed at a version satisfying every
+# released sub-module's `go` directive (the highest one wins).
+# `go-version-file: go.mod` reads the root module's go.mod; if a
+# sub-module declares a higher floor, pin `go-version` explicitly.
+- uses: actions/setup-go@v5
+  with:
+    go-version-file: go.mod
+
+- uses: disaresta-org/monorel/ci/github@<version>
+  with:
+    command: pr
+```
+
+Strengthen the existing "Requirements" → "go on PATH" bullet (line 78) to call out the failure mode explicitly: "If the runner's Go is older than the highest sub-module's `go` directive, tidy fails with `go.mod requires go >= X.Y; running Z; GOTOOLCHAIN=local`. The fix is always to bump the runner's Go, not to remove `GOTOOLCHAIN=local` from monorel's tidy step (the env var is part of monorel's offline-tidy determinism guarantee)."
+
+**`docs/src/workflows.md`: new CI-agnostic section.** monorel ships a GitHub-specific CI integration today, but the underlying requirement applies to any CI invoking `monorel release` (GitLab CI, Gitea Actions, CircleCI, Drone, self-hosted runners, etc.). Add a "## CI environment requirements" section listing the universal requirements:
+
+- Go installed at a version ≥ the highest `go` directive across released sub-modules. The `GOTOOLCHAIN=local` policy during offline tidy means the runner's Go must satisfy every sub-module; auto-download is intentionally blocked. Pin explicitly when sub-modules raise the floor.
+- `GOPROXY` set to a real proxy or `direct` so the prime-cache step (concern #2) can fetch third-party deps. The offline-tidy that follows uses `GOPROXY=off` regardless of this setting; only the priming step honors `GOPROXY`.
+- Push permissions for tags (the `release` command runs `git push --follow-tags`). Provider API token with `contents: write` and `pull-requests: write` for the `pr` command.
+
+Cross-link to `ci/github/README.md` for the GitHub-specific implementation.
+
+No code change.
+
+## Concern #4: CI race recipe on `chore(release):` commits
+
+### Root cause
+
+The `chore(release):` merge commit (created when the always-open release PR is merged to main) carries the new module versions in its `go.mod` files. The matching tags are created and pushed by `release.yml` (using `monorel/ci/github` with `command: release`) running on that same push event. Any other workflow that fires on the same push event and runs `go mod tidy` (or any operation that resolves Go modules) races the tag-push and may transiently fail with:
+
+```
+go: <module>: reading <module>/go.mod at revision v2.1.0: unknown revision v2.1.0
+```
+
+The CI failure is a phantom: the release succeeds, the tags get pushed, and the next non-release commit's CI run is clean. But the chore(release) commit carries a red mark in the GitHub UI on every release.
+
+### Fix
+
+Documentation only. Two layers.
+
+**`ci/github/README.md`: new "Recipes" section** with the GitHub-specific syntax:
+
+```markdown
+## Recipes
+
+### Skipping CI on chore(release) commits
+
+The release commit `chore(release): ...` is created by the always-open
+release PR's merge. On the same push event, `release.yml` (using this
+action with `command: release`) creates and pushes per-package tags.
+Any *other* workflow that runs on the same push and resolves Go module
+versions will race the tag-push and may transiently fail with:
+
+    go: example.com/foo/v2: reading example.com/foo/go.mod at revision
+        v2.1.0: unknown revision v2.1.0
+
+To avoid the phantom failure, skip the workflow on `chore(release):`
+commits. The skip filter:
+
+```yaml
+jobs:
+  test:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
+    # ... rest of job ...
+```
+
+Apply the filter to every job (`test`, `staticcheck`, `govulncheck`,
+etc.) that runs `go mod tidy` or anything else that resolves the new
+versions. Pull-request triggers stay always-on; only push-to-main runs
+are skipped, and only when the head commit is the release-PR merge.
+
+The `release.yml` workflow that runs the actual release pipeline does
+NOT need this filter; its own `if:` clause is the *opposite* shape
+(only run on `chore(release):` commits), so it's already mutually
+exclusive with the skip pattern above.
+```
+
+**`docs/src/workflows.md`: new CI-agnostic section "Avoiding the chore(release) CI race"** describing the principle and the per-CI filter syntax. Cover the three CI systems whose providers monorel supports today:
+
+- **GitHub Actions / Gitea Actions** (same syntax): `if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}` on each job. (Cross-link the GitHub README's Recipes section for the full snippet.)
+- **GitLab CI**: `rules:` clause on each job:
+  ```yaml
+  rules:
+    - if: '$CI_COMMIT_TITLE =~ /^chore\(release\):/'
+      when: never
+    - when: on_success
+  ```
+- **Generic / other CI systems**: skip the workflow when the head commit subject starts with `chore(release):`. The exact syntax varies; the principle is universal.
+
+Don't ship full alternative workflow files for GitLab/Gitea (out of scope; monorel doesn't ship reference CI integrations for those today). The filter snippets are enough to unblock anyone applying the principle to their own setup.
+
+No code change.
+
+## Tests (full coverage across concerns #1 and #2)
+
+All in `internal/release/gosum_test.go`, using the existing `setupSubmoduleFixture` helper (lines 31+).
+
+### Concern #1 regression tests
+
+1. **`TestApplyStable_RootChangesetDeletion_HashesMatchPublished`** (or in `release_test.go` as it exercises `applyStable`'s reorder): build a fixture with the root module having a `.changeset/<name>.md` consumed by the plan and one sub-module requiring root. Run `applyStable`. After the simulated chore(release) commit lands on the fake repo, compute the hash via `dirhash.HashZip` against `git archive` of the simulated tag, compare against the `h1:` entry in the sub-module's `go.sum`. They must match.
+
+2. **`TestTidySubmoduleGoSums_CrossSiblingCascade_ConvergesQuickly`**: three modules: A (root), B (depends on A), C (depends on B). All in-plan. Run `tidySubmoduleGoSums`. Verify it converges. Verify every `h1:` recorded in B's and C's `go.sum` matches what the corresponding tagged version's bytes hash to. Optionally instrument the iteration count via a test hook and assert ≤ 3 iterations.
+
+3. **`TestTidySubmoduleGoSums_FixpointNotReached_SurfacesDiagnosticError`**: pin the error UX. Mock the seed step or tidy step to introduce non-determinism (e.g., a test-only environment variable that makes seed produce a different hash each call). Confirm `tidySubmoduleGoSums` returns `errFixpointNotReached` with the per-iteration diff payload populated and the error message hints at filing an issue.
+
+### Concern #2 regression test
+
+4. **`TestTidySubmoduleGoSums_PrimesThirdPartyDeps_FromColdCache`**: build a fixture where an affected sub-module's `go.mod` requires a real third-party dep (e.g., `gopkg.in/yaml.v3`, which monorel itself uses). Run with a fresh `GOMODCACHE` (already what `setupSubmoduleFixture` sets up via `t.Setenv("GOMODCACHE", tmpModCache)`). Confirm `tidySubmoduleGoSums` succeeds. Without `primeModuleCache`, this would fail with the "module lookup disabled by GOPROXY=off" error.
+
+### Existing test coverage
+
+The existing tests in `gosum_test.go` (lines 131-330) all exercise `tidySubmoduleGoSums` with single-pass scenarios. After the fixpoint loop lands, those tests still produce the same end-state because the loop converges in 1 iteration when there's no cross-sibling dep to propagate. They should pass without modification.
+
+## Documentation surface
+
+Two layers of documentation across the four concerns. The detailed shapes are in the per-concern sections above; the summary:
+
+**`ci/github/README.md`** (GitHub-specific):
+- Inline comments on the existing `actions/setup-go` step in both example workflows, explaining the `GOTOOLCHAIN=local` rationale and the `go-version-file: go.mod` choice (concern #3).
+- Strengthened "Requirements" → "go on PATH" bullet calling out the failure mode (concern #3).
+- New "## Recipes" → "### Skipping CI on chore(release) commits" section with the GitHub-Actions if-clause snippet (concern #4).
+
+**`docs/src/workflows.md`** (CI-agnostic):
+- New "## CI environment requirements" section listing universal requirements: Go version ≥ highest sub-module floor, `GOPROXY` set to a real proxy or `direct`, push permissions for tags + provider API token (concern #3 universal version).
+- New "## Avoiding the chore(release) CI race" section describing the race and the per-CI filter syntax for GitHub Actions, GitLab CI, and Gitea Actions (concern #4 universal version).
+
+Cross-link `ci/github/README.md` from `docs/src/workflows.md` for the GitHub-specific implementation, and `docs/src/workflows.md` from `ci/github/README.md` for the universal principles.
+
+Add an entry to monorel's CHANGELOG (`CHANGELOG.md`) under the next release version covering all four concerns, with cross-references to the loglayer-go incident PRs (#77 / #78 / #80 / #81) as the empirical example.
+
+## Out of scope
+
+- **Action-side prerequisites enforcement.** The action could fail loudly at startup if `setup-go` hasn't run with a sufficient Go version, instead of letting tidy fail with the cryptic `GOTOOLCHAIN=local` error. Worth doing later; the README addition is the right level of intervention for now.
+- **Pushing tags before the chore(release) commit.** That'd eliminate concern #4 entirely (no race possible) but would require a redesign of monorel's release pipeline. Concern #4 is a docs gap; pre-tagging is a separate design problem.
+- **Yanking and republishing v2.1.0 / cli v2.2.0 / pretty v2.1.0 / console v2.1.0 of `loglayer/loglayer-go`.** loglayer-go applied a manual recovery (PR #81: strip and retidy) that fixed the bad `go.sum` hashes on `main`, so consumers fetching from `main`'s HEAD are fine. The published tags themselves still have the wrong recorded hashes embedded in their sub-modules' go.sum, but those entries are recorded against the *seeded* hash, not against the proxy hash; downstream consumers re-tidy and overwrite them with correct values. Already-published tags don't need to be re-cut for monorel's fix to take effect on future releases.
+
+## File-level summary
+
+**Modified:**
+- `internal/release/release.go`: reorder consumed-changesets deletion in `applyStable`. Update GoDoc on `applyStable` reflecting the new order.
+- `internal/release/gosum.go`: replace single-pass body of `tidySubmoduleGoSums` with fixpoint loop. Add `readGoSums`, `goSumsChanged`, `stageAffected` helpers. Add `errFixpointNotReached` type. Insert `primeModuleCache` call before the seed step. Update GoDoc reflecting both changes.
+- `internal/release/tidy.go`: add `primeModuleCache` and `primeCacheEnv` next to existing `runOfflineTidy` and `offlineTidyEnv`. No changes to the existing helpers.
+- `internal/release/cacheseed.go`: change `seedModuleCache` return type from `(func(), error)` to `([]seededEntry, error)`. Add exported helper `clearSeededEntries(entries []seededEntry) error`. No changes to the hash computation itself.
+- `internal/release/gosum_test.go`: add the four new tests above. Update existing tests' calls to `seedModuleCache` for the new return signature. Existing tests' calls of `tidySubmoduleGoSums` are unchanged.
+- `ci/github/README.md`: inline-comment the existing example workflows' `actions/setup-go` step with the rationale (concern #3). Strengthen the existing "Requirements" → "go on PATH" bullet to call out the `GOTOOLCHAIN=local` failure mode (concern #3). Add a new "## Recipes" section with the chore(release) skip-CI snippet (concern #4).
+- `docs/src/workflows.md`: add two new CI-agnostic sections: "## CI environment requirements" (concern #3 universal version) and "## Avoiding the chore(release) CI race" (concern #4 universal version with GitHub / GitLab / Gitea filter snippets). Cross-link from the GitHub-specific README for the implementation details.
+- `CHANGELOG.md`: entry covering all four concerns under the next release.
+
+**New:**
+- None. All changes layer onto existing files.
+
+## Changeset
+
+Single root-package changeset, `:minor` bump:
+
+```
+.changeset/cacheseed-fixpoint-and-pipeline-fixes.md
+---
+"monorel.disaresta.com": minor
+---
+
+Fix `cacheseed` writing the wrong h1: hash for released sub-modules
+(would silently produce broken go.sum entries on every release; see
+loglayer-go's v2.1.0 incident). Reorder applyStable so all working-tree
+mutations happen before the seed step, and replace the single-pass
+seed-and-tidy with iterate-to-fixpoint to handle cross-sibling dep
+chains.
+
+Add a `go mod download` priming step before offline tidy so fresh CI
+runners (with empty GOMODCACHE) can resolve third-party deps. The
+`GOPROXY=off` invariant during tidy is preserved.
+
+Document the `actions/setup-go` prerequisite (sub-modules with
+`go 1.25.0` directives need a 1.25+ runner since GOTOOLCHAIN=local
+during tidy blocks auto-download) and the `chore(release):`-commit
+skip filter recipe.
+
+See https://github.com/disaresta-org/monorel/issues/54.
+```

--- a/internal/git/fake.go
+++ b/internal/git/fake.go
@@ -3,6 +3,8 @@ package git
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -58,6 +60,13 @@ type Fake struct {
 	// regardless of which one. Single-shot: cleared after firing.
 	// Used to test error-handling paths in higher layers.
 	FailNext error
+
+	// Dir, when non-empty, is the repository root. When set,
+	// [Fake.Remove] also physically deletes the named paths from disk
+	// (mirroring `git rm -f`). Tests that verify working-tree state
+	// after Remove should set Dir; tests that only inspect Removed
+	// can leave it empty.
+	Dir string
 }
 
 // FakeCommit is one recorded commit on a [Fake].
@@ -162,11 +171,22 @@ func (f *Fake) Add(paths ...string) error {
 }
 
 // Remove implements [Repo.Remove]. Records the paths in Removed.
+// When [Fake.Dir] is set, also physically removes each path from
+// the working tree (mirroring `git rm -f`). Missing files are
+// silently skipped.
 func (f *Fake) Remove(paths ...string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if err := f.take(); err != nil {
 		return err
+	}
+	if f.Dir != "" {
+		for _, p := range paths {
+			abs := filepath.Join(f.Dir, p)
+			if err := os.Remove(abs); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("git fake remove %s: %w", p, err)
+			}
+		}
 	}
 	f.Removed = append(f.Removed, paths...)
 	return nil

--- a/internal/release/cacheseed.go
+++ b/internal/release/cacheseed.go
@@ -27,9 +27,10 @@ type seededEntry struct {
 // seedModuleCache writes the four cache files (.info, .mod, .zip,
 // .ziphash) for every in-plan released package into the developer's
 // Go module cache, in the layout `go mod tidy` expects when running
-// offline. Returns a cleanup closure that removes only these specific
-// entries; callers `defer cleanup()` so the cleanup runs whether the
-// orchestrator succeeds or fails.
+// offline. Returns a slice of [seededEntry] tracking every file
+// written; callers pass it to [clearSeededEntries] to remove the
+// entries when done. The slice is populated even on error (whatever
+// was written before the failure) so cleanup can still run.
 //
 // The cleanup is best-effort: per-entry remove failures are not
 // returned, since cache entries are content-addressed and a stale
@@ -38,20 +39,10 @@ type seededEntry struct {
 // Skips packages whose Path doesn't contain a go.mod (e.g. a
 // pure-changelog package), and packages whose go.mod parse fails
 // (those bubble out of the rewriter earlier).
-func seedModuleCache(opts Options) (cleanup func(), err error) {
+func seedModuleCache(opts Options) (seeded []seededEntry, err error) {
 	mc, err := goModCache()
 	if err != nil {
-		return func() {}, fmt.Errorf("seed module cache: %w", err)
-	}
-
-	var seeded []seededEntry
-	cleanup = func() {
-		for _, e := range seeded {
-			_ = os.Remove(e.infoPath)
-			_ = os.Remove(e.modPath)
-			_ = os.Remove(e.zipPath)
-			_ = os.Remove(e.zipHashPath)
-		}
+		return nil, fmt.Errorf("seed module cache: %w", err)
 	}
 
 	// Use the current time for the .info Time field. The actual
@@ -69,12 +60,12 @@ func seedModuleCache(opts Options) (cleanup func(), err error) {
 			if os.IsNotExist(err) {
 				continue
 			}
-			return cleanup, fmt.Errorf("seed module cache: read %s: %w", modFilePath, err)
+			return seeded, fmt.Errorf("seed module cache: read %s: %w", modFilePath, err)
 		}
 
 		mf, err := readModFile(modFilePath)
 		if err != nil {
-			return cleanup, fmt.Errorf("seed module cache: %w", err)
+			return seeded, fmt.Errorf("seed module cache: %w", err)
 		}
 		if mf == nil {
 			continue
@@ -87,16 +78,31 @@ func seedModuleCache(opts Options) (cleanup func(), err error) {
 
 		entry, err := writeCacheEntry(mc, mv, modDir, modBytes, now)
 		// Append unconditionally: writeCacheEntry returns its
-		// (partially-populated) entry on error too, and cleanup
-		// must be able to remove whatever it wrote before failing.
-		// Empty fields in entry round-trip safely through os.Remove.
+		// (partially-populated) entry on error too, and the caller
+		// uses the slice to clean up whatever was written before
+		// failure. Empty fields in entry round-trip safely through
+		// os.Remove via clearSeededEntries.
 		seeded = append(seeded, entry)
 		if err != nil {
-			return cleanup, fmt.Errorf("seed module cache for %s@%s: %w", mv.Path, mv.Version, err)
+			return seeded, fmt.Errorf("seed module cache for %s@%s: %w", mv.Path, mv.Version, err)
 		}
 	}
 
-	return cleanup, nil
+	return seeded, nil
+}
+
+// clearSeededEntries removes every cache file in entries. Called by
+// the orchestrator at the end of [tidySubmoduleGoSums] (and between
+// iterations of the fixpoint loop). Best-effort: per-file remove
+// failures are silently ignored, since cache entries are
+// content-addressed and a stale leftover is inert.
+func clearSeededEntries(entries []seededEntry) {
+	for _, e := range entries {
+		_ = os.Remove(e.infoPath)
+		_ = os.Remove(e.modPath)
+		_ = os.Remove(e.zipPath)
+		_ = os.Remove(e.zipHashPath)
+	}
 }
 
 // writeCacheEntry produces the four cache files for one (module,

--- a/internal/release/gosum.go
+++ b/internal/release/gosum.go
@@ -66,38 +66,67 @@ func tidySubmoduleGoSums(opts Options) error {
 		return err
 	}
 
-	// 4. Seed the cache with in-plan releases.
-	seeded, err := seedModuleCache(opts)
-	defer clearSeededEntries(seeded)
-	if err != nil {
-		return err
-	}
+	// 4. Iterate seed-and-tidy to fixpoint. Each iteration zips
+	//    every in-plan module's working tree, seeds the cache with
+	//    the resulting hashes, and runs offline tidy in each
+	//    affected sub-module. If any sub-module's go.sum was
+	//    mutated by the iteration's tidy, the working tree changed
+	//    too, so the next iteration re-seeds and re-tidies. The
+	//    loop converges when no go.sum is mutated; at that point
+	//    every recorded h1: matches the seeded hash, which matches
+	//    the working-tree hash, which is what `git archive` of the
+	//    published tag will produce.
+	//
+	//    Iteration cap defends against cycles/non-determinism. The
+	//    practical bound is the depth of the in-plan sibling dep
+	//    graph; a typical monorepo converges in 1-3 iterations.
+	const maxTidyIterations = 10
+	var seeded []seededEntry
+	defer func() { clearSeededEntries(seeded) }()
 
-	// 5. Run tidy in each affected sub-module. Hard-fail on the
-	//    first failure; staging happens only after all succeed.
-	for _, sub := range affected {
-		modDir := filepath.Join(opts.RepoDir, sub)
-		if err := runOfflineTidy(modDir); err != nil {
+	var lastDiffs map[string][2][]byte
+	for i := 0; i < maxTidyIterations; i++ {
+		clearSeededEntries(seeded)
+		seeded, err = seedModuleCache(opts)
+		if err != nil {
 			return err
 		}
-	}
 
-	// 6. Stage every (potentially) modified go.mod / go.sum.
-	for _, sub := range affected {
-		for _, name := range []string{"go.mod", "go.sum"} {
-			rel := filepath.Join(sub, name)
-			abs := filepath.Join(opts.RepoDir, rel)
-			if _, err := os.Stat(abs); os.IsNotExist(err) {
-				continue
-			} else if err != nil {
-				return fmt.Errorf("tidy: stat %s: %w", abs, err)
-			}
-			if err := opts.Repo.Add(rel); err != nil {
-				return fmt.Errorf("tidy: stage %s: %w", rel, err)
+		before, err := readGoSums(opts.RepoDir, affected)
+		if err != nil {
+			return err
+		}
+
+		for _, sub := range affected {
+			modDir := filepath.Join(opts.RepoDir, sub)
+			if err := runOfflineTidy(modDir); err != nil {
+				return err
 			}
 		}
+
+		after, err := readGoSums(opts.RepoDir, affected)
+		if err != nil {
+			return err
+		}
+
+		if !goSumsChanged(before, after) {
+			// Fixpoint reached.
+			return stageAffected(opts, affected)
+		}
+
+		// Capture the diff for diagnostic in case fixpoint never
+		// converges. Overwritten each iteration; we only emit the
+		// final iteration's diff if we exit via the cap.
+		lastDiffs = make(map[string][2][]byte, len(before))
+		for k := range before {
+			lastDiffs[k] = [2][]byte{before[k], after[k]}
+		}
 	}
-	return nil
+
+	return &errFixpointNotReached{
+		iterations: maxTidyIterations,
+		finalDiffs: lastDiffs,
+	}
 }
 
 // inPlanSiblings returns the set of import paths being released in

--- a/internal/release/gosum.go
+++ b/internal/release/gosum.go
@@ -97,6 +97,19 @@ func tidySubmoduleGoSums(opts Options) error {
 			return err
 		}
 
+		// Remove existing go.sum files before each tidy pass so the
+		// re-seed's new hashes take effect without triggering a
+		// SECURITY ERROR from Go's local go.sum verification. Tidy
+		// recreates go.sum from the seeded cache entries; the fixpoint
+		// check then compares the freshly-written go.sum against the
+		// pre-deletion snapshot.
+		for _, sub := range affected {
+			goSumPath := filepath.Join(opts.RepoDir, sub, "go.sum")
+			if err := os.Remove(goSumPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("tidy: remove %s before re-tidy: %w", goSumPath, err)
+			}
+		}
+
 		for _, sub := range affected {
 			modDir := filepath.Join(opts.RepoDir, sub)
 			if err := runOfflineTidy(modDir); err != nil {

--- a/internal/release/gosum.go
+++ b/internal/release/gosum.go
@@ -1,9 +1,11 @@
 package release
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/mod/module"
 )
@@ -225,4 +227,88 @@ func managedImportPaths(opts Options) map[string]bool {
 		out[mf.Module.Mod.Path] = true
 	}
 	return out
+}
+
+// readGoSums reads the go.sum bytes for every sub-module path in
+// affected. Missing files are recorded as nil byte slices (a
+// sub-module that hasn't yet been tidied may not have a go.sum
+// file). Used by [tidySubmoduleGoSums]'s fixpoint loop to detect
+// whether the most recent tidy iteration mutated any go.sum.
+func readGoSums(repoDir string, affected []string) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(affected))
+	for _, sub := range affected {
+		path := filepath.Join(repoDir, sub, "go.sum")
+		b, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				out[sub] = nil
+				continue
+			}
+			return nil, fmt.Errorf("readGoSums: %s: %w", path, err)
+		}
+		out[sub] = b
+	}
+	return out, nil
+}
+
+// goSumsChanged reports whether before and after differ on any key.
+// Caller passes snapshots from [readGoSums]; both maps must have the
+// same key set.
+func goSumsChanged(before, after map[string][]byte) bool {
+	for k, b := range before {
+		if !bytes.Equal(b, after[k]) {
+			return true
+		}
+	}
+	return false
+}
+
+// stageAffected stages each affected sub-module's go.mod and go.sum
+// in the repo. Idempotent: missing files are skipped; non-Stat
+// failures bubble up. Used by [tidySubmoduleGoSums] after the
+// fixpoint loop converges.
+func stageAffected(opts Options, affected []string) error {
+	for _, sub := range affected {
+		for _, name := range []string{"go.mod", "go.sum"} {
+			rel := filepath.Join(sub, name)
+			abs := filepath.Join(opts.RepoDir, rel)
+			if _, err := os.Stat(abs); os.IsNotExist(err) {
+				continue
+			} else if err != nil {
+				return fmt.Errorf("tidy: stat %s: %w", abs, err)
+			}
+			if err := opts.Repo.Add(rel); err != nil {
+				return fmt.Errorf("tidy: stage %s: %w", rel, err)
+			}
+		}
+	}
+	return nil
+}
+
+// errFixpointNotReached is returned by [tidySubmoduleGoSums] when
+// the seed-and-tidy loop fails to converge within maxTidyIterations.
+// The error carries the per-iteration go.sum diffs as a diagnostic
+// payload so the maintainer can see exactly which sub-module's
+// go.sum kept changing across iterations. This typically indicates
+// a monorel bug (cycle, non-determinism); the message hints the
+// maintainer to file an issue.
+type errFixpointNotReached struct {
+	iterations int
+	finalDiffs map[string][2][]byte // per sub-module: [0]=before, [1]=after for the last iteration
+}
+
+func (e *errFixpointNotReached) Error() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "tidy did not converge after %d iterations; this indicates a monorel bug.\n",
+		e.iterations)
+	fmt.Fprintf(&b, "Please file an issue at https://github.com/disaresta-org/monorel/issues with the following diffs:\n\n")
+	for sub, ba := range e.finalDiffs {
+		if bytes.Equal(ba[0], ba[1]) {
+			continue
+		}
+		fmt.Fprintf(&b, "==> %s/go.sum (last iteration's diff):\n", sub)
+		fmt.Fprintf(&b, "BEFORE:\n%s\n", ba[0])
+		fmt.Fprintf(&b, "AFTER:\n%s\n", ba[1])
+	}
+	return b.String()
 }

--- a/internal/release/gosum.go
+++ b/internal/release/gosum.go
@@ -66,7 +66,22 @@ func tidySubmoduleGoSums(opts Options) error {
 		return err
 	}
 
-	// 4. Iterate seed-and-tidy to fixpoint. Each iteration zips
+	// 4. Prime the module cache with third-party deps each affected
+	//    sub-module transitively requires. Tidy under GOPROXY=off
+	//    can only resolve from the cache; managed siblings are
+	//    seeded by the loop below, but third-party deps depend on
+	//    the cache being warm. Dev cache is usually warm from prior
+	//    builds; fresh CI runner cache isn't. Populate the cache
+	//    explicitly so the offline tidy that follows resolves
+	//    every transitive dep from the cache.
+	for _, sub := range affected {
+		modDir := filepath.Join(opts.RepoDir, sub)
+		if err := primeModuleCache(modDir, inPlan); err != nil {
+			return err
+		}
+	}
+
+	// 5. Iterate seed-and-tidy to fixpoint. Each iteration zips
 	//    every in-plan module's working tree, seeds the cache with
 	//    the resulting hashes, and runs offline tidy in each
 	//    affected sub-module. If any sub-module's go.sum was

--- a/internal/release/gosum.go
+++ b/internal/release/gosum.go
@@ -27,9 +27,12 @@ import (
 //   - opts.PreState != nil (pre-release mode; applyPrerelease
 //     doesn't rewrite go.mod, so go.sum can't drift).
 //
-// Called from applyStable AFTER rewriteSubmoduleGoMods and BEFORE
-// the consumed-changesets deletion so all the file changes land in
-// the same release commit.
+// Called from applyStable AFTER rewriteSubmoduleGoMods AND AFTER
+// the consumed-changesets deletion. The deletion is upstream of the
+// seed step so the working tree already has its final commit shape;
+// otherwise the seed's hash wouldn't match what `git archive` of
+// the published tag produces. See
+// docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md.
 func tidySubmoduleGoSums(opts Options) error {
 	if opts.PreState != nil {
 		return nil

--- a/internal/release/gosum.go
+++ b/internal/release/gosum.go
@@ -65,8 +65,8 @@ func tidySubmoduleGoSums(opts Options) error {
 	}
 
 	// 4. Seed the cache with in-plan releases.
-	cleanup, err := seedModuleCache(opts)
-	defer cleanup()
+	seeded, err := seedModuleCache(opts)
+	defer clearSeededEntries(seeded)
 	if err != nil {
 		return err
 	}

--- a/internal/release/gosum.go
+++ b/internal/release/gosum.go
@@ -117,6 +117,12 @@ func tidySubmoduleGoSums(opts Options) error {
 			}
 		}
 
+		if tidyHook != nil {
+			if err := tidyHook(i); err != nil {
+				return err
+			}
+		}
+
 		after, err := readGoSums(opts.RepoDir, affected)
 		if err != nil {
 			return err
@@ -354,3 +360,9 @@ func (e *errFixpointNotReached) Error() string {
 	}
 	return b.String()
 }
+
+// tidyHook is a per-iteration test hook used by the fixpoint loop
+// to inject non-determinism (or any other behavior) for testing
+// errFixpointNotReached. Production code never sets it; the only
+// caller is the gosum_test.go suite. nil means "no-op."
+var tidyHook func(iteration int) error

--- a/internal/release/gosum_test.go
+++ b/internal/release/gosum_test.go
@@ -683,3 +683,93 @@ func TestTidySubmoduleGoSums_FixpointNotReached_SurfacesDiagnosticError(t *testi
 		t.Errorf("error message missing diff payload: %q", msg)
 	}
 }
+
+// TestTidySubmoduleGoSums_PrimesThirdPartyDeps_FromColdCache pins
+// the regression for the fresh-CI-runner case. An affected
+// sub-module requires a third-party module not in monorel.toml's
+// managed set. With a fresh GOMODCACHE (default for
+// setupSubmoduleFixture), offline tidy with GOPROXY=off would fail
+// without the prime-cache step. With it, tidy succeeds because the
+// cache is populated before tidy runs.
+func TestTidySubmoduleGoSums_PrimesThirdPartyDeps_FromColdCache(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("`go` not on PATH: %v", err)
+	}
+	if testing.Short() {
+		t.Skip("network-bound: requires GOPROXY reachability for go mod download")
+	}
+
+	repoDir := t.TempDir()
+	tmpModCache := t.TempDir()
+	t.Cleanup(func() {
+		filepath.WalkDir(tmpModCache, func(path string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			os.Chmod(path, 0o755)
+			return nil
+		})
+	})
+	t.Setenv("GOMODCACHE", tmpModCache)
+
+	// a/ requires example.com/b (in-plan, will be seeded) AND
+	// gopkg.in/yaml.v3 (third-party). Without primeModuleCache,
+	// tidy under GOPROXY=off would fail on yaml.v3 since it's not
+	// in the fresh GOMODCACHE.
+	mustWriteFile(t, filepath.Join(repoDir, "a/go.mod"),
+		"module example.com/a\n\ngo 1.26\n\nrequire (\n\texample.com/b v0.1.0\n\tgopkg.in/yaml.v3 v3.0.1\n)\n")
+	mustWriteFile(t, filepath.Join(repoDir, "a/a.go"),
+		"package a\n\nimport (\n\t\"example.com/b\"\n\t_ \"gopkg.in/yaml.v3\"\n)\n\nfunc Greet() string { return b.Hello() }\n")
+	// Pre-populate a's go.sum with the yaml.v3 hashes (including its
+	// transitive dep check.v1's go.mod hash) so tidy can verify all
+	// entries without reaching the network during the offline tidy
+	// pass. Hashes are the public proxy hashes for these versions.
+	mustWriteFile(t, filepath.Join(repoDir, "a/go.sum"),
+		"gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=\n"+
+			"gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=\n"+
+			"gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=\n")
+
+	mustWriteFile(t, filepath.Join(repoDir, "b/go.mod"),
+		"module example.com/b\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(repoDir, "b/b.go"),
+		"package b\n\nfunc Hello() string { return \"hi\" }\n")
+
+	repo := git.NewFake()
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"a": {TagPrefix: "a", Path: "a"},
+			"b": {TagPrefix: "b", Path: "b"},
+		},
+	}
+	rp := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{
+			{Config: cfg.Packages["a"], Tag: "a/v0.1.0", Bump: semver.Minor},
+			{Config: cfg.Packages["b"], Tag: "b/v0.1.0", Bump: semver.Minor},
+		},
+	}
+
+	opts := Options{
+		Plan:         rp,
+		Config:       cfg,
+		Repo:         repo,
+		RepoDir:      repoDir,
+		ChangesetDir: filepath.Join(repoDir, ".changeset"),
+		Today:        "2026-05-03",
+	}
+
+	if err := tidySubmoduleGoSums(opts); err != nil {
+		t.Fatalf("tidySubmoduleGoSums: %v", err)
+	}
+
+	// Sanity: a/go.sum now has both example.com/b and yaml.v3 entries.
+	aGoSum, err := os.ReadFile(filepath.Join(repoDir, "a", "go.sum"))
+	if err != nil {
+		t.Fatalf("read a/go.sum: %v", err)
+	}
+	if !bytes.Contains(aGoSum, []byte("example.com/b v0.1.0")) {
+		t.Errorf("a/go.sum: missing example.com/b v0.1.0:\n%s", aGoSum)
+	}
+	if !bytes.Contains(aGoSum, []byte("gopkg.in/yaml.v3 v3.0.1")) {
+		t.Errorf("a/go.sum: missing gopkg.in/yaml.v3 v3.0.1:\n%s", aGoSum)
+	}
+}

--- a/internal/release/gosum_test.go
+++ b/internal/release/gosum_test.go
@@ -1,12 +1,17 @@
 package release
 
 import (
+	"bytes"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/sumdb/dirhash"
+	xzip "golang.org/x/mod/zip"
 
 	"monorel.disaresta.com/changeset"
 	"monorel.disaresta.com/config"
@@ -337,4 +342,159 @@ func TestTidy_OutOfPlanCacheMissingFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "go mod download") {
 		t.Errorf("error should hint at go mod download; got: %v", err)
 	}
+}
+
+// TestApply_RootChangesetDeletion_HashesMatchPublished pins the
+// regression for the loglayer-go v2.1.0 incident. The chore(release)
+// commit deletes consumed `.changeset/*.md` files. Those files live
+// inside the root module's source tree, so the root module's zip
+// hash differs between (a) the working tree at seed time (with the
+// changesets present) and (b) the chore(release) commit (without
+// them). Before the fix in Task 2, the affected sub-module's go.sum
+// would record (a)'s hash, which doesn't match what `git archive`
+// of the published tag produces.
+//
+// This test runs the full Apply pipeline and asserts that the
+// `h1:` for the in-plan root recorded in the affected sub-module's
+// go.sum equals the hash of `git archive` against the chore(release)
+// commit.
+func TestApply_RootChangesetDeletion_HashesMatchPublished(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("`go` not on PATH: %v", err)
+	}
+
+	repoDir := t.TempDir()
+	tmpModCache := t.TempDir()
+	t.Cleanup(func() {
+		filepath.WalkDir(tmpModCache, func(path string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			os.Chmod(path, 0o755)
+			return nil
+		})
+	})
+	t.Setenv("GOMODCACHE", tmpModCache)
+
+	// Layout:
+	//   <repoDir>/
+	//     go.mod              (module example.com/root, go 1.26)
+	//     root.go
+	//     .changeset/foo.md   (will be consumed by the plan)
+	//     sub/go.mod          (requires example.com/root)
+	//     sub/sub.go
+	mustWriteFile(t, filepath.Join(repoDir, "go.mod"),
+		"module example.com/root\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(repoDir, "root.go"),
+		"package root\n\nfunc Hello() string { return \"hi\" }\n")
+	mustWriteFile(t, filepath.Join(repoDir, ".changeset", "foo.md"),
+		"---\n\"root\": minor\n---\n\nbump\n")
+	mustWriteFile(t, filepath.Join(repoDir, "sub", "go.mod"),
+		"module example.com/sub\n\ngo 1.26\n\nrequire example.com/root v0.1.0\n")
+	mustWriteFile(t, filepath.Join(repoDir, "sub", "sub.go"),
+		"package sub\n\nimport \"example.com/root\"\n\nfunc Greet() string { return root.Hello() }\n")
+
+	repo := git.NewFake()
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"root": {TagPrefix: "", Path: "."},
+			"sub":  {TagPrefix: "sub", Path: "sub"},
+		},
+	}
+	rp := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{
+			{Config: cfg.Packages["root"], Tag: "v0.1.0", Bump: semver.Minor},
+			{Config: cfg.Packages["sub"], Tag: "sub/v0.1.0", Bump: semver.Minor},
+		},
+		Consumed: []*changeset.Changeset{{Name: "foo"}},
+	}
+
+	opts := Options{
+		Plan:         rp,
+		Config:       cfg,
+		Repo:         repo,
+		RepoDir:      repoDir,
+		ChangesetDir: filepath.Join(repoDir, ".changeset"),
+		Today:        "2026-05-03",
+	}
+
+	if _, err := Apply(opts); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Read back the recorded hash for example.com/root in sub/go.sum.
+	subGoSum, err := os.ReadFile(filepath.Join(repoDir, "sub", "go.sum"))
+	if err != nil {
+		t.Fatalf("read sub/go.sum: %v", err)
+	}
+	recordedH1 := extractH1(t, subGoSum, "example.com/root v0.1.0")
+	if recordedH1 == "" {
+		t.Fatalf("sub/go.sum: missing h1: line for example.com/root v0.1.0\n%s", subGoSum)
+	}
+
+	// Compute what `git archive`'s hash would be against the working
+	// tree as of the chore(release) commit. Apply staged the deletion
+	// of .changeset/foo.md into the FakeRepo, so on disk it's still
+	// there. For the test to compare against the post-deletion shape,
+	// remove the file from the working tree manually here. (FakeRepo
+	// stages but doesn't commit; this is the test's stand-in for the
+	// real commit.)
+	if err := os.Remove(filepath.Join(repoDir, ".changeset", "foo.md")); err != nil {
+		t.Fatalf("remove staged-deleted changeset: %v", err)
+	}
+
+	expectedH1, err := dirhashOfRoot(repoDir)
+	if err != nil {
+		t.Fatalf("compute expected hash: %v", err)
+	}
+	if recordedH1 != expectedH1 {
+		t.Errorf("sub/go.sum recorded wrong h1: for example.com/root v0.1.0\n  recorded: %s\n  expected: %s",
+			recordedH1, expectedH1)
+	}
+}
+
+// extractH1 pulls the `h1:HASH=` value for the given "<module> <version>"
+// prefix from a go.sum file's bytes. Returns the empty string if the
+// line is absent.
+func extractH1(t *testing.T, goSum []byte, prefix string) string {
+	t.Helper()
+	want := []byte(prefix + " ")
+	for _, line := range bytes.Split(goSum, []byte("\n")) {
+		if !bytes.HasPrefix(line, want) {
+			continue
+		}
+		// Skip the /go.mod sub-hash; we want the full-zip hash.
+		if bytes.Contains(line, []byte("/go.mod ")) {
+			continue
+		}
+		// line looks like: example.com/root v0.1.0 h1:HASH=
+		parts := bytes.Fields(line)
+		if len(parts) < 3 {
+			continue
+		}
+		return string(parts[2])
+	}
+	return ""
+}
+
+// dirhashOfRoot computes Hash1 of the root module zip built from
+// repoDir, matching what `git archive` would produce for a published
+// version pointing at the working tree's current state. Used to
+// verify that monorel's recorded hash matches what consumers will
+// fetch.
+func dirhashOfRoot(repoDir string) (string, error) {
+	mv := module.Version{Path: "example.com/root", Version: "v0.1.0"}
+	tmpZip, err := os.CreateTemp("", "monorel-test-zip-*.zip")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpZip.Name())
+	defer tmpZip.Close()
+	if err := xzip.CreateFromDir(tmpZip, mv, repoDir); err != nil {
+		return "", err
+	}
+	if err := tmpZip.Close(); err != nil {
+		return "", err
+	}
+	return dirhash.HashZip(tmpZip.Name(), dirhash.Hash1)
 }

--- a/internal/release/gosum_test.go
+++ b/internal/release/gosum_test.go
@@ -2,6 +2,8 @@ package release
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -629,4 +631,55 @@ func dirhashOfModule(repoDir, sub, importPath, version string) (string, error) {
 		return "", err
 	}
 	return dirhash.HashZip(tmpZip.Name(), dirhash.Hash1)
+}
+
+// TestTidySubmoduleGoSums_FixpointNotReached_SurfacesDiagnosticError
+// pins the diagnostic path. Inject a hook that mutates an affected
+// sub-module's go.sum on every iteration so the loop never
+// converges; assert it returns errFixpointNotReached after
+// maxTidyIterations and the message includes the per-iteration
+// diff payload.
+func TestTidySubmoduleGoSums_FixpointNotReached_SurfacesDiagnosticError(t *testing.T) {
+	opts, _ := setupSubmoduleFixture(t, true /* aRequiresB */)
+
+	// Inject non-determinism: append a unique line to a/go.sum
+	// after each tidy iteration. The next iteration's "before"
+	// snapshot will see the appended line; tidy may or may not
+	// remove it (depending on whether it parses as a valid sum
+	// line); either way, before != after, so the loop never
+	// converges.
+	originalHook := tidyHook
+	t.Cleanup(func() { tidyHook = originalHook })
+	tidyHook = func(iteration int) error {
+		path := filepath.Join(opts.RepoDir, "a", "go.sum")
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = fmt.Fprintf(f, "# fixpoint-test marker iteration=%d\n", iteration)
+		return err
+	}
+
+	err := tidySubmoduleGoSums(opts)
+	if err == nil {
+		t.Fatal("tidySubmoduleGoSums: want errFixpointNotReached, got nil")
+	}
+	var fpErr *errFixpointNotReached
+	if !errors.As(err, &fpErr) {
+		t.Fatalf("tidySubmoduleGoSums: want *errFixpointNotReached, got %T: %v", err, err)
+	}
+	if fpErr.iterations != 10 {
+		t.Errorf("iterations: got %d, want 10", fpErr.iterations)
+	}
+	msg := fpErr.Error()
+	if !strings.Contains(msg, "did not converge after 10 iterations") {
+		t.Errorf("error message missing convergence header: %q", msg)
+	}
+	if !strings.Contains(msg, "monorel/issues") {
+		t.Errorf("error message missing issue-filing hint: %q", msg)
+	}
+	if !strings.Contains(msg, "BEFORE:") || !strings.Contains(msg, "AFTER:") {
+		t.Errorf("error message missing diff payload: %q", msg)
+	}
 }

--- a/internal/release/gosum_test.go
+++ b/internal/release/gosum_test.go
@@ -497,3 +497,136 @@ func dirhashOfRoot(repoDir string) (string, error) {
 	}
 	return dirhash.HashZip(tmpZip.Name(), dirhash.Hash1)
 }
+
+// TestApply_CrossSiblingCascade_HashesConvergeToPublished pins the
+// regression for the cross-sibling cascade variant of the wrong-h1:
+// bug. Three in-plan modules A, B, C: A is the root; B requires A
+// and is required by C; C requires both A and B. Single-pass
+// seed-and-tidy would record B's pre-tidy hash in C's go.sum, since
+// B's own tidy modifies B's go.sum after C's tidy ran against the
+// seeded (pre-modification) hash.
+//
+// The fixpoint loop converges: every recorded h1: equals the hash
+// of `git archive` against the published commit.
+func TestApply_CrossSiblingCascade_HashesConvergeToPublished(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("`go` not on PATH: %v", err)
+	}
+
+	repoDir := t.TempDir()
+	tmpModCache := t.TempDir()
+	t.Cleanup(func() {
+		filepath.WalkDir(tmpModCache, func(path string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			os.Chmod(path, 0o755)
+			return nil
+		})
+	})
+	t.Setenv("GOMODCACHE", tmpModCache)
+
+	// Modules:
+	//   a/  (example.com/a, no deps)
+	//   b/  (example.com/b, requires a)
+	//   c/  (example.com/c, requires a AND b)
+	mustWriteFile(t, filepath.Join(repoDir, "a/go.mod"),
+		"module example.com/a\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(repoDir, "a/a.go"),
+		"package a\n\nfunc Hello() string { return \"a\" }\n")
+
+	mustWriteFile(t, filepath.Join(repoDir, "b/go.mod"),
+		"module example.com/b\n\ngo 1.26\n\nrequire example.com/a v0.1.0\n")
+	mustWriteFile(t, filepath.Join(repoDir, "b/b.go"),
+		"package b\n\nimport \"example.com/a\"\n\nfunc Hello() string { return a.Hello() + \"-b\" }\n")
+
+	mustWriteFile(t, filepath.Join(repoDir, "c/go.mod"),
+		"module example.com/c\n\ngo 1.26\n\nrequire (\n\texample.com/a v0.1.0\n\texample.com/b v0.1.0\n)\n")
+	mustWriteFile(t, filepath.Join(repoDir, "c/c.go"),
+		"package c\n\nimport (\n\t\"example.com/a\"\n\t\"example.com/b\"\n)\n\nfunc Hello() string { return a.Hello() + \"-\" + b.Hello() }\n")
+
+	repo := git.NewFake()
+	cfg := &config.Config{
+		Packages: map[string]config.PackageConfig{
+			"a": {TagPrefix: "a", Path: "a"},
+			"b": {TagPrefix: "b", Path: "b"},
+			"c": {TagPrefix: "c", Path: "c"},
+		},
+	}
+	rp := &plan.ReleasePlan{
+		Releases: []plan.PackageRelease{
+			{Config: cfg.Packages["a"], Tag: "a/v0.1.0", Bump: semver.Minor},
+			{Config: cfg.Packages["b"], Tag: "b/v0.1.0", Bump: semver.Minor},
+			{Config: cfg.Packages["c"], Tag: "c/v0.1.0", Bump: semver.Minor},
+		},
+	}
+
+	opts := Options{
+		Plan:         rp,
+		Config:       cfg,
+		Repo:         repo,
+		RepoDir:      repoDir,
+		ChangesetDir: filepath.Join(repoDir, ".changeset"),
+		Today:        "2026-05-03",
+	}
+
+	if _, err := Apply(opts); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Compute expected hashes after Apply has staged everything
+	// (including b's go.sum mutations and c's go.sum mutations).
+	// `dirhash` over each module's directory matches what
+	// `git archive` of the eventual tag will produce.
+	expectedA, err := dirhashOfModule(repoDir, "a", "example.com/a", "v0.1.0")
+	if err != nil {
+		t.Fatalf("hash a: %v", err)
+	}
+	expectedB, err := dirhashOfModule(repoDir, "b", "example.com/b", "v0.1.0")
+	if err != nil {
+		t.Fatalf("hash b: %v", err)
+	}
+
+	// c/go.sum should record A's actual hash AND B's actual hash.
+	cGoSum, err := os.ReadFile(filepath.Join(repoDir, "c", "go.sum"))
+	if err != nil {
+		t.Fatalf("read c/go.sum: %v", err)
+	}
+	if got := extractH1(t, cGoSum, "example.com/a v0.1.0"); got != expectedA {
+		t.Errorf("c/go.sum recorded wrong h1: for example.com/a v0.1.0\n  got:  %s\n  want: %s\n  full go.sum:\n%s",
+			got, expectedA, cGoSum)
+	}
+	if got := extractH1(t, cGoSum, "example.com/b v0.1.0"); got != expectedB {
+		t.Errorf("c/go.sum recorded wrong h1: for example.com/b v0.1.0\n  got:  %s\n  want: %s\n  full go.sum:\n%s",
+			got, expectedB, cGoSum)
+	}
+
+	// b/go.sum should record A's actual hash.
+	bGoSum, err := os.ReadFile(filepath.Join(repoDir, "b", "go.sum"))
+	if err != nil {
+		t.Fatalf("read b/go.sum: %v", err)
+	}
+	if got := extractH1(t, bGoSum, "example.com/a v0.1.0"); got != expectedA {
+		t.Errorf("b/go.sum recorded wrong h1: for example.com/a v0.1.0\n  got:  %s\n  want: %s",
+			got, expectedA)
+	}
+}
+
+// dirhashOfModule computes Hash1 of a sub-module's zip built from
+// repoDir/sub. Like dirhashOfRoot but for an arbitrary sub-module.
+func dirhashOfModule(repoDir, sub, importPath, version string) (string, error) {
+	mv := module.Version{Path: importPath, Version: version}
+	tmpZip, err := os.CreateTemp("", "monorel-test-zip-*.zip")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(tmpZip.Name())
+	defer tmpZip.Close()
+	if err := xzip.CreateFromDir(tmpZip, mv, filepath.Join(repoDir, sub)); err != nil {
+		return "", err
+	}
+	if err := tmpZip.Close(); err != nil {
+		return "", err
+	}
+	return dirhash.HashZip(tmpZip.Name(), dirhash.Hash1)
+}

--- a/internal/release/gosum_test.go
+++ b/internal/release/gosum_test.go
@@ -395,6 +395,7 @@ func TestApply_RootChangesetDeletion_HashesMatchPublished(t *testing.T) {
 		"package sub\n\nimport \"example.com/root\"\n\nfunc Greet() string { return root.Hello() }\n")
 
 	repo := git.NewFake()
+	repo.Dir = repoDir
 	cfg := &config.Config{
 		Packages: map[string]config.PackageConfig{
 			"root": {TagPrefix: "", Path: "."},
@@ -434,12 +435,10 @@ func TestApply_RootChangesetDeletion_HashesMatchPublished(t *testing.T) {
 
 	// Compute what `git archive`'s hash would be against the working
 	// tree as of the chore(release) commit. Apply staged the deletion
-	// of .changeset/foo.md into the FakeRepo, so on disk it's still
-	// there. For the test to compare against the post-deletion shape,
-	// remove the file from the working tree manually here. (FakeRepo
-	// stages but doesn't commit; this is the test's stand-in for the
-	// real commit.)
-	if err := os.Remove(filepath.Join(repoDir, ".changeset", "foo.md")); err != nil {
+	// of .changeset/foo.md via Repo.Remove (which, with repo.Dir set,
+	// physically removes the file). If the file is already gone (the
+	// fixed path: deletion runs before tidy), this is a no-op.
+	if err := os.Remove(filepath.Join(repoDir, ".changeset", "foo.md")); err != nil && !os.IsNotExist(err) {
 		t.Fatalf("remove staged-deleted changeset: %v", err)
 	}
 

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -407,8 +407,13 @@ func configFromPlan(p *plan.ReleasePlan) *config.Config {
 }
 
 // applyStable writes CHANGELOG entries, rewrites go.mod files for
-// the released sub-modules, deletes consumed changesets, and stages
-// everything. Caller does the commit.
+// the released sub-modules, deletes consumed changesets, then runs
+// offline tidy in every affected sub-module, and stages everything.
+// The deletion happens before tidy so the seed step inside tidy
+// hashes the working tree in its final commit shape (not a
+// transient state with changesets still present); see
+// docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md.
+// Caller does the commit.
 func applyStable(opts Options, today string) error {
 	for _, r := range opts.Plan.Releases {
 		entry := buildEntry(r, today)
@@ -434,21 +439,25 @@ func applyStable(opts Options, today string) error {
 		return err
 	}
 
+	// Delete the consumed changesets BEFORE seeding/tidy. The
+	// `.changeset/*.md` files live inside the root module's source
+	// tree; running tidy's seed step against a working tree that
+	// still has them produces a hash that doesn't match the
+	// chore(release) commit's hash (which lands without them). See
+	// docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md.
+	for _, cs := range opts.Plan.Consumed {
+		rel := filepath.Join(".changeset", cs.Name+".md")
+		if err := opts.Repo.Remove(rel); err != nil {
+			return fmt.Errorf("release: remove %s: %w", rel, err)
+		}
+	}
+
 	// Run `go mod tidy` (offline, against a seeded local cache) in
 	// every released sub-module that requires an in-plan sibling, so
 	// the release commit's go.sum entries match what consumers will
 	// hash from the proxy after the tag pushes.
 	if err := tidySubmoduleGoSums(opts); err != nil {
 		return err
-	}
-
-	// Delete the consumed changesets. The planner's Consumed list
-	// dedupes multi-package changesets, so we hit each file once.
-	for _, cs := range opts.Plan.Consumed {
-		rel := filepath.Join(".changeset", cs.Name+".md")
-		if err := opts.Repo.Remove(rel); err != nil {
-			return fmt.Errorf("release: remove %s: %w", rel, err)
-		}
 	}
 	return nil
 }

--- a/internal/release/tidy.go
+++ b/internal/release/tidy.go
@@ -79,3 +79,69 @@ func offlineTidyEnv() []string {
 	)
 	return env
 }
+
+// primeModuleCache populates the local module cache with the
+// third-party deps modDir's go.mod transitively requires. Subsequent
+// offline tidy with GOPROXY=off can resolve those deps from the
+// cache without reaching out to the network.
+//
+// Uses the inherited GOPROXY (typically https://proxy.golang.org,direct)
+// and GOSUMDB so go.sum hashes are verified during download. Does
+// NOT mutate go.sum: `go mod download` reads go.sum, downloads the
+// listed modules, and writes nothing. The download is bounded by the
+// existing entries in go.sum: any module not already pinned wouldn't
+// be downloaded (tidy adds pins later, after the in-plan siblings
+// are seeded).
+//
+// PATH, HOME, USER, TMPDIR, LANG, LC_*, GOMODCACHE, GOCACHE, GOPROXY,
+// GOSUMDB pass through.
+func primeModuleCache(modDir string) error {
+	cmd := exec.Command("go", "mod", "download")
+	cmd.Dir = modDir
+	cmd.Env = primeCacheEnv()
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("prime module cache in %s: %w\n%s\n\n"+
+			"Hint: this typically means GOPROXY isn't reachable from this environment. "+
+			"Confirm `GOPROXY` is a real proxy URL (e.g. https://proxy.golang.org,direct), "+
+			"or set `GOPROXY=direct` to fetch straight from the source repo",
+			modDir, err, out)
+	}
+	return nil
+}
+
+// primeCacheEnv builds the env slice for the prime-cache subprocess.
+// Mirrors offlineTidyEnv's "scratch env, no caller GOFLAGS leak"
+// shape, but inherits GOPROXY and GOSUMDB so download can fetch from
+// the network.
+func primeCacheEnv() []string {
+	inherit := []string{
+		"PATH",
+		"HOME",
+		"USER",
+		"TMPDIR",
+		"LANG",
+		"GOMODCACHE",
+		"GOCACHE",
+		"GOPROXY",
+		"GOSUMDB",
+	}
+	env := make([]string, 0, len(inherit)+8)
+	for _, k := range inherit {
+		if v, ok := os.LookupEnv(k); ok {
+			env = append(env, k+"="+v)
+		}
+	}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "LC_") {
+			env = append(env, e)
+		}
+	}
+	env = append(env,
+		"GOWORK=off",
+		"GOFLAGS=",
+		"GOTOOLCHAIN=local",
+	)
+	return env
+}

--- a/internal/release/tidy.go
+++ b/internal/release/tidy.go
@@ -97,7 +97,9 @@ func offlineTidyEnv() []string {
 // inPlan is the set of module import paths being released in the
 // current plan. Entries in go.sum whose module path matches a key
 // in inPlan are skipped: those modules will be seeded by the caller's
-// seedModuleCache step, not fetched from the proxy.
+// seedModuleCache step, not fetched from the proxy. Both full-zip
+// entries and /go.mod-only entries are processed; /go.mod-only entries
+// represent modules needed for graph resolution but not imported.
 //
 // If no go.sum exists in modDir, the function returns without running
 // the download command. A missing go.sum means tidy hasn't yet
@@ -116,8 +118,11 @@ func primeModuleCache(modDir string, inPlan map[string]string) error {
 	}
 
 	// Collect module@version pairs from go.sum, excluding in-plan
-	// modules (which will be seeded by the caller) and /go.mod entries
-	// (the per-module download fetches the .mod file automatically).
+	// modules (which will be seeded by the caller).
+	// /go.mod-only entries (modules pruned from the build list but
+	// needed for graph resolution) are included: strip the /go.mod
+	// suffix to get the bare version, then deduplicate against any
+	// full-zip entry for the same module@version.
 	var targets []string
 	seen := make(map[string]bool)
 	for _, line := range strings.Split(string(goSumBytes), "\n") {
@@ -131,10 +136,11 @@ func primeModuleCache(modDir string, inPlan map[string]string) error {
 		}
 		modPath := parts[0]
 		modVer := parts[1]
-		// Skip /go.mod entries; `go mod download mod@ver` fetches both.
-		if strings.HasSuffix(modVer, "/go.mod") {
-			continue
-		}
+		// Strip /go.mod suffix to get the bare version used as the
+		// download target. Deduplication via `seen` ensures we don't
+		// enqueue a module twice when both the /go.mod and full-zip
+		// entries are present.
+		modVer = strings.TrimSuffix(modVer, "/go.mod")
 		// Skip in-plan modules; seedModuleCache handles those.
 		if _, ok := inPlan[modPath]; ok {
 			continue

--- a/internal/release/tidy.go
+++ b/internal/release/tidy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -93,10 +94,64 @@ func offlineTidyEnv() []string {
 // be downloaded (tidy adds pins later, after the in-plan siblings
 // are seeded).
 //
+// inPlan is the set of module import paths being released in the
+// current plan. Entries in go.sum whose module path matches a key
+// in inPlan are skipped: those modules will be seeded by the caller's
+// seedModuleCache step, not fetched from the proxy.
+//
+// If no go.sum exists in modDir, the function returns without running
+// the download command. A missing go.sum means tidy hasn't yet
+// recorded any third-party hashes, so there is nothing to pre-fill.
+//
 // PATH, HOME, USER, TMPDIR, LANG, LC_*, GOMODCACHE, GOCACHE, GOPROXY,
 // GOSUMDB pass through.
-func primeModuleCache(modDir string) error {
-	cmd := exec.Command("go", "mod", "download")
+func primeModuleCache(modDir string, inPlan map[string]string) error {
+	goSumPath := filepath.Join(modDir, "go.sum")
+	goSumBytes, err := os.ReadFile(goSumPath)
+	if os.IsNotExist(err) {
+		// Nothing pinned yet; no third-party deps to pre-fill.
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("prime module cache: read %s: %w", goSumPath, err)
+	}
+
+	// Collect module@version pairs from go.sum, excluding in-plan
+	// modules (which will be seeded by the caller) and /go.mod entries
+	// (the per-module download fetches the .mod file automatically).
+	var targets []string
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(string(goSumBytes), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		modPath := parts[0]
+		modVer := parts[1]
+		// Skip /go.mod entries; `go mod download mod@ver` fetches both.
+		if strings.HasSuffix(modVer, "/go.mod") {
+			continue
+		}
+		// Skip in-plan modules; seedModuleCache handles those.
+		if _, ok := inPlan[modPath]; ok {
+			continue
+		}
+		key := modPath + "@" + modVer
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		targets = append(targets, key)
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	args := append([]string{"mod", "download"}, targets...)
+	cmd := exec.Command("go", args...)
 	cmd.Dir = modDir
 	cmd.Env = primeCacheEnv()
 


### PR DESCRIPTION
Closes #54.

## Summary

Four-concern fix package surfaced by [`loglayer/loglayer-go`'s v2.1.0 release incident](https://github.com/loglayer/loglayer-go/pull/76):

1. **Critical**: `release/cacheseed` writes the correct `h1:` hash for in-plan modules. Reorders `applyStable` so consumed-changeset deletion happens before the seed step (the canonical `.changeset/*.md`-deletion variant), and replaces the single-pass seed-and-tidy with iterate-to-fixpoint to handle cross-sibling dep chains. Without this fix, every monorel-driven release silently produced broken `go.sum` entries; downstream consumers hit `SECURITY ERROR: checksum mismatch` on cold-cache installs.
2. **Cache priming**: new `primeModuleCache` step before offline tidy. Fresh CI runners (empty `GOMODCACHE`) couldn't resolve third-party deps under `GOPROXY=off`. The new step runs `go mod download module@version,...` (with the inherited `GOPROXY`) for every third-party dep parsed from the affected sub-modules' `go.sum`. The `GOPROXY=off`-during-tidy invariant is preserved.
3. **Toolchain docs**: inline comments above `actions/setup-go@v5` in `ci/github/README.md`'s example workflows explain the `GOTOOLCHAIN=local` rationale. Strengthened "Requirements" → "go on PATH" bullet calls out the failure mode. New CI-agnostic "## CI environment requirements" section in `docs/src/workflows.md` covers GitHub / GitLab / Gitea / generic CI.
4. **chore(release) race recipe**: new "## Recipes" section in `ci/github/README.md` with the GitHub Actions skip-filter snippet. Universal "## Avoiding the chore(release) CI race" section in `docs/src/workflows.md` shows the pattern for GitHub / GitLab / Gitea / generic.

## Spec, plan, regression tests

- Spec: [`docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md`](./docs/superpowers/specs/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes-design.md)
- Plan: [`docs/superpowers/plans/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes.md`](./docs/superpowers/plans/2026-05-03-cacheseed-fixpoint-and-release-pipeline-fixes.md)
- Four new regression tests in `internal/release/gosum_test.go`:
  - `TestApply_RootChangesetDeletion_HashesMatchPublished` (canonical changeset-deletion variant)
  - `TestApply_CrossSiblingCascade_HashesConvergeToPublished` (cross-sibling cascade variant)
  - `TestTidySubmoduleGoSums_FixpointNotReached_SurfacesDiagnosticError` (diagnostic path)
  - `TestTidySubmoduleGoSums_PrimesThirdPartyDeps_FromColdCache` (cold-cache priming)

## Notable adaptations from plan to implementation

- **`internal/git/fake.go` got an opt-in `Dir` field** so `Fake.Remove` can physically delete files. Existing tests not setting `Dir` are unaffected. Required because the regression test's bug needs `Repo.Remove` to actually delete the changeset from disk.
- **Fixpoint loop deletes each affected sub-module's `go.sum` before every tidy pass.** When tidy mutates an in-plan sibling's own go.sum, the sibling's zip hash changes; iteration 2's re-seed produces a different hash, and tidy under `GOPROXY=off` raises a SECURITY ERROR on the now-mismatched recorded hash. Deleting first lets tidy regenerate from scratch against the fresh seed. Convergence test confirms the loop reaches fixpoint in 2 iterations for the cascade case.
- **`primeModuleCache(modDir, inPlan)` filters in-plan modules out** of the download targets so fake `example.com/*` paths in test fixtures don't 404 from the proxy. Includes `/go.mod`-only entries for transitive deps (e.g., `gopkg.in/check.v1` from `yaml.v3`).
- **`docs/.vitepress/config.ts`** got a targeted `ignoreDeadLinks: [/ci\/github\/README/]` regex because the cross-link from `docs/src/workflows.md` to `ci/github/README.md` is outside `docs/src/` and VitePress can't resolve it at build time. Resolves correctly when read on GitHub.
- **`CHANGELOG.md` not manually edited** (the plan's Task 13). The file's own header documents that monorel maintains it from changesets; manual edits would conflict with the next release run. The changeset (Task 14) carries the body that monorel will roll into the v0.14.0 entry.

## Test plan

- [x] `go test ./...` passes (existing + 4 new regression tests, all green)
- [x] `go vet ./...` clean
- [x] `cd docs && bun run docs:build` clean
- [x] `monorel preview` validates the changeset (renders v0.13.0 → v0.14.0)
- [x] Two-stage final code review (spec compliance + opus quality review) passed with no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)