### PR TITLE
docs: propagate Bitbucket and trailers fallback through stale claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The GitHub flow looks like this:
 - uses: actions/setup-go@v5
   with:
     go-version-file: go.mod
-- uses: disaresta-org/monorel/ci/github@v0.12.0
+- uses: disaresta-org/monorel/ci/github@v0.14.0
   with:
     command: pr      # or 'release' for the post-merge tag + push + publish step
 ```

--- a/docs/src/_partials/gitea-doctor-yml.md
+++ b/docs/src/_partials/gitea-doctor-yml.md
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with: { fetch-depth: 0 }
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: doctor
 ```

--- a/docs/src/_partials/gitea-release-pr-yml.md
+++ b/docs/src/_partials/gitea-release-pr-yml.md
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: pr
         env:

--- a/docs/src/_partials/gitea-release-yml.md
+++ b/docs/src/_partials/gitea-release-yml.md
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: release
         env:

--- a/docs/src/_partials/github-doctor-yml.md
+++ b/docs/src/_partials/github-doctor-yml.md
@@ -18,7 +18,7 @@ jobs:
           # (fetch-depth: 1) would miss them and turn doctor into a
           # no-op.
           fetch-depth: 0
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: doctor
 ```

--- a/docs/src/_partials/github-release-pr-yml.md
+++ b/docs/src/_partials/github-release-pr-yml.md
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: pr
 ```

--- a/docs/src/_partials/github-release-yml.md
+++ b/docs/src/_partials/github-release-yml.md
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: release
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -80,7 +80,7 @@ Side-effect-bearing packages should never be public commitments — every refact
 
 From v0.2.0 forward, the public packages follow the same SemVer rules as the rest of monorel: additive changes (new types, new functions, new fields on existing types) are minor bumps; breaking changes (renames, removals, signature changes, field type changes) are major bumps.
 
-Pre-1.0 caveat: v0.x is still soft-locked. Breaking changes between v0.minor releases are possible if a design issue surfaces, but they will be called out in `CHANGELOG.md` and `whats-new.md` with a migration path.
+Pre-1.0 caveat: v0.x is still soft-locked. Breaking changes between v0.minor releases are possible if a design issue surfaces, but they will be called out in `CHANGELOG.md` with a migration path.
 
 ## Quick example
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -382,4 +382,4 @@ The same logic is exposed as a Go library at [`monorel.disaresta.com/doctor`](/a
 ## Exit codes
 
 - `0`: success.
-- non-zero: an error occurred. The CLI prints the error to stderr; commands that do partial work (e.g. `release --publish` failing on the second provider release) print a "created N/M" line before the error.
+- non-zero: an error occurred. The CLI prints the error to stderr; commands that do partial work (e.g. `monorel publish` failing on the second provider release) print a "created N/M" line before the error.

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -30,7 +30,7 @@ Identifies the version-control host that owns the repo. monorel is host-agnostic
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `name` | string | `"github"` | Provider implementation. Supported: `"github"`, `"gitea"` (also covers Forgejo via API compatibility), `"gitlab"`. Future: `"bitbucket"`. |
+| `name` | string | `"github"` | Provider implementation. Supported: `"bitbucket"` (Bitbucket Cloud), `"gitea"` (also covers Forgejo via API compatibility), `"github"`, `"gitlab"`. |
 | `owner` | string | required | The user or org that owns the repo. On GitLab maps to namespace; on Bitbucket to workspace. |
 | `repo` | string | required | The repository name. |
 | `host` | string | `""` | API host for self-hosted installations. Empty means the provider's default public host. |
@@ -97,7 +97,7 @@ Tags: `v1.6.0` (root), `transports/zerolog/v1.6.0`, `transports/zap/v1.6.0`. Eac
 `monorel` rejects misconfigurations at load time:
 
 - **`provider.owner is required`** / **`provider.repo is required`**: required fields.
-- **`provider.name %q is not recognized`**: provider name is not in `config.KnownProviders`. Today only `"github"` is supported.
+- **`provider.name %q is not recognized`**: provider name is not in `config.KnownProviders` (`"bitbucket"`, `"gitea"`, `"github"`, `"gitlab"`).
 - **`no packages declared`**: at least one `[packages."<name>"]` block is required.
 - **`packages.X: path is required`** / **`changelog is required`**: per-package required fields.
 - **`packages.X and packages.Y share tag_prefix Z`**: two packages mapping to the same tag namespace would silently collide. Pick distinct prefixes.

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -41,7 +41,7 @@ The bot orchestrator stages a `monorel/release` branch off the default branch an
 
 ## Provider-neutral host seam
 
-`internal/provider.Client` is a six-method interface (`GetDefaultBranch`, `FindOpenReleasePR`, `CreatePR`, `UpdatePR`, `ClosePR`, `CreateRelease`). The factory dispatches by `config.ProviderConfig.Name` to a per-provider subpackage. GitHub today; GitLab / Gitea / Bitbucket / Forgejo by adding a subpackage.
+`internal/provider.Client` is a seven-method interface (`GetDefaultBranch`, `FindOpenReleasePR`, `FindPRByMergeCommit`, `CreatePR`, `UpdatePR`, `ClosePR`, `CreateRelease`). The factory dispatches by `config.ProviderConfig.Name` to a per-provider subpackage. GitHub, GitLab, Gitea / Forgejo, and Bitbucket Cloud are all built in; add a subpackage to support a host that isn't covered.
 
 **Why:** The interface is genuinely the slice of host operations monorel uses. Naming the abstraction `provider` (rather than `github`) is a small upfront cost that pays off the first time someone wants GitLab.
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -35,7 +35,7 @@ docker run --rm \
   ghcr.io/disaresta-org/monorel:latest plan
 ```
 
-For commands that need a provider token (`monorel publish`, `monorel preview --upsert`, `monorel release --publish`), pass it via an environment variable. The shorthand `-e GITHUB_TOKEN` forwards the host's variable of the same name without retyping its value:
+For commands that need a provider token (`monorel publish`, `monorel preview --upsert`), pass it via an environment variable. The shorthand `-e GITHUB_TOKEN` forwards the host's variable of the same name without retyping its value:
 
 ```sh
 export GITHUB_TOKEN=ghp_…   # (or use your shell's secret store)

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -108,9 +108,9 @@ Re-run it. `CreateRelease` is idempotent on the tag name: each tag the prior run
 
 The merge stripped the trailer block. Most likely cause: a squash-merge setting that drops the commit body (see [Branch protection](/integrations/github#branch-protection)).
 
-**First, the universal trailers fallback usually recovers automatically.** Since v0.13, `monorel preview` writes a `<!-- monorel-trailers ... -->` HTML comment into the PR body whenever it opens or updates the always-open release PR. When `monorel tag` finds no `monorel-Release:` trailers on HEAD, it walks back to the merged PR via the provider's `FindPRByMergeCommit` lookup and parses trailers from that comment block. So even a force-applied squash-merge that rewrote the body still completes the release. Fixing the squash-merge setting is still recommended (one fewer round-trip, one fewer failure mode), but not urgent.
+**First, the universal trailers fallback usually recovers automatically.** Since v0.14, `monorel preview` writes a `<!-- monorel-trailers ... -->` HTML comment into the PR body whenever it opens or updates the always-open release PR. When `monorel tag` finds no `monorel-Release:` trailers on HEAD, it walks back to the merged PR via the provider's `FindPRByMergeCommit` lookup and parses trailers from that comment block. So even a force-applied squash-merge that rewrote the body still completes the release. Fixing the squash-merge setting is still recommended (one fewer round-trip, one fewer failure mode), but not urgent.
 
-The fallback fails only when **both** the commit body AND the PR body's comment block are absent. The latter happens when a contributor edited the PR body and removed the comment block before merge, or when an older `monorel preview` (pre-v0.13) wrote the body without the comment. In that case, hand-create the tags pointing at the merge commit:
+The fallback fails only when **both** the commit body AND the PR body's comment block are absent. The latter happens when a contributor edited the PR body and removed the comment block before merge, or when an older `monorel preview` (pre-v0.14) wrote the body without the comment. In that case, hand-create the tags pointing at the merge commit:
 
 ```sh
 git tag -a <prefix>/v<X.Y.Z> <merge-sha> -m "Release <prefix> v<X.Y.Z>"

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -58,7 +58,7 @@ The [`examples/`](https://github.com/disaresta-org/monorel/tree/main/examples) d
 
 Each is a `monorel.toml` + workflow files + `.changeset/README.md` you can copy into your repo.
 
-For a real production setup at scale, [loglayer-go](https://github.com/loglayer/loglayer-go) runs monorel across 25 sub-modules.
+For a real production setup at scale, [loglayer-go](https://github.com/loglayer/loglayer-go) runs monorel across 26 sub-modules.
 :::
 
 ## Wire up the GitHub Action

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -77,7 +77,7 @@ The state when `.changeset/pre.json` exists. In this mode, `monorel release` pro
 
 ## Provider
 
-The version-control host (GitHub, GitLab, Gitea, Bitbucket, Forgejo). monorel's `internal/provider` interface abstracts the host-specific operations (find PR, create PR, create release, etc.). Selected by `provider.name` in `monorel.toml`. As of v0.7, `github`, `gitea`, and `gitlab` are wired up; the `gitea` implementation also covers Forgejo via API compatibility. The seam is ready for `bitbucket`.
+The version-control host (GitHub, GitLab, Gitea, Bitbucket, Forgejo). monorel's `internal/provider` interface abstracts the host-specific operations (find PR, create PR, create release, etc.). Selected by `provider.name` in `monorel.toml`. As of v0.14, `github`, `gitea` (also covers `forgejo` via API compatibility), `gitlab`, and `bitbucket` (Bitbucket Cloud) are wired up.
 
 ## Release PR
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,7 @@ features:
   - title: Pre-release support
     details: monorel pre enter rc switches the repo into release-candidate mode; pre exit returns to stable. Per-package counters; multi-channel.
   - title: Provider-neutral host seam
-    details: GitHub today, GitLab / Gitea / Bitbucket / Forgejo by adding a subpackage. Renames, hosts, and auth shapes are encapsulated in the provider, not the orchestrator.
+    details: Four providers wired up out of the box (GitHub, GitLab, Gitea / Forgejo, Bitbucket Cloud); add a subpackage to support others. Renames, hosts, and auth shapes are encapsulated in the provider, not the orchestrator.
   - title: Self-hosted from day one
     details: monorel releases itself with monorel. The same binary that ships your library cuts its own tags.
 ---

--- a/docs/src/integrations/bitbucket.md
+++ b/docs/src/integrations/bitbucket.md
@@ -7,10 +7,6 @@ description: "Wire up monorel against a Bitbucket Cloud repository: configuratio
 
 monorel's Bitbucket provider talks to [Bitbucket Cloud](https://bitbucket.org) via the standard Bitbucket REST API v2. The implementation is hand-rolled against `net/http` (no SDK), so the provider has no extra direct dependencies and works on any platform Go does.
 
-::: info Available in v0.14+
-The Bitbucket provider landed in monorel v0.14.0. Earlier versions support `github`, `gitea`, and `gitlab` only.
-:::
-
 ::: warning Bitbucket Cloud only
 Only Bitbucket Cloud (`bitbucket.org`) is supported. Bitbucket Data Center / Server (the self-hosted product) uses a different REST surface and is not covered. The package layout is namespace-ready for a future `bitbucket/datacenter/` sibling, but that work is not on the roadmap.
 :::

--- a/docs/src/integrations/gitea.md
+++ b/docs/src/integrations/gitea.md
@@ -101,7 +101,7 @@ PRs created via Gitea Actions' auto-injected `secrets.GITHUB_TOKEN` are subject 
 Fix: generate a personal access token at `/-/user/settings/applications` (or your Forgejo instance's equivalent) with `repository: write` + `user: read`. Add it as a repo secret (e.g. `MONOREL_GITEA_TOKEN`) and pass it to the action wrapper instead of the auto-injected token:
 
 ```yaml
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: pr
         env:

--- a/docs/src/integrations/github.md
+++ b/docs/src/integrations/github.md
@@ -43,7 +43,7 @@ The two workflow files below implement the lifecycle: `release-pr.yml` keeps the
 - Invokes monorel with the configured command (`pr` or `release`).
 
 ::: tip Pre-1.0 pinning
-monorel hasn't shipped a moving major-track tag yet (no `@v0` or `@v1` ref). Pin to an exact patch (`@v0.11.0` or whichever you've validated) until that ships. Bump deliberately when a new monorel release lands.
+monorel hasn't shipped a moving major-track tag yet (no `@v0` or `@v1` ref). Pin to an exact patch (`@v0.14.0` or whichever you've validated) until that ships. Bump deliberately when a new monorel release lands.
 :::
 
 ### `release-pr.yml`: maintain the always-open release PR
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: release
       - name: Capture root tag
@@ -201,7 +201,7 @@ Simplest path. Create a fine-grained PAT scoped to the target repo with these pe
 Add it as a repo secret (e.g. `MONOREL_PR_TOKEN`) and pass it to the action's `token` input:
 
 ```yaml
-- uses: disaresta-org/monorel/ci/github@v0.11.0
+- uses: disaresta-org/monorel/ci/github@v0.14.0
   with:
     command: pr
     token: ${{ secrets.MONOREL_PR_TOKEN }}
@@ -238,7 +238,7 @@ jobs:
         with:
           app-id: ${{ vars.MONOREL_APP_ID }}
           private-key: ${{ secrets.MONOREL_APP_PRIVATE_KEY }}
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with:
           command: pr
           token: ${{ steps.app-token.outputs.token }}

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -27,7 +27,7 @@ The off-the-shelf options each have a sharp edge for this layout.
 | Tidies sub-module `go.sum` at release | ❌ | n/a (JS) | ❌ | ✅ |
 | Source of truth | commit footers (`Release-As:`) | `.changeset/*.md` | configurable (commits or files) | `.changeset/*.md` |
 | Native to | TypeScript | TypeScript | Rust | Go |
-| Multi-provider | GitHub | GitHub (bot); CLI host-agnostic | GitHub / GitLab / Gitea | GitHub + Gitea / Forgejo + GitLab |
+| Multi-provider | GitHub | GitHub (bot); CLI host-agnostic | GitHub / GitLab / Gitea | GitHub + Gitea / Forgejo + GitLab + Bitbucket Cloud |
 | Polyglot / non-language-specific | ✅ | ⚠️ JS-shaped (`package.json` per package) | ✅ | ❌ Go-only by design |
 
 The first three rows are the common ground: every tool in this category will manage independent per-package versions, write a per-package CHANGELOG, and support pre-release windows. The friction shows up below those rows: how releases are *triggered* (commit messages vs explicit files), what tag shapes are supported, and which language ecosystem the tool is native to.
@@ -60,7 +60,7 @@ monorel takes the changesets *idea* (per-PR intent files, named affected package
 - **Tag format is per-package.** `tag_prefix = ""` for the main module yields bare `vX.Y.Z`; `tag_prefix = "transports/foo"` for a sub-module yields `transports/foo/vX.Y.Z`. Both work in the same repo.
 - **Always-open release PR.** The bot orchestrator force-pushes a speculative-version branch and upserts a PR. Merging the PR runs `monorel release` on the merge commit, pushes tags, and publishes per-tag releases.
 - **Pre-release support.** `monorel pre enter rc` switches the repo to release-candidate mode; subsequent releases append `-rc.N` to the next stable version and increment a per-package counter. `pre exit` returns to stable.
-- **Provider-neutral.** GitHub, Gitea / Forgejo, and GitLab today; Bitbucket by adding a subpackage. The orchestrator never sees provider-specific types.
+- **Provider-neutral.** GitHub, Gitea / Forgejo, GitLab, and Bitbucket Cloud are all built in. The orchestrator never sees provider-specific types; add a subpackage to support a host that isn't covered.
 - **Clean `go.mod` at release time.** Sub-modules carry dev `replace` directives and placeholder `require` versions for local cross-module work; monorel strips and pins them in the release commit so downstream consumers' `go mod tidy` resolves the published versions.
 - **Tidy sub-module `go.sum` at release time.** Pinning sibling requires shifts the `go.sum` drift problem onto consumers. monorel runs `go mod tidy` (offline, against a seeded local cache) in every released sub-module that requires an in-plan sibling, so the release commit's `go.sum` is canonically clean. No proxy roundtrip; main is `go mod tidy`-clean for every consumer on the next pull.
 

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -391,7 +391,7 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: actions/setup-go@v5
         with: { go-version-file: go.mod }
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with: { command: pr }
 ```
 
@@ -414,7 +414,7 @@ jobs:
         with: { fetch-depth: 0 }
       - uses: actions/setup-go@v5
         with: { go-version-file: go.mod }
-      - uses: disaresta-org/monorel/ci/github@v0.11.0
+      - uses: disaresta-org/monorel/ci/github@v0.14.0
         with: { command: release }
 ```
 
@@ -425,7 +425,7 @@ jobs:
 Same composite action; pass `GITEA_TOKEN` for the secret.
 
 ```yaml
-- uses: disaresta-org/monorel/ci/github@v0.11.0
+- uses: disaresta-org/monorel/ci/github@v0.14.0
   with: { command: pr }
   env:
     GITEA_TOKEN: ${{ secrets.MONOREL_GITEA_TOKEN }}

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -155,7 +155,7 @@ GitHub Actions / Gitea Actions: use the composite action.
 ```yaml
 - uses: actions/setup-go@v5
   with: { go-version-file: go.mod }   # required since v0.11; tidy needs `go` on PATH
-- uses: disaresta-org/monorel/ci/github@v0.11.0
+- uses: disaresta-org/monorel/ci/github@v0.14.0
   with:
     command: pr      # or "release" or "doctor"
 ```

--- a/docs/src/recipes/bootstrapping-monorel.md
+++ b/docs/src/recipes/bootstrapping-monorel.md
@@ -8,7 +8,7 @@ description: "How to ship monorel's first release before monorel exists. One-tim
 monorel releases itself with monorel from `v0.1.1` onward. The first release (`v0.1.0`) has to happen without monorel because the binary doesn't exist yet. This page documents that one-time bootstrap.
 
 ::: warning One-time only
-After `v0.1.0` ships, every subsequent release goes through `monorel release --publish` (locally or via the GitHub Action). Do not re-run this bootstrap on a healthy repo.
+After `v0.1.0` ships, every subsequent release goes through monorel's standard post-merge pipeline (`monorel tag`, `git push --follow-tags`, `monorel publish`), run locally or by the GitHub Action's `command: release`. Do not re-run this bootstrap on a healthy repo.
 :::
 
 ## What ships in v0.1.0
@@ -75,7 +75,7 @@ git push origin v0.1.0
 
 GoReleaser's auto-generated body is empty (`changelog.disable: true`). Paste the `## [0.1.0]` section from `CHANGELOG.md` into the GitHub Release body via the UI.
 
-(For `v0.1.1` onward, `monorel release --publish` writes the body automatically; this manual step is only for the bootstrap.)
+(For `v0.1.1` onward, `monorel publish` writes the body automatically; this manual step is only for the bootstrap.)
 
 ### 6. Verify the install path
 
@@ -99,6 +99,6 @@ From `v0.1.1` on:
 
 1. Author changesets via `monorel add`.
 2. CI runs `monorel preview --upsert` on push to main → release PR opens / updates.
-3. Merging the release PR runs `monorel release --publish` on the merge commit → tags pushed → binary-build workflow → archives attached.
+3. Merging the release PR runs the post-merge pipeline on the merge commit (`monorel tag` → `git push --follow-tags` → `monorel publish`) → binary-build workflow fires on the tag push → archives attached.
 
 The bootstrap workflow file (`build-release-binaries.yml`) is the only piece that survives the bootstrap; everything else converges on the `monorel`-driven flow.


### PR DESCRIPTION
## Summary

Post-v0.14.0 audit found multiple doc pages still treating Bitbucket Cloud as "coming soon" / "by adding a subpackage" and the trailers fallback as a v0.13 feature (it shipped in v0.14.0). Plus a pre-existing inaccuracy: five doc pages reference a `monorel release --publish` flag that doesn't exist (the actual flow is `monorel release` then a separate `monorel publish`).

## Changes

- **Provider lists**: `configuration.md`, `design.md`, `glossary.md`, `index.md`, `introduction.md` — Bitbucket is now listed as a built-in provider alongside GitHub / Gitea / GitLab. Drops the "Future:" / "by adding a subpackage" caveats.
- **Provider seam method count** in `design.md`: was six, now seven (`FindPRByMergeCommit` added in v0.14.0 for the trailers fallback).
- **`faq.md`**: "Since v0.13" → "Since v0.14" for the trailers fallback.
- **Fictional `monorel release --publish` flag** removed from `bootstrapping-monorel.md`, `cli-reference.md`, `docker.md`. Replaced with the correct two-step (or three-step) sequence.
- **CI action wrapper pin** bumped from `@v0.11.0` (or `v0.12.0`) to `@v0.14.0` across `README.md`, all integration pages, all `_partials/*-yml.md`, `docker.md`, `llms.txt`, `llms-full.txt`. Users adopting today get the trailers fallback and Bitbucket support.
- **`api.md`**: dropped a dangling reference to a `whats-new.md` page that doesn't exist.
- **`introduction.md` Multi-provider row** now lists Bitbucket Cloud (the original trigger for this PR).
- **`bitbucket.md`** drops the redundant `Available in v0.14+` callout.

## Out of scope (flagged for follow-ups)

- `api.md` doctor example imports `internal/git`, which isn't externally importable. Real bug; non-trivial fix (would need to construct a `GitLog` function value via `os/exec`).
- `gitea.md` action wrapper points at `monorel/ci/github`; needs verification of whether Gitea Actions accepts the github-namespaced action path.

## Test plan

- [x] `bun run docs:build` clean (no broken anchors, no broken links)
- [x] No remaining `Available in v0.14` text in `bitbucket.md`
- [x] No remaining `monorel release --publish` references anywhere in `docs/src/`
- [x] `Multi-provider` row in `introduction.md` includes Bitbucket Cloud