### PR TITLE
fix(ci): require monorel-Release trailer in release-workflow guards

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,8 +16,11 @@ jobs:
   release-pr:
     runs-on: ubuntu-latest
     # Skip release-PR upserts on the release commit itself; otherwise
-    # we'd churn the PR right after merging it.
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    # we'd churn the PR right after merging it. Require BOTH the
+    # chore(release): subject prefix AND the monorel-Release: trailer
+    # in the body: a feature PR titled `chore(release): X` would also
+    # match a subject-only check, leaving the release PR un-upserted.
+    if: ${{ !(startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:')) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,12 @@ permissions:
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release):')
+    # Require BOTH the chore(release): subject prefix AND a
+    # monorel-Release: trailer in the body. Subject prefix alone is
+    # not sufficient: a feature PR titled `chore(release): graduate
+    # to v1.0.0` also starts with the prefix but doesn't carry the
+    # trailer monorel tag needs to know which tags to create.
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:'))
     runs-on: ubuntu-latest
     outputs:
       # Latest bare vX.Y.Z tag created by `monorel release`. Empty when

--- a/docs/src/_partials/bitbucket-pipelines-yml.md
+++ b/docs/src/_partials/bitbucket-pipelines-yml.md
@@ -13,13 +13,16 @@ pipelines:
             - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
             - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
             # Detect release-merge commits by scanning the FULL commit
-            # message (subject + body) for the chore(release): trailer
-            # marker. Bitbucket's merge strategies replace the source
-            # subject with `Merged in <branch> (pull request #N)`, so a
-            # subject-only check would never match. Both squash and
-            # merge_commit preserve the source subject as a body line.
+            # message (subject + body) for both the chore(release):
+            # subject line AND the monorel-Release: trailer. Bitbucket's
+            # merge strategies replace the source subject with `Merged
+            # in <branch> (pull request #N)`, so a subject-only check
+            # would never match. Both squash and merge_commit preserve
+            # the source subject as a body line. Requiring the trailer
+            # too defends against a feature PR whose own subject is
+            # `chore(release): X` from tripping monorel tag.
             - HEAD_MSG=$(git log -1 --format=%B)
-            - if echo "$HEAD_MSG" | grep -qE '(^|\n)chore\(release\):'; then
+            - if echo "$HEAD_MSG" | grep -qE '(^|\n)chore\(release\):' && echo "$HEAD_MSG" | grep -qF 'monorel-Release:'; then
                 monorel tag &&
                 git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
                 monorel publish;

--- a/docs/src/_partials/gitea-release-pr-yml.md
+++ b/docs/src/_partials/gitea-release-pr-yml.md
@@ -8,7 +8,12 @@ permissions:
   pull-requests: write
 jobs:
   release-pr:
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    # Skip on the release PR's own merge commit so the workflow
+    # doesn't churn the just-merged PR. Require BOTH the
+    # chore(release): subject prefix AND the monorel-Release: trailer
+    # in the body: a feature PR titled `chore(release): X` would also
+    # match a subject-only check, leaving the release PR un-upserted.
+    if: ${{ !(startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/src/_partials/gitea-release-yml.md
+++ b/docs/src/_partials/gitea-release-yml.md
@@ -8,7 +8,12 @@ permissions:
   contents: write
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release):')
+    # Require BOTH the chore(release): subject prefix AND a
+    # monorel-Release: trailer in the body. Subject prefix alone is
+    # not sufficient: a feature PR titled `chore(release): X` also
+    # starts with the prefix but doesn't carry the trailer monorel
+    # tag needs to know which tags to create.
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/src/_partials/github-release-pr-yml.md
+++ b/docs/src/_partials/github-release-pr-yml.md
@@ -10,10 +10,12 @@ permissions:
 
 jobs:
   release-pr:
-    # Skip on the release PR's own merge commit (subject begins with
-    # "chore(release):" by monorel convention) so the workflow doesn't
-    # churn the just-merged PR.
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    # Skip on the release PR's own merge commit so the workflow
+    # doesn't churn the just-merged PR. Require BOTH the
+    # chore(release): subject prefix AND the monorel-Release: trailer
+    # in the body: a feature PR titled `chore(release): X` would also
+    # match a subject-only check, leaving the release PR un-upserted.
+    if: ${{ !(startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/src/_partials/github-release-yml.md
+++ b/docs/src/_partials/github-release-yml.md
@@ -10,7 +10,12 @@ permissions:
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release):')
+    # Require BOTH the chore(release): subject prefix AND a
+    # monorel-Release: trailer in the body. Subject prefix alone is
+    # not sufficient: a feature PR titled `chore(release): X` also
+    # starts with the prefix but doesn't carry the trailer monorel
+    # tag needs to know which tags to create.
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/src/_partials/gitlab-ci-yml.md
+++ b/docs/src/_partials/gitlab-ci-yml.md
@@ -19,11 +19,15 @@ doctor:
     - monorel doctor
 
 # Maintain the always-open release MR. Fires on every push to the
-# default branch except the chore(release): merge commit.
+# default branch except the release-cut commit. Require BOTH the
+# chore(release): subject prefix AND a monorel-Release: trailer in
+# the body to identify the release commit; a feature MR titled
+# `chore(release): X` would otherwise match a subject-only check
+# and silently skip the release-PR upsert.
 release-pr:
   stage: release-pr
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE !~ /^chore\(release\):/
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_TITLE !~ /^chore\(release\):/ || $CI_COMMIT_MESSAGE !~ /monorel-Release:/)
   variables:
     GITLAB_TOKEN: $MONOREL_GITLAB_TOKEN
   script:
@@ -37,11 +41,15 @@ release-pr:
     - git push -f "https://oauth2:${MONOREL_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" monorel/release
     - monorel preview --upsert
 
-# Cut the release after the always-open MR is merged.
+# Cut the release after the always-open MR is merged. Require BOTH
+# the chore(release): subject prefix AND a monorel-Release: trailer
+# in the body; subject prefix alone is not sufficient (a feature MR
+# titled `chore(release): X` would match and trip monorel tag with
+# `no monorel-Release: trailer`).
 release:
   stage: release
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^chore\(release\):/
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^chore\(release\):/ && $CI_COMMIT_MESSAGE =~ /monorel-Release:/
   variables:
     GITLAB_TOKEN: $MONOREL_GITLAB_TOKEN
   script:

--- a/examples/bitbucket/bitbucket-pipelines.yml
+++ b/examples/bitbucket/bitbucket-pipelines.yml
@@ -12,13 +12,16 @@ pipelines:
             - export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
             - export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
             # Detect release-merge commits by scanning the FULL commit
-            # message (subject + body) for the chore(release): trailer
-            # marker. Bitbucket's merge strategies replace the source
-            # subject with `Merged in <branch> (pull request #N)`, so a
-            # subject-only check would never match. Both squash and
-            # merge_commit preserve the source subject as a body line.
+            # message (subject + body) for both the chore(release):
+            # subject line AND the monorel-Release: trailer. Bitbucket's
+            # merge strategies replace the source subject with `Merged
+            # in <branch> (pull request #N)`, so a subject-only check
+            # would never match. Both squash and merge_commit preserve
+            # the source subject as a body line. Requiring the trailer
+            # too defends against a feature PR whose own subject is
+            # `chore(release): X` from tripping monorel tag.
             - HEAD_MSG=$(git log -1 --format=%B)
-            - if echo "$HEAD_MSG" | grep -qE '(^|\n)chore\(release\):'; then
+            - if echo "$HEAD_MSG" | grep -qE '(^|\n)chore\(release\):' && echo "$HEAD_MSG" | grep -qF 'monorel-Release:'; then
                 monorel tag &&
                 git push --follow-tags "https://${BB_USER}:${BITBUCKET_TOKEN}@bitbucket.org/${BITBUCKET_REPO_FULL_NAME}.git" &&
                 monorel publish;

--- a/examples/gitea/.gitea/workflows/release-pr.yml
+++ b/examples/gitea/.gitea/workflows/release-pr.yml
@@ -7,7 +7,12 @@ permissions:
   pull-requests: write
 jobs:
   release-pr:
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    # Skip on the release PR's own merge commit so the workflow
+    # doesn't churn the just-merged PR. Require BOTH the
+    # chore(release): subject prefix AND the monorel-Release: trailer
+    # in the body: a feature PR titled `chore(release): X` would also
+    # match a subject-only check, leaving the release PR un-upserted.
+    if: ${{ !(startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/examples/gitea/.gitea/workflows/release.yml
+++ b/examples/gitea/.gitea/workflows/release.yml
@@ -7,7 +7,12 @@ permissions:
   contents: write
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release):')
+    # Require BOTH the chore(release): subject prefix AND a
+    # monorel-Release: trailer in the body. Subject prefix alone is
+    # not sufficient: a feature PR titled `chore(release): X` also
+    # starts with the prefix but doesn't carry the trailer monorel
+    # tag needs to know which tags to create.
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/examples/github/.github/workflows/release-pr.yml
+++ b/examples/github/.github/workflows/release-pr.yml
@@ -9,10 +9,12 @@ permissions:
 
 jobs:
   release-pr:
-    # Skip on the release PR's own merge commit (subject begins with
-    # "chore(release):" by monorel convention) so the workflow doesn't
-    # churn the just-merged PR.
-    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    # Skip on the release PR's own merge commit so the workflow
+    # doesn't churn the just-merged PR. Require BOTH the
+    # chore(release): subject prefix AND the monorel-Release: trailer
+    # in the body: a feature PR titled `chore(release): X` would also
+    # match a subject-only check, leaving the release PR un-upserted.
+    if: ${{ !(startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/examples/github/.github/workflows/release.yml
+++ b/examples/github/.github/workflows/release.yml
@@ -9,7 +9,12 @@ permissions:
 
 jobs:
   release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore(release):')
+    # Require BOTH the chore(release): subject prefix AND a
+    # monorel-Release: trailer in the body. Subject prefix alone is
+    # not sufficient: a feature PR titled `chore(release): X` also
+    # starts with the prefix but doesn't carry the trailer monorel
+    # tag needs to know which tags to create.
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.head_commit.message, 'chore(release):') && contains(github.event.head_commit.message, 'monorel-Release:'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/examples/gitlab/.gitlab-ci.yml
+++ b/examples/gitlab/.gitlab-ci.yml
@@ -6,11 +6,15 @@ stages:
   - release
 
 # Maintain the always-open release MR. Fires on every push to the
-# default branch except the chore(release): merge commit.
+# default branch except the release-cut commit. Require BOTH the
+# chore(release): subject prefix AND a monorel-Release: trailer in
+# the body to identify the release commit; a feature MR titled
+# `chore(release): X` would otherwise match a subject-only check
+# and silently skip the release-PR upsert.
 release-pr:
   stage: release-pr
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE !~ /^chore\(release\):/
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_TITLE !~ /^chore\(release\):/ || $CI_COMMIT_MESSAGE !~ /monorel-Release:/)
   variables:
     GITLAB_TOKEN: $MONOREL_GITLAB_TOKEN
   script:
@@ -24,11 +28,15 @@ release-pr:
     - git push -f "https://oauth2:${MONOREL_GITLAB_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git" monorel/release
     - monorel preview --upsert
 
-# Cut the release after the always-open MR is merged.
+# Cut the release after the always-open MR is merged. Require BOTH
+# the chore(release): subject prefix AND a monorel-Release: trailer
+# in the body; subject prefix alone is not sufficient (a feature MR
+# titled `chore(release): X` would match and trip monorel tag with
+# `no monorel-Release: trailer`).
 release:
   stage: release
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^chore\(release\):/
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $CI_COMMIT_TITLE =~ /^chore\(release\):/ && $CI_COMMIT_MESSAGE =~ /monorel-Release:/
   variables:
     GITLAB_TOKEN: $MONOREL_GITLAB_TOKEN
   script:


### PR DESCRIPTION
## Problem

PR #61's merge surfaced a real bug. The release workflow's guard:

```yaml
if: startsWith(github.event.head_commit.message, 'chore(release):')
```

only checks the commit subject. PR #61's title was `chore(release): graduate to v1.0.0` (a regular feature PR carrying a `:major` changeset), and its squash-merge subject inherited the same prefix. Two consequences:

- **release.yml fired** (false positive on subject), ran `monorel tag`, and exited 1 with `release: HEAD is not a release commit (no monorel-Release: trailer)`.
- **release-pr.yml's negation skipped** (it thought this WAS the release commit), so no actual release PR opened. The `:major` changeset is still sitting on main, unprocessed.

This trap exists symmetrically across every provider's example workflow, not just monorel's own — same pattern, same vulnerability.

## Fix

Tighten the guard everywhere it appears: require BOTH the subject prefix AND the `monorel-Release:` trailer in the body. The trailer is what `monorel tag` actually consumes, so it's the honest signal that this is a real release commit.

### Files updated (14 total)

**monorel's own workflows:**
- `.github/workflows/release.yml` (positive check)
- `.github/workflows/release-pr.yml` (negative check)

**Example workflows:**
- `examples/github/.github/workflows/{release,release-pr}.yml`
- `examples/gitea/.gitea/workflows/{release,release-pr}.yml`
- `examples/gitlab/.gitlab-ci.yml` (both rules)
- `examples/bitbucket/bitbucket-pipelines.yml`

**Docs partials** (kept byte-identical to the example workflows):
- `docs/src/_partials/{github,gitea,gitlab,bitbucket}-*.md`

### Per-provider syntax

| Provider | Form |
|---|---|
| GitHub Actions | `startsWith(message, 'chore(release):') && contains(message, 'monorel-Release:')` |
| Gitea Actions | same |
| GitLab CI | `$CI_COMMIT_TITLE =~ /^chore\(release\):/ && $CI_COMMIT_MESSAGE =~ /monorel-Release:/` |
| Bitbucket Pipelines (bash) | `grep -qE '(^|\n)chore\(release\):' && grep -qF 'monorel-Release:'` chained on `git log -1 --format=%B` |

`workflow_dispatch` carve-outs and existing comments preserved.

## Recovery for the v1.0.0 release

After this PR merges:

1. The merge commit subject (`fix(ci): ...`) doesn't start with `chore(release):` — release-pr.yml fires.
2. release-pr.yml sees the v1.0.0 `:major` changeset still on main, opens the actual release PR.
3. Merging that release PR produces a real `chore(release):` commit with the `monorel-Release:` trailer. release.yml's tightened guard correctly identifies it. v1.0.0 cuts cleanly.

## Test plan

- [x] `go vet ./...`, `gofmt -l .` clean
- [x] `bun run docs:build` clean
- [x] Each example workflow + its corresponding partial verified byte-identical
- [x] `workflow_dispatch` carve-outs preserved
- [x] PR title does NOT start with `chore(release):` (would re-trip the bug being fixed)