### PR TITLE
fix(detect): match trailer line-anchored, not via substring

### DIFF
--- a/.changeset/detect-trailer-line-start.md
+++ b/.changeset/detect-trailer-line-start.md
@@ -1,0 +1,11 @@
+---
+"monorel.disaresta.com": patch
+---
+
+**Fix `detect-release` false-positive on prose mentions of the trailer marker.**
+
+`detect.IsReleaseMerge`'s trailer fast path used `strings.Contains(headBody, "monorel-Release:")`, which matched anywhere in the body — including prose mentions of the marker (e.g., docs commits that explain how the trailer works, or squash-merge bodies that aggregate sub-commit messages discussing release tooling).
+
+The CI symptom was a contradiction: `monorel detect-release` reported "release commit detected (source: trailer)" on a non-release commit, then the next pipeline step `monorel tag` correctly rejected HEAD with `ErrNoReleaseCommit`. The release workflow exited non-zero on every push to main whose squash body coincidentally contained the literal text `monorel-Release:`.
+
+The fix line-anchors the match to mirror the canonical parser at `release.parseReleaseTrailers`: the marker must appear at the start of a (whitespace-trimmed) line. Detect and tag now agree on what counts as a real trailer.

--- a/.changeset/detect-trailer-line-start.md
+++ b/.changeset/detect-trailer-line-start.md
@@ -4,7 +4,7 @@
 
 **Fix `detect-release` false-positive on prose mentions of the trailer marker.**
 
-`detect.IsReleaseMerge`'s trailer fast path used `strings.Contains(headBody, "monorel-Release:")`, which matched anywhere in the body — including prose mentions of the marker (e.g., docs commits that explain how the trailer works, or squash-merge bodies that aggregate sub-commit messages discussing release tooling).
+`detect.IsReleaseMerge`'s trailer fast path used `strings.Contains(headBody, "monorel-Release:")`, which matched anywhere in the body, including prose mentions of the marker (e.g., docs commits that explain how the trailer works, or squash-merge bodies that aggregate sub-commit messages discussing release tooling).
 
 The CI symptom was a contradiction: `monorel detect-release` reported "release commit detected (source: trailer)" on a non-release commit, then the next pipeline step `monorel tag` correctly rejected HEAD with `ErrNoReleaseCommit`. The release workflow exited non-zero on every push to main whose squash body coincidentally contained the literal text `monorel-Release:`.
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -37,11 +37,28 @@ import (
 // orchestrator imports detect for the Auto flow).
 const releaseHeadBranch = "monorel/release"
 
-// trailerMarker is the literal substring detect looks for in HEAD's
-// commit body to confirm a release commit. monorel apply writes one
-// `monorel-Release:` line per released package; checking for the
-// prefix is sufficient because the marker is monorel-distinctive.
+// trailerMarker is the line prefix detect looks for in HEAD's commit
+// body to confirm a release commit. monorel apply writes one
+// `monorel-Release:` line per released package, each at the start of
+// its own line in the trailer block. The match is line-anchored (after
+// trimming whitespace), matching [release.parseReleaseTrailers]: a
+// commit body that mentions the literal text `monorel-Release:` in
+// prose must NOT be misclassified as a release commit.
 const trailerMarker = "monorel-Release:"
+
+// hasReleaseTrailer reports whether msg contains a `monorel-Release:`
+// line at the start of any (trimmed) line. Mirrors the canonical
+// parser at [release.parseReleaseTrailers] so detect and tag agree on
+// what "has a trailer" means; a substring check would falsely match
+// commit bodies whose prose mentions the marker.
+func hasReleaseTrailer(msg string) bool {
+	for _, line := range strings.Split(msg, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), trailerMarker) {
+			return true
+		}
+	}
+	return false
+}
 
 // Source describes which signal told detect "yes, this is a release
 // commit." Populated for diagnostic logging in the CLI.
@@ -115,7 +132,7 @@ func IsReleaseMerge(ctx context.Context, repo git.Repo, prov provider.Client, sh
 	if err != nil {
 		return nil, fmt.Errorf("detect: read HEAD commit message: %w", err)
 	}
-	if strings.Contains(msg, trailerMarker) {
+	if hasReleaseTrailer(msg) {
 		return &Result{IsRelease: true, Source: SourceTrailer}, nil
 	}
 

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -177,3 +177,59 @@ func TestIsReleaseMerge_NilRepo(t *testing.T) {
 		t.Errorf("err = %v, want ErrRepoRequired", err)
 	}
 }
+
+// TestIsReleaseMerge_TrailerInProseDoesNotMatch is a regression test
+// for the false-positive that broke main's release CI on the e2e PR
+// squash-merge: the body contained the literal text "monorel-Release:"
+// inside prose (sub-commit descriptions discussing the trailer), but
+// no actual trailer line. The trailer signal must use line-anchored
+// matching to agree with release.parseReleaseTrailers.
+func TestIsReleaseMerge_TrailerInProseDoesNotMatch(t *testing.T) {
+	repo := git.NewFake()
+	// The exact shape that broke CI: prose mentions the trailer marker
+	// without it appearing as a real trailer line. Multiple variants in
+	// one body to cover the realistic squash-merge case.
+	body := "test(e2e): live-Forgejo end-to-end suite (27 scenarios) (#65)\n\n" +
+		"* fix(orchestrator): populate Release bodies in auto's release path\n\n" +
+		"monorel auto's release path called release.PublishReleases with\n" +
+		"release.Tag's Result, but Tag's ReleaseInfo entries have empty\n" +
+		"Body fields.\n\n" +
+		"* test(e2e): expand suite to 27 scenarios\n\n" +
+		"errors: surfaces non-semver tags through validate. The validate\n" +
+		"command's output mentions monorel-Release: trailer parsing in its\n" +
+		"diagnostic text.\n\n" +
+		"Co-authored-by: Someone <noreply@example.com>\n"
+	stageAndCommit(t, repo, body)
+
+	// Provider has no PR matching HEAD, so the API signal can't fire.
+	// Without the line-anchored fix, the substring check would match
+	// the prose mentions and incorrectly return IsRelease=true.
+	pf := provider.NewFake()
+
+	res, err := IsReleaseMerge(context.Background(), repo, pf, "abcd")
+	if err != nil {
+		t.Fatalf("IsReleaseMerge: %v", err)
+	}
+	if res.IsRelease {
+		t.Errorf("IsRelease = true on prose-only mention; want false (Source=%s)", res.Source)
+	}
+}
+
+// TestIsReleaseMerge_TrailerWithLeadingWhitespace covers the realistic
+// case where an indented trailer line still counts: monorel apply
+// writes trailers flush-left, but downstream tooling that re-renders
+// the message (some squash-merge UIs) may indent. release's parser
+// trims whitespace before matching, so detect must too.
+func TestIsReleaseMerge_TrailerWithLeadingWhitespace(t *testing.T) {
+	repo := git.NewFake()
+	stageAndCommit(t, repo, "chore(release)\n\n  monorel-Release: pkg-a v1.0.0\n")
+
+	pf := provider.NewFake()
+	res, err := IsReleaseMerge(context.Background(), repo, pf, "")
+	if err != nil {
+		t.Fatalf("IsReleaseMerge: %v", err)
+	}
+	if !res.IsRelease || res.Source != SourceTrailer {
+		t.Errorf("indented trailer not matched: IsRelease=%v Source=%q", res.IsRelease, res.Source)
+	}
+}

--- a/tests/e2e/errors_test.go
+++ b/tests/e2e/errors_test.go
@@ -44,6 +44,45 @@ func TestErrors_TagConflict(t *testing.T) {
 	}
 }
 
+// TestErrors_TrailerInProseDoesNotMatch is the e2e regression test
+// for the false-positive that broke main's release CI: a non-release
+// commit body that mentions the literal text "monorel-Release:" in
+// prose (typical of docs / test commits about the trailer) was
+// detected as a release commit because detect.IsReleaseMerge used a
+// substring check. Fixed in detect.go by line-anchoring to match the
+// canonical release.parseReleaseTrailers parser.
+//
+// The test pushes a commit whose body mentions the trailer marker in
+// prose (no actual trailer line) and asserts that detect-release
+// exits 1 (not a release). Without the fix, detect-release would
+// exit 0 and the release pipeline would attempt to tag a non-release
+// commit.
+func TestErrors_TrailerInProseDoesNotMatch(t *testing.T) {
+	r := newScenarioRepo(t, "trailer-prose")
+	r.ScaffoldSinglePackage(t, "pkg-a", "pkg-a", "pkg-a")
+	// Commit body mentions "monorel-Release:" in prose but has no
+	// actual trailer line. The shape mirrors what GitHub's squash UI
+	// produced for PR #65 (e2e suite expansion): sub-commit
+	// descriptions discussing the trailer parser.
+	r.WriteFile(t, "pkg-a/notes.txt",
+		"docs: explain monorel-Release: trailer parsing in the apply step\n")
+	body := "docs(release): expand explanation of monorel-Release: trailers\n\n" +
+		"The release commit body carries one monorel-Release: line per\n" +
+		"released package. Detect's trailer fast path agrees with\n" +
+		"release.parseReleaseTrailers on what counts as a real trailer.\n"
+	r.CommitAll(t, body)
+	r.PushMain(t)
+
+	res := r.Monorel(t, "detect-release")
+	if res.ExitCode != 1 {
+		t.Errorf("detect-release on prose-mention commit should exit 1; got %d\nstdout: %s\nstderr: %s",
+			res.ExitCode, res.Stdout, res.Stderr)
+	}
+	if !strings.Contains(res.Stderr, "not a release-PR merge") {
+		t.Errorf("stderr should explain 'not a release-PR merge'; got:\n%s", res.Stderr)
+	}
+}
+
 // TestErrors_TrailersFallbackFailure: when
 // neither signal can fire (HEAD body has no trailer AND no PR
 // matches the SHA), monorel tag returns ErrNoReleaseCommit and
@@ -115,6 +154,7 @@ func TestErrors_ValidateStrict(t *testing.T) {
 	r := newScenarioRepo(t, "validate-strict")
 	r.ScaffoldSinglePackage(t, "pkg-a", "pkg-a", "pkg-a")
 	r.CommitAll(t, "init")
+	r.PushMain(t)
 
 	// Construct a warning-only state by tagging a non-semver tag.
 	// validate --check-tags surfaces that as a warning. We use the

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -129,6 +129,42 @@ changelog = %q
 	r.WriteFile(t, ".changeset/README.md", "# Changesets\n")
 }
 
+// ScaffoldMultiPackage writes a monorel.toml plus README + CHANGELOG
+// stubs for N flat packages where the package name, tag prefix, and
+// path are all the same string (the common multi-package shape used
+// in versioning scenarios). Single-module repo: no go.mod, no
+// `replace` directives. For the multi-module loglayer-shaped layout
+// use ScaffoldMultiModule.
+//
+// The TOML is always rewritten; per-package README + CHANGELOG files
+// are written only if they don't already exist, so calling this
+// helper mid-life (to register a NEW package alongside an existing
+// one) preserves the existing package's release history on disk.
+func (r *ScenarioRepo) ScaffoldMultiPackage(t *testing.T, pkgs ...string) {
+	t.Helper()
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "[provider]\nname = \"gitea\"\nhost = %q\nowner = %q\nrepo = %q\n",
+		giteaHost, r.Owner, r.Name)
+	for _, p := range pkgs {
+		fmt.Fprintf(&sb, "\n[packages.%q]\ntag_prefix = %q\npath = %q\nchangelog = %q\n",
+			p, p, p, filepath.Join(p, "CHANGELOG.md"))
+	}
+	r.WriteFile(t, "monorel.toml", sb.String())
+	for _, p := range pkgs {
+		readme := filepath.Join(r.Local, p, "README.md")
+		if _, err := os.Stat(readme); os.IsNotExist(err) {
+			r.WriteFile(t, filepath.Join(p, "README.md"), "# "+p+"\n")
+		}
+		changelog := filepath.Join(r.Local, p, "CHANGELOG.md")
+		if _, err := os.Stat(changelog); os.IsNotExist(err) {
+			r.WriteFile(t, filepath.Join(p, "CHANGELOG.md"), "# Changelog\n\n## [Unreleased]\n\n")
+		}
+	}
+	if _, err := os.Stat(filepath.Join(r.Local, ".changeset/README.md")); os.IsNotExist(err) {
+		r.WriteFile(t, ".changeset/README.md", "# Changesets\n")
+	}
+}
+
 // ScaffoldMultiModule writes a 3-module scaffold mirroring the
 // loglayer-go layout: a bare-tag root + two path-prefixed sub-modules
 // with `replace` directives during dev. Returns the package keys.
@@ -560,4 +596,23 @@ func readFile(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(data)
+}
+
+// contains reports whether s appears in slice.
+func contains(slice []string, s string) bool {
+	for _, e := range slice {
+		if e == s {
+			return true
+		}
+	}
+	return false
+}
+
+// mapKeys returns the keys of m as a slice (unordered).
+func mapKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -136,10 +136,12 @@ changelog = %q
 // `replace` directives. For the multi-module loglayer-shaped layout
 // use ScaffoldMultiModule.
 //
-// The TOML is always rewritten; per-package README + CHANGELOG files
-// are written only if they don't already exist, so calling this
-// helper mid-life (to register a NEW package alongside an existing
-// one) preserves the existing package's release history on disk.
+// The TOML is always rewritten with name == path == tag_prefix for
+// every listed package; if the prior TOML had a different tag_prefix
+// or path, it is replaced. Per-package README + CHANGELOG files are
+// written only if they don't already exist, so calling this helper
+// mid-life (to register a NEW package alongside an existing one)
+// preserves the existing package's release history on disk.
 func (r *ScenarioRepo) ScaffoldMultiPackage(t *testing.T, pkgs ...string) {
 	t.Helper()
 	var sb strings.Builder

--- a/tests/e2e/lifecycle_test.go
+++ b/tests/e2e/lifecycle_test.go
@@ -201,6 +201,7 @@ func TestLifecycle_PreReleaseCounter(t *testing.T) {
 	r.PushMain(t)
 
 	cutOne := func(label string, idx int) {
+		t.Helper()
 		r.WriteChangeset(t, "rc-"+label, map[string]string{"pkg-a": "patch"}, "rc "+label+".")
 		r.CommitAll(t, "chore: rc "+label)
 		r.PushMain(t)
@@ -214,9 +215,9 @@ func TestLifecycle_PreReleaseCounter(t *testing.T) {
 		r.CheckoutMain(t)
 		r.MonorelOK(t, "auto")
 	}
-	// First rc cycle uses the existing initial changeset, but the
-	// counter only ticks per-cycle. Drop a sentinel changeset before
-	// each release run to keep the planner non-empty.
+	// rc.0 reuses the initial `feat` changeset committed above; rc.1
+	// and rc.2 each drop a fresh sentinel changeset via cutOne so the
+	// planner has work to do.
 	r.MonorelOK(t, "auto")
 	prs := r.PRs(t, "open")
 	r.MergePR(t, prs[0].Number, "squash")
@@ -347,11 +348,16 @@ func TestLifecycle_PreModeErrors(t *testing.T) {
 	// Enter pre mode.
 	r.MonorelOK(t, "pre", "enter", "rc")
 
-	// pre enter again → error.
+	// pre enter again → error. Pin the message so a future rewrite
+	// can't silently weaken the contract to a no-op.
 	res = r.Monorel(t, "pre", "enter", "beta")
 	if res.ExitCode == 0 {
 		t.Errorf("pre enter while already in pre mode should error; got 0 exit\nstdout: %s\nstderr: %s",
 			res.Stdout, res.Stderr)
+	}
+	combined := res.Stdout + "\n" + res.Stderr
+	if !strings.Contains(combined, "already in pre-release mode") {
+		t.Errorf("expected 'already in pre-release mode' in output; got:\n%s", combined)
 	}
 }
 
@@ -374,13 +380,4 @@ func TestLifecycle_DoctorCleanState(t *testing.T) {
 	if !strings.Contains(combined, "No findings") && !strings.Contains(combined, "looks healthy") {
 		t.Errorf("doctor on clean state should report no findings\nfull output:\n%s", combined)
 	}
-}
-
-func contains(slice []string, s string) bool {
-	for _, e := range slice {
-		if e == s {
-			return true
-		}
-	}
-	return false
 }

--- a/tests/e2e/versioning_test.go
+++ b/tests/e2e/versioning_test.go
@@ -68,9 +68,10 @@ func TestVersioning_NewPackageMidLife(t *testing.T) {
 
 	// Now register pkg-b alongside pkg-a, plus a :major changeset
 	// for pkg-b. Expected: pkg-b/v1.0.0 (initial) + pkg-a unchanged.
-	// ScaffoldMultiPackage rewrites monorel.toml + the package
-	// CHANGELOG/README stubs in one shot; pkg-a's existing release
-	// history is recorded via tags, not files, so the rewrite is safe.
+	// ScaffoldMultiPackage rewrites monorel.toml and adds pkg-b's
+	// stubs; pkg-a's existing CHANGELOG (which has the v0.1.0
+	// release entry) is preserved by the helper's "write only if
+	// missing" stub semantics.
 	r.ScaffoldMultiPackage(t, "pkg-a", "pkg-b")
 	r.WriteChangeset(t, "feat-b", map[string]string{"pkg-b": "major"}, "Initial pkg-b.")
 	r.CommitAll(t, "feat: register pkg-b")

--- a/tests/e2e/versioning_test.go
+++ b/tests/e2e/versioning_test.go
@@ -68,31 +68,10 @@ func TestVersioning_NewPackageMidLife(t *testing.T) {
 
 	// Now register pkg-b alongside pkg-a, plus a :major changeset
 	// for pkg-b. Expected: pkg-b/v1.0.0 (initial) + pkg-a unchanged.
-	original := readFile(t, r.Local+"/monorel.toml")
-	updated := strings.ReplaceAll(original,
-		`[packages."pkg-a"]
-tag_prefix = "pkg-a"
-path = "pkg-a"
-changelog = "pkg-a/CHANGELOG.md"
-`,
-		`[packages."pkg-a"]
-tag_prefix = "pkg-a"
-path = "pkg-a"
-changelog = "pkg-a/CHANGELOG.md"
-
-[packages."pkg-b"]
-tag_prefix = "pkg-b"
-path = "pkg-b"
-changelog = "pkg-b/CHANGELOG.md"
-`)
-	// Guard against silent no-op if the helper template ever changes.
-	if updated == original || !strings.Contains(updated, `[packages."pkg-b"]`) {
-		t.Fatalf("monorel.toml mutation failed; pkg-b block not added.\nbefore:\n%s\nafter:\n%s",
-			original, updated)
-	}
-	r.WriteFile(t, "monorel.toml", updated)
-	r.WriteFile(t, "pkg-b/README.md", "# pkg-b\n")
-	r.WriteFile(t, "pkg-b/CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n")
+	// ScaffoldMultiPackage rewrites monorel.toml + the package
+	// CHANGELOG/README stubs in one shot; pkg-a's existing release
+	// history is recorded via tags, not files, so the rewrite is safe.
+	r.ScaffoldMultiPackage(t, "pkg-a", "pkg-b")
 	r.WriteChangeset(t, "feat-b", map[string]string{"pkg-b": "major"}, "Initial pkg-b.")
 	r.CommitAll(t, "feat: register pkg-b")
 	r.PushMain(t)
@@ -228,27 +207,7 @@ func TestVersioning_MaxBumpPrecedence(t *testing.T) {
 // per-package bump merge across changeset files.
 func TestVersioning_OverlappingChangesetsMergeBumps(t *testing.T) {
 	r := newScenarioRepo(t, "overlap")
-	r.WriteFile(t, "monorel.toml", `[provider]
-name = "gitea"
-host = "`+giteaHost+`"
-owner = "`+r.Owner+`"
-repo = "`+r.Name+`"
-
-[packages."pkg-a"]
-tag_prefix = "pkg-a"
-path = "pkg-a"
-changelog = "pkg-a/CHANGELOG.md"
-
-[packages."pkg-b"]
-tag_prefix = "pkg-b"
-path = "pkg-b"
-changelog = "pkg-b/CHANGELOG.md"
-`)
-	for _, p := range []string{"pkg-a", "pkg-b"} {
-		r.WriteFile(t, p+"/README.md", "# "+p+"\n")
-		r.WriteFile(t, p+"/CHANGELOG.md", "# Changelog\n\n## [Unreleased]\n\n")
-	}
-	r.WriteFile(t, ".changeset/README.md", "# Changesets\n")
+	r.ScaffoldMultiPackage(t, "pkg-a", "pkg-b")
 
 	r.WriteChangeset(t, "feat", map[string]string{"pkg-a": "minor"}, "feat A.")
 	r.WriteChangeset(t, "fix", map[string]string{"pkg-a": "patch", "pkg-b": "patch"}, "fix A+B.")
@@ -271,12 +230,4 @@ changelog = "pkg-b/CHANGELOG.md"
 			t.Errorf("unexpected tag: %s", tag)
 		}
 	}
-}
-
-func mapKeys(m map[string]bool) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }


### PR DESCRIPTION
## Summary

- Fixes a false-positive in `detect.IsReleaseMerge` where prose mentions of `monorel-Release:` in a commit body were incorrectly treated as a release-trailer match.
- Symptom: PR #65's squash-merge commit mentioned the marker in sub-commit descriptions; `monorel detect-release` claimed "release commit detected (source: trailer)" and the workflow then ran `monorel tag`, which correctly errored with `ErrNoReleaseCommit`. Net: the release workflow exits non-zero on every push to main whose squash body coincidentally contains the literal text `monorel-Release:` (failing run: https://github.com/disaresta-org/monorel/actions/runs/25299648899).
- Fix: line-anchor the match in `detect.IsReleaseMerge`, mirroring `release.parseReleaseTrailers`. Detect and tag now agree on what counts as a real trailer.

## Why this slipped past the existing tests

`detect_test.go` covered the trailer-hits, API-hits, and various error paths, but every "no trailer" case used a body with no marker text at all. The failure mode requires the exact text `monorel-Release:` to appear *as prose* without being a real trailer line — a shape unit tests didn't try and the e2e suite didn't either.

## Tests added

- **Unit (`internal/detect/detect_test.go`):**
  - `TestIsReleaseMerge_TrailerInProseDoesNotMatch` — uses PR #65's exact prose-mention shape (multi-paragraph body where the marker appears mid-sentence inside sub-commit descriptions).
  - `TestIsReleaseMerge_TrailerWithLeadingWhitespace` — pins the trim-then-match contract so a re-rendering UI that indents the trailer line still counts.
- **E2E (`tests/e2e/errors_test.go`):**
  - `TestErrors_TrailerInProseDoesNotMatch` — pushes a commit whose body mentions the marker only in prose, asserts `monorel detect-release` exits 1.

## Deferred review items also addressed

The code review on PR #65 deferred several items to a follow-up. Folded into the second commit (`a7fe3a0`):

- **Important:** New `ScaffoldMultiPackage` helper replaces inline-TOML in `TestVersioning_NewPackageMidLife` and `TestVersioning_OverlappingChangesetsMergeBumps`. Idempotent on existing files so it composes mid-life.
- **Minor:** `contains` and `mapKeys` consolidated into `helpers_test.go` (were per-file duplicates).
- **Minor:** `t.Helper()` added to `TestLifecycle_PreReleaseCounter`'s `cutOne` closure.
- **Minor:** Misleading "Drop a sentinel changeset before each release run" comment fixed.
- **Minor:** `TestLifecycle_PreModeErrors` now pins the "already in pre-release mode" message.
- **Minor:** `TestErrors_ValidateStrict` now calls `r.PushMain(t)` for parity with every other scenario.

## Test plan

- [x] `go vet ./...` and `go vet -tags=e2e ./tests/e2e/`
- [x] `go test ./...` (full unit suite green)
- [x] `go test -tags=e2e ./tests/e2e/...` (28 scenarios green in 75s against fresh Forgejo)
- [x] `go test -tags=e2e -run TestIsReleaseMerge_TrailerInProse ./internal/detect/` and the new e2e regression — both reproduce the original failure when the fix is reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)