### PR TITLE
fix(ci): grant pull-requests:write to release.yml

### DIFF
--- a/.changeset/release-workflow-pr-permission.md
+++ b/.changeset/release-workflow-pr-permission.md
@@ -1,0 +1,18 @@
+---
+"monorel.disaresta.com": patch
+---
+
+**Fix `release.yml` 403 on every non-release push to main.**
+
+When PR #64 consolidated `release-pr.yml` into `release.yml`, the
+`pull-requests: write` permission was lost. The release path (tag +
+push) only needs `contents: write`, but the feature path (`monorel
+auto` against the always-open release PR) needs to PATCH the PR via
+GitHub's REST API, which requires `pull-requests: write`.
+
+Symptom: every push to `main` whose HEAD is NOT a release commit
+fails the `release` workflow with `403 Resource not accessible by
+integration` from `PATCH /repos/.../pulls/<n>`.
+
+This is a self-host-only fix; the example workflows and docs partials
+already document the correct two-permission shape.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,14 @@ on:
   workflow_dispatch:
 
 permissions:
+  # contents:write to push tags (release path) and to force-push the
+  # monorel/release branch (feature path).
+  # pull-requests:write so monorel auto's feature path can PATCH the
+  # always-open release PR via `monorel preview --upsert`. Lost when
+  # release-pr.yml was consolidated into this workflow; without it,
+  # the GitHub API returns 403 on every non-release push to main.
   contents: write
+  pull-requests: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- Fixes a regression introduced when PR #64 consolidated `release-pr.yml` into `release.yml`: the `pull-requests: write` permission was dropped, so every non-release push to `main` now fails with a 403.

The release path (`detect-release` → `tag` → `push`) only needs `contents: write`. But the feature path (`monorel auto` calling `preview --upsert`) PATCHes the always-open release PR via the GitHub REST API, which requires `pull-requests: write`.

Failing run that surfaced the bug: https://github.com/disaresta-org/monorel/actions/runs/25300102088

```
auto: orchestrator: orchestrator: update PR #63: github: edit PR #63:
PATCH https://api.github.com/repos/disaresta-org/monorel/pulls/63:
403 Resource not accessible by integration
```

The example workflows under `examples/github/.github/workflows/release.yml` and the docs partial at `docs/src/_partials/github-release-yml.md` already document both permissions correctly. Only the self-hosted `release.yml` regressed.

## Test plan

- [x] Diff inspected; permissions block is the only change
- [ ] Workflow run on this PR's merge commit succeeds (the merge will be a non-release commit, so it should hit the feature path; that's the path the bug breaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)