### PR TITLE
ci(e2e): clean up e2e-gitea workflow (cache + preflight)

### DIFF
--- a/.github/workflows/e2e-gitea.yml
+++ b/.github/workflows/e2e-gitea.yml
@@ -49,16 +49,13 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-
-      - name: Cache Go module download
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-e2e-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-e2e-
+          # setup-go's built-in cache (default true since v4) already
+          # covers ~/go/pkg/mod and ~/.cache/go-build, keyed on
+          # go.sum. An explicit actions/cache@v4 step used to live
+          # here on the same paths; it was redundant and produced two
+          # post-action cache uploads at job teardown that ran in
+          # parallel with each other.
+          cache: true
 
       # testcontainers-go expects a working Docker daemon at
       # /var/run/docker.sock. ubuntu-latest's default image has it.

--- a/.github/workflows/e2e-gitea.yml
+++ b/.github/workflows/e2e-gitea.yml
@@ -57,10 +57,10 @@ jobs:
           # parallel with each other.
           cache: true
 
-      # testcontainers-go expects a working Docker daemon at
-      # /var/run/docker.sock. ubuntu-latest's default image has it.
-      - name: Verify docker is up
-        run: docker info >/dev/null
-
+      # testcontainers-go connects to /var/run/docker.sock from inside
+      # the test process; ubuntu-latest ships Docker. If the daemon
+      # were ever down, testcontainers returns a clear error of its
+      # own when the first scenario calls forgejo.Run, so a separate
+      # `docker info` preflight step would only duplicate that signal.
       - name: Run e2e suite
         run: go test -tags=e2e -count=1 -timeout 15m -v ./tests/e2e/...


### PR DESCRIPTION
## Summary

Two small e2e-gitea workflow cleanups, both surfaced by the run at https://github.com/disaresta-org/monorel/actions/runs/25300242103.

### 1. Drop redundant `actions/cache@v4` step

`actions/setup-go@v5` enables module + build caching by default since v4: it caches `~/go/pkg/mod` and `~/.cache/go-build` keyed on `go.sum`. The explicit `actions/cache@v4` step covered the same paths with a different key.

Visible symptom: two post-action cache uploads at job teardown. Also burned cache quota and slowed teardown.

`cache: true` is now explicit on the setup-go step to match the style used in `ci.yml`, so a future reader doesn't assume caching is absent.

### 2. Drop the `Verify docker is up` preflight

testcontainers-go connects to `/var/run/docker.sock` from inside the test process. If the daemon were ever down, the first scenario's `forgejo.Run` returns a clear error of its own, so a separate `docker info` preflight only duplicates that signal. The original step also redirected output to `/dev/null`, so it added no observability when Docker was up either.

## Test plan

- [x] Diff inspected; only the two intentional cleanups
- [ ] Workflow run on this PR's merge confirms cache works (the merge will be the first hit on the new `setup-go-only` cache key, then a second push should hit the cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)