### PR TITLE
ci: changeset-style + scenario-count lints, plus deferred review fixups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,18 @@ jobs:
             exit 1
           fi
 
+  changeset-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-changeset-style.sh
+
+  e2e-scenario-count:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-e2e-scenario-count.sh
+
   commit-lint:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -39,11 +39,8 @@ func TestIsReleaseMerge_TrailerHits(t *testing.T) {
 	if res.Source != SourceTrailer {
 		t.Errorf("Source = %q, want %q", res.Source, SourceTrailer)
 	}
-	// Trailer signal short-circuits: API should not be called.
-	// provider.Fake doesn't track call counts directly, but we can
-	// prove the API was not invoked by setting FailNext: if the API
-	// call had happened, the test would have failed with that error.
-	// (Re-run a fresh call with FailNext set to confirm.)
+	// Prove the trailer signal short-circuits: arm provider.FailNext
+	// so any API call would surface as an error, then re-run.
 	pf.FailNext = provider.FailOnce(errors.New("API should not have been called"))
 	res2, err := IsReleaseMerge(context.Background(), repo, pf, "")
 	if err != nil {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -53,6 +53,12 @@ pre-commit:
         - "monorel.toml"
         - ".changeset/*.md"
       run: go run ./cmd/monorel validate
+    # Catch em-dashes in changeset bodies before they ship into the
+    # auto-generated CHANGELOG verbatim. Project rule documented at
+    # .claude/rules/documentation.md.
+    changeset-style:
+      glob: ".changeset/*.md"
+      run: bash scripts/check-changeset-style.sh
 
 pre-push:
   commands:

--- a/scripts/check-changeset-style.sh
+++ b/scripts/check-changeset-style.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Lint changeset bodies (and other always-released prose) for the
+# project's documented style rules.
+#
+# Why scoped tightly: changesets and CHANGELOG entries are auto-published
+# verbatim by `monorel release`. Prose-quality regressions in those
+# files ship with the next tag and can't be edited out without
+# re-cutting a release. Other prose (docs/src, README) gets a normal
+# review cycle; this script intentionally does not police it.
+#
+# Run locally:
+#   bash scripts/check-changeset-style.sh
+#
+# Wired into:
+#   - lefthook pre-commit (when .changeset/*.md changes)
+#   - CI .github/workflows/ci.yml (every push and PR)
+
+set -euo pipefail
+
+# Files in scope. Glob expansion happens in the loop below; an empty
+# match (e.g. no pending changesets) is fine and treated as a no-op.
+TARGETS=()
+shopt -s nullglob
+for f in .changeset/*.md; do
+  # Skip the conventional README marker.
+  case "$(basename "$f")" in
+    README.md) continue ;;
+  esac
+  TARGETS+=("$f")
+done
+shopt -u nullglob
+
+if [ ${#TARGETS[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# U+2014 EM DASH. The project's docs rule (.claude/rules/documentation.md)
+# bans these and prescribes per-context replacements (colon, period,
+# semicolon, parens). The auto-generated CHANGELOG is the most-important
+# place to enforce this since it ships unedited.
+EM_DASH=$'\xe2\x80\x94'
+
+violations=0
+for f in "${TARGETS[@]}"; do
+  if grep -nF "$EM_DASH" "$f" >/dev/null 2>&1; then
+    echo "::error file=$f::em-dash (U+2014) found; replace with colon, period, semicolon, or parens (see .claude/rules/documentation.md)" >&2
+    grep -nF "$EM_DASH" "$f" | sed 's/^/  /' >&2
+    violations=$((violations + 1))
+  fi
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo "" >&2
+  echo "$violations changeset file(s) contain em-dashes. Fix and re-stage." >&2
+  exit 1
+fi

--- a/scripts/check-changeset-style.sh
+++ b/scripts/check-changeset-style.sh
@@ -8,6 +8,13 @@
 # re-cutting a release. Other prose (docs/src, README) gets a normal
 # review cycle; this script intentionally does not police it.
 #
+# Scoping note: the script scans every `.changeset/*.md` on disk, not
+# just the ones currently staged. Lefthook's `glob:` controls when the
+# step fires, but once it fires the script checks all of them. A
+# latent em-dash in an older changeset still ships into CHANGELOG at
+# the next release, so it's worth catching on any commit that touches
+# the directory.
+#
 # Run locally:
 #   bash scripts/check-changeset-style.sh
 #

--- a/scripts/check-e2e-scenario-count.sh
+++ b/scripts/check-e2e-scenario-count.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Verify that tests/e2e/README.md's "N scenarios in M files" claim
-# matches the actual count of `Test*` functions in tests/e2e/.
+# matches the actual counts in tests/e2e/.
 #
 # Why: the README's coverage table is hand-maintained. A new scenario
 # without a matching README update silently drifts; this catches it
@@ -14,31 +14,46 @@
 
 set -euo pipefail
 
-# Count top-level Test* functions (`func TestX(t *testing.T) {`),
-# excluding TestMain (test-runner setup, not a scenario). Subtests via
-# `t.Run` aren't counted; the README convention is "1 Test func = 1
-# scenario" regardless of how many sub-cases it sweeps.
-actual=$(grep -hE '^func Test[A-Za-z_]+\(t \*testing\.T\)' tests/e2e/*_test.go \
-  | grep -v '^func TestMain' \
+# Count top-level Test* functions (`func TestX(t *testing.T) {`).
+# TestMain has signature `(m *testing.M)`, so this regex naturally
+# excludes it. Subtests via `t.Run` aren't counted; the README
+# convention is "1 Test func = 1 scenario" regardless of how many
+# sub-cases it sweeps.
+actual_scenarios=$(grep -hE '^func Test[A-Za-z_]+\(t \*testing\.T\)' tests/e2e/*_test.go | wc -l)
+
+# Count scenario-bearing files. Excludes helpers_test.go and
+# main_test.go (test-runner plumbing, no scenarios) so the count
+# matches what's listed in the README's per-file coverage table.
+actual_files=$(ls tests/e2e/*_test.go \
+  | grep -vE '/(helpers_test|main_test)\.go$' \
   | wc -l)
 
-# Pull the asserted scenario count from the README. The line shape is:
+# Pull the asserted counts from the README. The line shape is:
 #   `<N> scenarios in <M> files. ...`
 # (See tests/e2e/README.md.)
-claimed=$(grep -oE '^[0-9]+ scenarios in [0-9]+ files' tests/e2e/README.md \
-  | head -1 | awk '{print $1}')
-
-if [ -z "$claimed" ]; then
+line=$(grep -oE '^[0-9]+ scenarios in [0-9]+ files' tests/e2e/README.md | head -1)
+if [ -z "$line" ]; then
   echo "::error file=tests/e2e/README.md::could not find 'N scenarios in M files' line" >&2
   exit 1
 fi
+claimed_scenarios=$(echo "$line" | awk '{print $1}')
+claimed_files=$(echo "$line" | awk '{print $4}')
 
-if [ "$actual" != "$claimed" ]; then
-  echo "::error file=tests/e2e/README.md::e2e scenario count drift: README claims $claimed, actual is $actual" >&2
+drift=0
+if [ "$actual_scenarios" != "$claimed_scenarios" ]; then
+  echo "::error file=tests/e2e/README.md::e2e scenario count drift: README claims $claimed_scenarios, actual is $actual_scenarios" >&2
+  drift=1
+fi
+if [ "$actual_files" != "$claimed_files" ]; then
+  echo "::error file=tests/e2e/README.md::e2e file count drift: README claims $claimed_files files, actual is $actual_files" >&2
+  drift=1
+fi
+
+if [ "$drift" -ne 0 ]; then
   echo "" >&2
-  echo "Update tests/e2e/README.md's '$claimed scenarios in N files.' line and the" >&2
+  echo "Update tests/e2e/README.md's '$claimed_scenarios scenarios in $claimed_files files.' line and the" >&2
   echo "per-file coverage table to match. Then re-run this script." >&2
   exit 1
 fi
 
-echo "OK: tests/e2e/ has $actual scenarios; README matches."
+echo "OK: tests/e2e/ has $actual_scenarios scenarios in $actual_files files; README matches."

--- a/scripts/check-e2e-scenario-count.sh
+++ b/scripts/check-e2e-scenario-count.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verify that tests/e2e/README.md's "N scenarios in M files" claim
+# matches the actual count of `Test*` functions in tests/e2e/.
+#
+# Why: the README's coverage table is hand-maintained. A new scenario
+# without a matching README update silently drifts; this catches it
+# before a reviewer has to.
+#
+# Run locally:
+#   bash scripts/check-e2e-scenario-count.sh
+#
+# Wired into:
+#   - .github/workflows/ci.yml (every push and PR)
+
+set -euo pipefail
+
+# Count top-level Test* functions (`func TestX(t *testing.T) {`),
+# excluding TestMain (test-runner setup, not a scenario). Subtests via
+# `t.Run` aren't counted; the README convention is "1 Test func = 1
+# scenario" regardless of how many sub-cases it sweeps.
+actual=$(grep -hE '^func Test[A-Za-z_]+\(t \*testing\.T\)' tests/e2e/*_test.go \
+  | grep -v '^func TestMain' \
+  | wc -l)
+
+# Pull the asserted scenario count from the README. The line shape is:
+#   `<N> scenarios in <M> files. ...`
+# (See tests/e2e/README.md.)
+claimed=$(grep -oE '^[0-9]+ scenarios in [0-9]+ files' tests/e2e/README.md \
+  | head -1 | awk '{print $1}')
+
+if [ -z "$claimed" ]; then
+  echo "::error file=tests/e2e/README.md::could not find 'N scenarios in M files' line" >&2
+  exit 1
+fi
+
+if [ "$actual" != "$claimed" ]; then
+  echo "::error file=tests/e2e/README.md::e2e scenario count drift: README claims $claimed, actual is $actual" >&2
+  echo "" >&2
+  echo "Update tests/e2e/README.md's '$claimed scenarios in N files.' line and the" >&2
+  echo "per-file coverage table to match. Then re-run this script." >&2
+  exit 1
+fi
+
+echo "OK: tests/e2e/ has $actual scenarios; README matches."

--- a/tests/e2e/helpers_test.go
+++ b/tests/e2e/helpers_test.go
@@ -5,7 +5,9 @@ package e2e_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
@@ -154,15 +156,15 @@ func (r *ScenarioRepo) ScaffoldMultiPackage(t *testing.T, pkgs ...string) {
 	r.WriteFile(t, "monorel.toml", sb.String())
 	for _, p := range pkgs {
 		readme := filepath.Join(r.Local, p, "README.md")
-		if _, err := os.Stat(readme); os.IsNotExist(err) {
+		if _, err := os.Stat(readme); errors.Is(err, fs.ErrNotExist) {
 			r.WriteFile(t, filepath.Join(p, "README.md"), "# "+p+"\n")
 		}
 		changelog := filepath.Join(r.Local, p, "CHANGELOG.md")
-		if _, err := os.Stat(changelog); os.IsNotExist(err) {
+		if _, err := os.Stat(changelog); errors.Is(err, fs.ErrNotExist) {
 			r.WriteFile(t, filepath.Join(p, "CHANGELOG.md"), "# Changelog\n\n## [Unreleased]\n\n")
 		}
 	}
-	if _, err := os.Stat(filepath.Join(r.Local, ".changeset/README.md")); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(r.Local, ".changeset/README.md")); errors.Is(err, fs.ErrNotExist) {
 		r.WriteFile(t, ".changeset/README.md", "# Changesets\n")
 	}
 }


### PR DESCRIPTION
## Summary

Three commits, each addressing recurring drift caught by the reviews on the e2e + detect-fix PRs:

### `a9186b7` — Add `scripts/check-changeset-style.sh` and `scripts/check-e2e-scenario-count.sh`

- **Em-dash check**: greps `.changeset/*.md` for U+2014 (em-dash). The project's docs rule (`/.claude/rules/documentation.md`) bans them, but they slipped into PR #65's and PR #66's changeset bodies and would have shipped verbatim into the auto-generated `CHANGELOG.md`. The script exits 1 with a workflow-friendly `::error file=...` annotation pointing at the file and line.
- **Scenario-count check**: greps `tests/e2e/*_test.go` for `Test*` functions and asserts the count matches `tests/e2e/README.md`'s "N scenarios in M files" line. Catches the case where a contributor adds an e2e scenario but forgets to update the README's per-file coverage table.

Both scripts smoke-tested locally:
- changeset-style: passes on current `.changeset/`, fails clearly with a synthetic em-dash injection.
- scenario-count: 27 scenarios in 6 files, README matches.

### `946c365` — Wire into lefthook + CI

- `lefthook.yml` pre-commit gains `changeset-style` (only runs on `.changeset/*.md` changes). Catches em-dashes locally before the developer pushes.
- `.github/workflows/ci.yml` gains `changeset-style` and `e2e-scenario-count` jobs so the checks run for contributors without lefthook installed.
- Scenario-count is intentionally CI-only — editing e2e tests isn't frequent enough to justify a per-commit cost.

### `9ea942a` — Two leftover Minor items from prior reviews

- `detect_test.go`'s `TestIsReleaseMerge_TrailerHits`: tighten the "API should not be called" comment trail (was 4 sentences; now 1).
- `helpers_test.go`'s `ScaffoldMultiPackage`: swap `os.IsNotExist(err)` for `errors.Is(err, fs.ErrNotExist)` — idiomatic Go 1.13+ form, behavior identical for our case.

## Test plan

- [x] Both lint scripts pass on current `main`
- [x] Both lint scripts fail with clear messages on synthetic drift
- [x] `go vet ./...` and `go vet -tags=e2e ./tests/e2e/`
- [x] `go test ./internal/detect/` (unit suite green)
- [x] `go test -tags=e2e -run TestVersioning_NewPackageMidLife|TestVersioning_OverlappingChangesetsMergeBumps ./tests/e2e/` (the two scenarios touched by the helper rewrite, both green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)