### PR TITLE
ci(lint): extend changeset-style to typography family + add self-test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Run the lint's own self-test first; if a refactor of the
+      # matcher regressed any banned-character case the test catches it
+      # before the production scan does.
+      - run: bash scripts/test-check-changeset-style.sh
       - run: bash scripts/check-changeset-style.sh
 
   e2e-scenario-count:

--- a/scripts/check-changeset-style.sh
+++ b/scripts/check-changeset-style.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Lint changeset bodies (and other always-released prose) for the
-# project's documented style rules.
+# Lint changeset bodies for typography characters that should be ASCII
+# in the auto-generated CHANGELOG.
 #
 # Why scoped tightly: changesets and CHANGELOG entries are auto-published
 # verbatim by `monorel release`. Prose-quality regressions in those
@@ -11,12 +11,15 @@
 # Scoping note: the script scans every `.changeset/*.md` on disk, not
 # just the ones currently staged. Lefthook's `glob:` controls when the
 # step fires, but once it fires the script checks all of them. A
-# latent em-dash in an older changeset still ships into CHANGELOG at
-# the next release, so it's worth catching on any commit that touches
-# the directory.
+# latent typography character in an older changeset still ships into
+# CHANGELOG at the next release, so it's worth catching on any commit
+# that touches the directory.
 #
 # Run locally:
 #   bash scripts/check-changeset-style.sh
+#
+# Self-test:
+#   bash scripts/test-check-changeset-style.sh
 #
 # Wired into:
 #   - lefthook pre-commit (when .changeset/*.md changes)
@@ -24,12 +27,27 @@
 
 set -euo pipefail
 
-# Files in scope. Glob expansion happens in the loop below; an empty
-# match (e.g. no pending changesets) is fine and treated as a no-op.
+# Banned typography characters, each with the ASCII replacement the
+# project's docs rule prescribes. Keep this list synchronized with
+# .claude/rules/documentation.md.
+#
+# Format: "<utf-8 byte sequence>|<U+ codepoint>|<name>|<replacement hint>"
+# The codepoint and name are for the error message; the replacement
+# hint helps the contributor know what to type instead.
+BANNED=(
+  $'\xe2\x80\x94|U+2014|EM DASH|use a colon, period, semicolon, or parens (see .claude/rules/documentation.md)'
+  $'\xe2\x80\x93|U+2013|EN DASH|use a hyphen for ranges (1-10), or "to" prose ("1 to 10")'
+  $'\xe2\x80\x98|U+2018|LEFT SINGLE QUOTATION MARK|use ASCII apostrophe (\x27)'
+  $'\xe2\x80\x99|U+2019|RIGHT SINGLE QUOTATION MARK|use ASCII apostrophe (\x27)'
+  $'\xe2\x80\x9c|U+201C|LEFT DOUBLE QUOTATION MARK|use ASCII double quote (")'
+  $'\xe2\x80\x9d|U+201D|RIGHT DOUBLE QUOTATION MARK|use ASCII double quote (")'
+  $'\xe2\x80\xa6|U+2026|HORIZONTAL ELLIPSIS|use three ASCII dots (...)'
+)
+
+# Collect target files. Empty match (no pending changesets) → exit 0.
 TARGETS=()
 shopt -s nullglob
-for f in .changeset/*.md; do
-  # Skip the conventional README marker.
+for f in "${CHANGESET_DIR:-.changeset}"/*.md; do
   case "$(basename "$f")" in
     README.md) continue ;;
   esac
@@ -41,23 +59,22 @@ if [ ${#TARGETS[@]} -eq 0 ]; then
   exit 0
 fi
 
-# U+2014 EM DASH. The project's docs rule (.claude/rules/documentation.md)
-# bans these and prescribes per-context replacements (colon, period,
-# semicolon, parens). The auto-generated CHANGELOG is the most-important
-# place to enforce this since it ships unedited.
-EM_DASH=$'\xe2\x80\x94'
-
 violations=0
-for f in "${TARGETS[@]}"; do
-  if grep -nF "$EM_DASH" "$f" >/dev/null 2>&1; then
-    echo "::error file=$f::em-dash (U+2014) found; replace with colon, period, semicolon, or parens (see .claude/rules/documentation.md)" >&2
-    grep -nF "$EM_DASH" "$f" | sed 's/^/  /' >&2
-    violations=$((violations + 1))
-  fi
+for entry in "${BANNED[@]}"; do
+  IFS='|' read -r char codepoint name fix <<< "$entry"
+  for f in "${TARGETS[@]}"; do
+    if grep -nF "$char" "$f" >/dev/null 2>&1; then
+      while IFS= read -r line; do
+        echo "::error file=$f::$codepoint $name: $fix" >&2
+        echo "  $line" >&2
+      done < <(grep -nF "$char" "$f")
+      violations=$((violations + 1))
+    fi
+  done
 done
 
 if [ "$violations" -gt 0 ]; then
   echo "" >&2
-  echo "$violations changeset file(s) contain em-dashes. Fix and re-stage." >&2
+  echo "$violations changeset typography violation(s) found. Replace with ASCII and re-stage." >&2
   exit 1
 fi

--- a/scripts/test-check-changeset-style.sh
+++ b/scripts/test-check-changeset-style.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check-changeset-style.sh.
+#
+# Drives the lint against fixture inputs and asserts each expected
+# violation is reported (or not) per the typography rule.
+#
+# Run locally:
+#   bash scripts/test-check-changeset-style.sh
+#
+# Wired into:
+#   - .github/workflows/ci.yml (every push and PR)
+
+set -euo pipefail
+
+LINT="$(cd "$(dirname "$0")" && pwd)/check-changeset-style.sh"
+if [ ! -x "$LINT" ]; then
+  echo "lint script not executable: $LINT" >&2
+  exit 1
+fi
+
+# Each test runs the lint against a fixture directory and asserts the
+# exit code + (optionally) that a substring appears in stderr.
+pass_count=0
+fail_count=0
+
+# Run the lint against a fixture directory. Captures stderr for the
+# substring check. Stdout is the lint's "OK" line on pass.
+run_case() {
+  local name="$1" want_exit="$2" want_substr="${3:-}" fixture_dir="$4"
+  local stderr
+  set +e
+  stderr=$(CHANGESET_DIR="$fixture_dir" bash "$LINT" 2>&1 >/dev/null)
+  local got_exit=$?
+  set -e
+  if [ "$got_exit" != "$want_exit" ]; then
+    echo "FAIL [$name]: exit=$got_exit, want $want_exit" >&2
+    echo "  stderr: $stderr" >&2
+    fail_count=$((fail_count + 1))
+    return
+  fi
+  if [ -n "$want_substr" ] && ! echo "$stderr" | grep -qF "$want_substr"; then
+    echo "FAIL [$name]: stderr missing substring: $want_substr" >&2
+    echo "  stderr: $stderr" >&2
+    fail_count=$((fail_count + 1))
+    return
+  fi
+  echo "PASS [$name]"
+  pass_count=$((pass_count + 1))
+}
+
+# Build all fixture directories under one tmpdir; cleaned up on exit.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Case 1: empty .changeset/ directory -> exit 0 (no-op).
+mkdir "$TMP/empty"
+run_case "empty-directory" 0 "" "$TMP/empty"
+
+# Case 2: only a README.md (the conventional non-changeset marker) -> exit 0.
+mkdir "$TMP/only-readme"
+echo "# Changesets" > "$TMP/only-readme/README.md"
+run_case "only-readme" 0 "" "$TMP/only-readme"
+
+# Case 3: clean changeset with allowed ASCII typography -> exit 0.
+mkdir "$TMP/clean"
+cat > "$TMP/clean/feat.md" <<'EOF'
+---
+"pkg-a": minor
+---
+
+Add support for X. The behavior matches Y; see issue (link) for context.
+
+Use ASCII 'quotes', "double quotes", and three dots (...) only.
+EOF
+run_case "clean-changeset" 0 "" "$TMP/clean"
+
+# Case 4: em-dash -> exit 1, error mentions U+2014.
+mkdir "$TMP/em-dash"
+printf 'fix em \xe2\x80\x94 dash here\n' > "$TMP/em-dash/bad.md"
+run_case "em-dash" 1 "U+2014 EM DASH" "$TMP/em-dash"
+
+# Case 5: en-dash -> exit 1, error mentions U+2013.
+mkdir "$TMP/en-dash"
+printf 'numeric range 1\xe2\x80\x9310 here\n' > "$TMP/en-dash/bad.md"
+run_case "en-dash" 1 "U+2013 EN DASH" "$TMP/en-dash"
+
+# Case 6: smart single quotes -> exit 1, both directions reported.
+mkdir "$TMP/smart-single"
+printf 'apostrophe \xe2\x80\x98smart\xe2\x80\x99 quotes\n' > "$TMP/smart-single/bad.md"
+run_case "smart-single-left" 1 "U+2018 LEFT SINGLE QUOTATION MARK" "$TMP/smart-single"
+run_case "smart-single-right" 1 "U+2019 RIGHT SINGLE QUOTATION MARK" "$TMP/smart-single"
+
+# Case 7: smart double quotes -> exit 1, both directions reported.
+mkdir "$TMP/smart-double"
+printf 'curly \xe2\x80\x9cdoubles\xe2\x80\x9d here\n' > "$TMP/smart-double/bad.md"
+run_case "smart-double-left" 1 "U+201C LEFT DOUBLE QUOTATION MARK" "$TMP/smart-double"
+run_case "smart-double-right" 1 "U+201D RIGHT DOUBLE QUOTATION MARK" "$TMP/smart-double"
+
+# Case 8: ellipsis -> exit 1, error mentions U+2026.
+mkdir "$TMP/ellipsis"
+printf 'something missing\xe2\x80\xa6 here\n' > "$TMP/ellipsis/bad.md"
+run_case "ellipsis" 1 "U+2026 HORIZONTAL ELLIPSIS" "$TMP/ellipsis"
+
+# Case 9: multiple violations across multiple files -> exit 1, count
+# message reports plural.
+mkdir "$TMP/multi"
+printf 'em \xe2\x80\x94 dash\n' > "$TMP/multi/a.md"
+printf 'curly \xe2\x80\x9cdouble\xe2\x80\x9d\n' > "$TMP/multi/b.md"
+run_case "multi-file" 1 "violation(s) found" "$TMP/multi"
+
+# Case 10: README.md with em-dash is skipped (the script excludes README).
+mkdir "$TMP/readme-em"
+printf 'em \xe2\x80\x94 dash in README\n' > "$TMP/readme-em/README.md"
+run_case "readme-skipped" 0 "" "$TMP/readme-em"
+
+# Case 11: a clean changeset alongside a violating one -> exit 1
+# (any single violation fails the run).
+mkdir "$TMP/mixed"
+cat > "$TMP/mixed/clean.md" <<'EOF'
+fix: clean ASCII only.
+EOF
+printf 'em \xe2\x80\x94 dash\n' > "$TMP/mixed/bad.md"
+run_case "mixed-clean-and-bad" 1 "U+2014 EM DASH" "$TMP/mixed"
+
+echo ""
+total=$((pass_count + fail_count))
+echo "ran $total case(s); $pass_count passed, $fail_count failed"
+if [ "$fail_count" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Two commits closing out the open recommendations from PR #69's review.

### `f9760db` — Extend the changeset-style lint to the typography family

The em-dash check was the seed; this generalizes the lint to the seven autocorrect-inserted typography characters that don't belong in CHANGELOG entries:

| Codepoint | Name | ASCII fix |
|-----------|------|-----------|
| U+2014 | EM DASH (already caught) | colon, period, semicolon, parens |
| U+2013 | EN DASH | hyphen for ranges, "to" prose |
| U+2018 | LEFT SINGLE QUOTATION MARK | ASCII apostrophe `'` |
| U+2019 | RIGHT SINGLE QUOTATION MARK | ASCII apostrophe `'` |
| U+201C | LEFT DOUBLE QUOTATION MARK | ASCII `"` |
| U+201D | RIGHT DOUBLE QUOTATION MARK | ASCII `"` |
| U+2026 | HORIZONTAL ELLIPSIS | three ASCII dots `...` |

Each error annotation includes the codepoint, name, and a fix hint so the contributor knows exactly what to type instead. The data is a bash array; adding a future banned character is one line.

The script now reads `CHANGESET_DIR` from the environment (defaulting to `.changeset`). That makes it driveable from a self-test harness without copying fixtures into the real `.changeset/` directory; the lefthook + CI invocations don't set the env var, so they continue to scan the real directory.

### `884e97a` — Self-test harness with 13 fixture cases

`scripts/test-check-changeset-style.sh` covers:

- **Empty `.changeset/` directory** → exit 0, no-op
- **Only `README.md` present** → exit 0, README correctly skipped
- **Clean ASCII changeset** → exit 0
- **Each banned typography character** → exit 1, error message names `U+xxxx`
- **Mixed clean + bad files** → exit 1 (any single violation fails the run)
- **Multi-file violations** → exit 1, count message reports plural

CI runs the self-test **before** the production lint, so a regression in the matcher (e.g., a refactor that drops a character from the banned list) is caught with a clear `FAIL [<case>]` annotation rather than as a silent green-when-it-should-be-red production scan.

Verified by manual regression: commenting out the em-dash entry in the production lint causes the harness to fail with `FAIL [em-dash]` and `FAIL [mixed-clean-and-bad]`, exit 1.

## What's still open from PR #69's review

**Recommendation 3** — extend `check-e2e-scenario-count.sh` to parse the per-file coverage table directly. That's a separate, larger effort (markdown table parsing) and not bundled here. The script already validates total count + file count after `a35cbec`; per-file is the next layer.

## Test plan

- [x] Self-test passes on the unmodified lint: `13 case(s); 13 passed, 0 failed`
- [x] Self-test correctly detects regressions (commented-out em-dash entry → `FAIL [em-dash]`, exit 1)
- [x] Production lint runs clean against the current `.changeset/` (empty post-release; trivially passes)
- [x] No production code touched; tests/e2e/ unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)