### PR TITLE
fix(gitlab): entrypoint override + known-issue for multi-module tidy

### DIFF
--- a/.changeset/gitlab-pipeline-entrypoint.md
+++ b/.changeset/gitlab-pipeline-entrypoint.md
@@ -1,0 +1,11 @@
+---
+"monorel.disaresta.com": patch
+---
+
+**Fix `examples/gitlab/.gitlab-ci.yml` failing on the `docker+machine` executor.**
+
+The published `ghcr.io/disaresta-org/monorel` image is an entrypoint-binary container (its entrypoint is `monorel` itself). GitLab's `docker+machine` executor wraps every script as `sh -c '...'` and passes that to the container's entrypoint, producing `monorel sh -c '...'` and failing with `unknown command "sh"`.
+
+The example pipeline + the partial it includes from now use the long-form `image:` block with `entrypoint: [""]` to clear the container's entrypoint so the runner's shell wrapper takes over. Surfaced by an end-to-end test against a real GitLab runner.
+
+Also documents an outstanding known issue in `docs/src/integrations/gitlab.md`: multi-module Go monorepos with sibling `require`s hit a separate offline-tidy bug on cold-cache CI runners. Tracked separately from this fix; single-module repos and multi-module repos without in-plan sibling requires are unaffected. A new build-tag-gated test (`tests/e2e/tidy_isolated_test.go` under `e2e_tidy`) reproduces the bug deterministically using a `golang:1.26-alpine` testcontainer for use during the eventual fix.

--- a/docs/src/_partials/gitlab-ci-yml.md
+++ b/docs/src/_partials/gitlab-ci-yml.md
@@ -1,6 +1,13 @@
 ```yaml
 default:
-  image: ghcr.io/disaresta-org/monorel:1.0.0
+  # entrypoint: [""] override is required: the published image's
+  # entrypoint is `monorel` (entrypoint-binary container), and
+  # GitLab's docker+machine executor wraps every script as
+  # `sh -c '...'`. Without the override the runner invokes
+  # `monorel sh -c '...'` and fails with `unknown command "sh"`.
+  image:
+    name: ghcr.io/disaresta-org/monorel:1.0.0
+    entrypoint: [""]
 
 monorel:
   rules:

--- a/docs/src/integrations/gitlab.md
+++ b/docs/src/integrations/gitlab.md
@@ -57,6 +57,10 @@ Detection uses HEAD's `monorel-Release:` commit-body trailer OR the provider's `
 
 <!--@include: ../_partials/gitlab-ci-yml.md-->
 
+::: warning Image entrypoint override required
+The `image:` block uses the long form with `entrypoint: [""]`. The published `ghcr.io/disaresta-org/monorel` image is an entrypoint-binary container (its entrypoint is `monorel` itself). GitLab's `docker+machine` executor wraps every script as `sh -c '...'` and passes that to the container's entrypoint, which produces `monorel sh -c '...'` and fails with `unknown command "sh"`. Clearing the entrypoint with `[""]` lets the runner's shell wrapper take over. The short-form `image: <name>` in the example will NOT work; use the long form verbatim.
+:::
+
 Setup:
 
 1. **Add `MONOREL_GITLAB_TOKEN` as a CI/CD variable** under Settings → CI/CD → Variables. Use a personal or project access token with `api` scope. Mark it Masked but NOT Protected (so it's available on the bot-managed `monorel/release` branch too).
@@ -160,3 +164,15 @@ GitLab CI doesn't have GitHub Actions' anti-recursion rule, but pipelines on the
 - The project has [Pipelines for Merged Results](https://docs.gitlab.com/ci/pipelines/merged_results_pipelines/) enabled and the merge result fails to compute (rare).
 
 Check the project's CI/CD → Pipelines page for the actual status; usually a transient runner issue.
+
+### `tidy in <sub-module>: exit status 1` with `module lookup disabled by GOPROXY=off` (multi-module, clean runner)
+
+Known issue with multi-module repos on cold-cache GitLab runners. `monorel apply`'s offline `go mod tidy` step fails inside a sub-module that requires another in-plan sibling, with:
+
+```
+go: example.com/widget/<sub-module>: module lookup disabled by GOPROXY=off
+```
+
+The bug is in monorel's seed-and-tidy flow, not your config. It does NOT reproduce on a developer's machine (the local `GOMODCACHE` has accumulated state that masks it) but does reproduce reliably in shared CI runners and inside the published Docker image. Until it's fixed, the multi-module Go-monorepo path on GitLab is unverified end-to-end.
+
+Single-module repos are unaffected. Multi-module repos where no sub-module has an in-plan sibling `require` are unaffected.

--- a/examples/gitlab/.gitlab-ci.yml
+++ b/examples/gitlab/.gitlab-ci.yml
@@ -1,5 +1,13 @@
 default:
-  image: ghcr.io/disaresta-org/monorel:1.0.0
+  # The published image's entrypoint is `monorel` (it ships as an
+  # entrypoint-binary container). GitLab's docker+machine executor
+  # wraps every script as `sh -c '...'`, so without this override
+  # the runner invokes `monorel sh -c '...'` and fails with
+  # `unknown command "sh"`. Setting entrypoint to `[""]` clears the
+  # container's entrypoint so the runner's shell wrapper takes over.
+  image:
+    name: ghcr.io/disaresta-org/monorel:1.0.0
+    entrypoint: [""]
 
 monorel:
   rules:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/google/go-github/v68 v68.0.0
 	github.com/spf13/cobra v1.10.2
+	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/forgejo v0.42.0
 	gitlab.com/gitlab-org/api/client-go v1.46.0
 	go.loglayer.dev/plugins/fmtlog/v2 v2.0.1
@@ -94,7 +95,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
-	github.com/testcontainers/testcontainers-go v0.42.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/tests/e2e/tidy_isolated_test.go
+++ b/tests/e2e/tidy_isolated_test.go
@@ -1,0 +1,238 @@
+//go:build e2e_tidy
+
+// Package e2e_tidy isolates the multi-module + offline `go mod tidy`
+// path from `monorel apply` against a clean Go module cache, the
+// shape every CI runner sees on first run.
+//
+// The default `tests/e2e/` suite runs against the developer's local
+// GOMODCACHE, which has accumulated state from prior monorel dev
+// runs and accidentally masks a real bug: when a multi-module repo
+// has sub-modules that `require` an in-plan sibling, `monorel
+// apply`'s offline tidy fails with `module lookup disabled by
+// GOPROXY=off` on a fresh runner. The Forgejo lifecycle scenarios
+// don't catch this because they share the host's cache.
+//
+// This test runs `monorel apply` inside `golang:1.26-alpine` (the
+// same image the published `ghcr.io/disaresta-org/monorel` is
+// built from), so the GOMODCACHE is empty. The bug surfaces every
+// time on every machine.
+//
+// Build tag `e2e_tidy` keeps it out of the default `go test ./...`
+// run; CI invokes it with `go test -tags=e2e_tidy ./tests/e2e/`.
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const tidyImage = "golang:1.26-alpine"
+
+// TestApply_MultiModule_CleanCache pins the contract that
+// `monorel apply` succeeds end-to-end on a clean Go module cache for
+// a multi-module repo with sibling `require`s. Reproduces against a
+// fresh `golang:1.26-alpine` container; the bug fix lives in the
+// seed-and-tidy ordering in `internal/release/`.
+//
+// Currently SKIPPED by default because it surfaces a known
+// outstanding bug in monorel apply's offline tidy path (multi-module
+// + sibling-require + clean GOMODCACHE causes go's tidy to attempt a
+// proxy lookup of the module-being-tidied, which fails under
+// GOPROXY=off). The user-facing manifestation is documented in
+// docs/src/integrations/gitlab.md's troubleshooting section. To
+// validate the bug status, run with MONOREL_TIDY_REPRO=1:
+//
+//	MONOREL_TIDY_REPRO=1 go test -tags=e2e_tidy ./tests/e2e/...
+//
+// Once the seed-and-tidy ordering fix lands, drop the skip guard.
+func TestApply_MultiModule_CleanCache(t *testing.T) {
+	if os.Getenv("MONOREL_TIDY_REPRO") != "1" {
+		t.Skip("known bug; set MONOREL_TIDY_REPRO=1 to run the deterministic repro")
+	}
+	ctx := context.Background()
+
+	// Build a static linux/amd64 monorel binary from the current
+	// source tree. The container will exec it directly (no Go
+	// toolchain layering needed; alpine ships its own).
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "monorel")
+	build := exec.Command("go", "build", "-o", binPath, "monorel.disaresta.com/cmd/monorel")
+	build.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux", "GOARCH=amd64")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build monorel: %v\n%s", err, out)
+	}
+
+	// Build the multi-module scaffold mirroring helpers_test.go's
+	// ScaffoldMultiModule: root + transports/foo + plugins/bar,
+	// each sub-module with a `replace example.com/widget => ../..`
+	// and `import _ "example.com/widget"` in its source.
+	repoDir := t.TempDir()
+	scaffoldMultiModuleForTidy(t, repoDir)
+
+	// Spin up an alpine container with the repo + binary mounted.
+	// `golang:1.26-alpine` ships its own Go toolchain at /usr/local/go.
+	req := testcontainers.ContainerRequest{
+		Image: tidyImage,
+		Cmd:   []string{"sleep", "infinity"},
+		Mounts: testcontainers.ContainerMounts{
+			testcontainers.BindMount(repoDir, "/work"),
+			testcontainers.BindMount(binPath, "/usr/local/bin/monorel"),
+		},
+		WorkingDir: "/work",
+		WaitingFor: wait.ForExec([]string{"go", "version"}).WithExitCodeMatcher(func(c int) bool { return c == 0 }).WithStartupTimeout(60 * time.Second),
+	}
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("start container: %v", err)
+	}
+	defer func() { _ = container.Terminate(ctx) }()
+
+	// Install git (golang:alpine doesn't ship it) and init the repo.
+	// monorel apply needs a clean working tree, so the scaffold has to
+	// be committed before invoking apply.
+	for _, args := range [][]string{
+		{"apk", "add", "--no-cache", "git"},
+		{"git", "config", "--global", "user.email", "t@t"},
+		{"git", "config", "--global", "user.name", "t"},
+		{"git", "config", "--global", "init.defaultBranch", "main"},
+		{"git", "config", "--global", "--add", "safe.directory", "/work"},
+		{"sh", "-c", "cd /work && git init -q && git add -A && git commit -qm init"},
+	} {
+		code, reader, err := container.Exec(ctx, args)
+		if err != nil || code != 0 {
+			out, _ := readAll(reader)
+			t.Fatalf("setup `%s`: code=%d err=%v\n%s", strings.Join(args, " "), code, err, out)
+		}
+	}
+
+	// Run monorel apply.
+	code, reader, err := container.Exec(ctx, []string{"sh", "-c", "cd /work && monorel apply"})
+	if err != nil {
+		t.Fatalf("exec monorel apply: %v", err)
+	}
+	out, _ := readAll(reader)
+
+	if code != 0 {
+		t.Fatalf("monorel apply exited %d on a clean cache (multi-module + offline tidy regression):\n%s",
+			code, out)
+	}
+
+	// Verify the apply produced the expected post-state.
+	for _, sub := range []string{"transports/foo", "plugins/bar"} {
+		body := readFile(t, filepath.Join(repoDir, sub, "go.mod"))
+		if strings.Contains(body, "replace example.com/widget") {
+			t.Errorf("%s/go.mod still has replace directive after apply:\n%s", sub, body)
+		}
+		if !strings.Contains(body, "require example.com/widget v0.1.0") {
+			t.Errorf("%s/go.mod missing pinned require for v0.1.0:\n%s", sub, body)
+		}
+		if _, err := os.Stat(filepath.Join(repoDir, sub, "go.sum")); err != nil {
+			t.Errorf("%s/go.sum not created by tidy: %v", sub, err)
+		}
+	}
+}
+
+// scaffoldMultiModuleForTidy writes a 3-module scaffold (root +
+// transports/foo + plugins/bar) into dir. Mirrors helpers_test.go's
+// ScaffoldMultiModule but writes everything under a single dir
+// (caller's t.TempDir()) and uses `example.com/widget` as the
+// canonical module path so the test exercises the same path the
+// GitLab live test exercised.
+func scaffoldMultiModuleForTidy(t *testing.T, dir string) {
+	t.Helper()
+	mustWrite(t, filepath.Join(dir, "go.mod"), "module example.com/widget\n\ngo 1.25\n")
+	mustWrite(t, filepath.Join(dir, "widget.go"), "package widget\n")
+	mustWrite(t, filepath.Join(dir, "CHANGELOG.md"), "# Changelog\n\n## [Unreleased]\n\n")
+
+	for _, sub := range []string{"transports/foo", "plugins/bar"} {
+		_ = os.MkdirAll(filepath.Join(dir, sub), 0o755)
+		pkg := filepath.Base(sub)
+		mustWrite(t, filepath.Join(dir, sub, "go.mod"),
+			"module example.com/widget/"+sub+"\n\n"+
+				"go 1.25\n\n"+
+				"require example.com/widget v0.0.0-00010101000000-000000000000\n\n"+
+				"replace example.com/widget => ../..\n")
+		mustWrite(t, filepath.Join(dir, sub, pkg+".go"),
+			"package "+pkg+"\n\nimport _ \"example.com/widget\"\n")
+		mustWrite(t, filepath.Join(dir, sub, "CHANGELOG.md"), "# Changelog\n\n## [Unreleased]\n\n")
+	}
+
+	mustWrite(t, filepath.Join(dir, ".changeset", "README.md"), "# Changesets\n")
+	mustWrite(t, filepath.Join(dir, ".changeset", "feat.md"),
+		"---\n"+
+			`"example.com/widget": minor`+"\n"+
+			`"transports/foo": minor`+"\n"+
+			`"plugins/bar": patch`+"\n"+
+			"---\n\n"+
+			"Initial multi-module release.\n")
+	mustWrite(t, filepath.Join(dir, "monorel.toml"),
+		`[provider]
+name = "github"
+owner = "test"
+repo = "test"
+
+[packages."example.com/widget"]
+tag_prefix = ""
+path       = "."
+changelog  = "CHANGELOG.md"
+
+[packages."transports/foo"]
+tag_prefix = "transports/foo"
+path       = "transports/foo"
+changelog  = "transports/foo/CHANGELOG.md"
+
+[packages."plugins/bar"]
+tag_prefix = "plugins/bar"
+path       = "plugins/bar"
+changelog  = "plugins/bar/CHANGELOG.md"
+`)
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	_ = os.MkdirAll(filepath.Dir(path), 0o755)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// readFile is local-only because helpers_test.go is gated on
+// build tag `e2e` while this file uses `e2e_tidy`; the test is
+// self-contained.
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(body)
+}
+
+// readAll consumes a testcontainers Exec reader into a string. The
+// reader's stream includes a small framing header per line; this
+// helper drops nothing and just returns the raw bytes for diagnostic
+// printing in test failures.
+func readAll(r interface{ Read(p []byte) (int, error) }) (string, error) {
+	var buf [4096]byte
+	var sb strings.Builder
+	for {
+		n, err := r.Read(buf[:])
+		if n > 0 {
+			sb.Write(buf[:n])
+		}
+		if err != nil {
+			return sb.String(), err
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two findings from a live `examples/gitlab/.gitlab-ci.yml` run on a real gitlab.com runner. One fixed in this PR, one documented + captured in a deterministic regression test.

## Gap 1 (FIXED): entrypoint-binary image vs GitLab's `docker+machine` executor

The published `ghcr.io/disaresta-org/monorel` image is an entrypoint-binary container (its entrypoint is `monorel` itself). GitLab's `docker+machine` executor wraps every script as `sh -c '...'` and passes that to the container's entrypoint, producing `monorel sh -c '...'` and failing with:

```
unknown command "sh" for "monorel"
```

Surfaced when the example pipeline ran on a fresh project against a real runner. Static review missed it because the symptom only shows up when the runner actually exec's the container.

**Fix**: long-form `image:` block with `entrypoint: [""]`:

```yaml
default:
  image:
    name: ghcr.io/disaresta-org/monorel:1.0.0
    entrypoint: [""]
```

Applied to:
- `examples/gitlab/.gitlab-ci.yml`
- `docs/src/_partials/gitlab-ci-yml.md` (the partial users copy)
- `docs/src/integrations/gitlab.md` (warning callout explaining why)

Bitbucket left alone because the provider is currently disabled in monorel.toml validation; same fix likely applies when re-enabled.

## Gap 2 (DOCUMENTED): multi-module + offline tidy on a clean runner

A separate, deeper bug. When a multi-module repo has sub-modules that `require` an in-plan sibling, `monorel apply`'s offline `go mod tidy` fails inside the sub-module with:

```
go: example.com/widget/<sub-module>: module lookup disabled by GOPROXY=off
```

Reproduces deterministically inside `golang:1.26-alpine` (the same image the published release runs in). Does NOT reproduce on a developer's machine because the local `GOMODCACHE` has accumulated state that masks it. The Forgejo testcontainer suite passes the same multi-module scenarios for this reason.

Investigated several fix attempts (skip-self in seed, stash-restore around tidy) — none converged in the time available; the seed-and-tidy ordering needs a deeper rework.

**Captured as**:
- A known-issue note in `docs/src/integrations/gitlab.md`'s troubleshooting (honest framing: no clean workaround, fix is in monorel itself).
- `tests/e2e/tidy_isolated_test.go` — a build-tag-gated (`e2e_tidy`) regression test that uses `testcontainers-go` to spin up `golang:1.26-alpine`, mounts a host-built monorel binary + a multi-module scaffold, runs `monorel apply` inside, and asserts the post-state. Reproduces the bug deterministically.

The test is skipped by default (gated on `MONOREL_TIDY_REPRO=1` env var) so it doesn't block CI on a known bug. Once the seed-and-tidy ordering fix lands, drop the skip guard and the test becomes a regression guard.

Single-module repos and multi-module repos without in-plan sibling requires are **unaffected**.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` clean (default suite)
- [x] `go test -tags=e2e_tidy ./tests/e2e/` clean (test skipped without env var)
- [x] `MONOREL_TIDY_REPRO=1 go test -tags=e2e_tidy ./tests/e2e/` reproduces Gap 2 deterministically
- [x] `bun run docs:build` clean
- [x] Live GitLab runner verified Gap 1 (the entrypoint-override resolution): the same scaffold + the new `entrypoint: [""]` example pipeline runs on a real GitLab runner past the image-pull stage; only Gap 2 still fails subsequent runs

## Follow-ups

- **Gap 2 fix in `internal/release/`**: the seed-and-tidy ordering needs to either (a) avoid creating the `cache/download/<self-module>/` directory tree at all when seeding (skip-self in seedModuleCache wasn't sufficient — go's resolver still triggers the lookup; the directory's existence alone is enough), (b) keep a temporary self-`replace` directive during tidy and strip it after, or (c) swap the offline tidy mode for permissive `-mod=mod` resolution. Each has trade-offs around go.sum h1 stability vs. correctness; needs design.
- **Refactor the existing `tests/e2e/` Forgejo scenarios to run apply inside container-isolated Go environments**, so this class of bug surfaces in the suite on the dev machine. Bigger change; separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)