### PR TITLE
docs: CONTRIBUTING e2e tags + tighten README intro

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,21 @@ make build       # build the monorel binary
 | `make docs` | Build the VitePress docs site. |
 | `make docs-dev` | Run the docs dev server with live reload. |
 
+## Running the e2e suites
+
+`make ci` (and the pre-push hook) covers unit tests + race detection across the repo. The build-tag-gated end-to-end suites under `tests/e2e/` are not in the default test run; invoke them explicitly when you're touching the release pipeline, the provider seam, or the offline-tidy / cacheseed paths. Both require Docker (testcontainers-go starts disposable containers and tears them down at the end of the run).
+
+```sh
+# Forgejo lifecycle scenarios (~27 tests, ~75s wall clock):
+go test -tags=e2e -count=1 -timeout 15m ./tests/e2e/...
+
+# Clean-cache regression test for multi-module offline tidy
+# (`monorel apply` inside a fresh golang:1.26-alpine, ~15s):
+go test -tags=e2e_tidy -count=1 -timeout 5m ./tests/e2e/... -run TestApply_MultiModule_CleanCache
+```
+
+CI (`.github/workflows/e2e-gitea.yml`) runs the Forgejo suite on every PR. The `e2e_tidy` reproducer is opt-in locally; consider running it whenever you change `internal/release/cacheseed.go`, `internal/release/tidy.go`, or anything in the seed-and-tidy fixpoint loop.
+
 ## Workflow
 
 - Branch off `main` as `<type>/<short-slug>` (e.g. `feat/planner`, `fix/changeset-name-collision`).
@@ -74,6 +89,7 @@ monorel/
 ├── ci/                         per-CI-system action wrappers
 │   └── github/action.yml       composite GitHub Action (runs `monorel auto`)
 ├── tests/e2e/                  live-Forgejo integration suite (build tag `e2e`)
+│                                  + clean-cache reproducer in `golang:1.26-alpine` (build tag `e2e_tidy`)
 ├── docs/                       VitePress docs site
 └── .changeset/                 self-hosted changesets
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
 </p>
 
-A changesets-style release tool for single-module and multi-module Go monorepos.
+A changesets-style release tool for single-module and multi-module Go repos.
 
 `monorel` manages per-package versions, tags, and CHANGELOG entries in a Go monorepo using explicit `.changeset/*.md` files instead of inferring releases from commit messages. Pair it with CI on your provider (GitHub, Gitea / Forgejo, or GitLab) to drive an always-open release PR whose diff IS the actual file changes the next release will produce.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT" /></a>
 </p>
 
-A changesets-style release tool for multi-module Go monorepos. Single-module repos work too (config is just one `[packages]` entry).
+A changesets-style release tool for single-module and multi-module Go monorepos.
 
 `monorel` manages per-package versions, tags, and CHANGELOG entries in a Go monorepo using explicit `.changeset/*.md` files instead of inferring releases from commit messages. Pair it with CI on your provider (GitHub, Gitea / Forgejo, or GitLab) to drive an always-open release PR whose diff IS the actual file changes the next release will produce.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 ---
 title: "monorel: changesets-style releases for Go monorepos"
-description: A release tool for multi-module Go monorepos. Per-PR intent via .changeset files, native Go tag conventions, always-open release PR.
+description: A release tool for single-module and multi-module Go repos. Per-PR intent via .changeset files, native Go tag conventions, always-open release PR.
 
 layout: home
 

--- a/docs/src/public/llms-full.txt
+++ b/docs/src/public/llms-full.txt
@@ -1,6 +1,6 @@
 # monorel: Comprehensive LLM Reference
 
-> A changesets-style release tool for multi-module Go monorepos. Bare `vX.Y.Z` tags for the root module, `<path>/vX.Y.Z` tags for sub-modules. Authors declare release intent in per-PR `.changeset/<name>.md` files; an always-open release PR aggregates the plan; merging it creates per-package tags and provider releases. Module path: `monorel.disaresta.com`. GitHub: `github.com/disaresta-org/monorel`.
+> A changesets-style release tool for single-module and multi-module Go repos. Bare `vX.Y.Z` tags for the root module, `<path>/vX.Y.Z` tags for sub-modules. Authors declare release intent in per-PR `.changeset/<name>.md` files; an always-open release PR aggregates the plan; merging it creates per-package tags and provider releases. Module path: `monorel.disaresta.com`. GitHub: `github.com/disaresta-org/monorel`.
 
 This is the comprehensive reference. For the concise index see [llms.txt](https://monorel.disaresta.com/llms.txt).
 

--- a/docs/src/public/llms.txt
+++ b/docs/src/public/llms.txt
@@ -1,6 +1,6 @@
 # monorel
 
-> A changesets-style release tool for multi-module Go monorepos. Bare `vX.Y.Z` tags for the root module, `<path>/vX.Y.Z` tags for sub-modules. Authors declare release intent in per-PR `.changeset/<name>.md` files; an always-open release PR aggregates the plan; merging it creates per-package tags and provider releases. Module path: `monorel.disaresta.com`. GitHub: `github.com/disaresta-org/monorel`.
+> A changesets-style release tool for single-module and multi-module Go repos. Bare `vX.Y.Z` tags for the root module, `<path>/vX.Y.Z` tags for sub-modules. Authors declare release intent in per-PR `.changeset/<name>.md` files; an always-open release PR aggregates the plan; merging it creates per-package tags and provider releases. Module path: `monorel.disaresta.com`. GitHub: `github.com/disaresta-org/monorel`.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

**CONTRIBUTING.md**: project layout now mentions both e2e build tags (`e2e` Forgejo suite + `e2e_tidy` clean-cache reproducer added with the v1.0 multi-module GOMODCACHE-pinning fix). New "Running the e2e suites" section gives the exact go-test invocations for both, plus the Docker prerequisite.

**README.md**: lead line tightened from `... for multi-module Go monorepos. Single-module repos work too (config is just one [packages] entry).` to `... for single-module and multi-module Go monorepos.`

## Test plan

- [x] Renders cleanly on GitHub
- [x] Both tag invocations work locally (`-tags=e2e` and `-tags=e2e_tidy`)