### PR TITLE
chore(ci): dogfood the chore(release) skip filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,20 @@ permissions:
   contents: read
 
 jobs:
+  # Skip on `chore(release):` push commits across every job that
+  # resolves Go module versions (`test`, `lint`, `tidy`). PR runs
+  # are unaffected because the filter checks `head_commit.message`
+  # which is null for `pull_request` events.
+  #
+  # The dogfood: monorel's own `ci/github/README.md` documents this
+  # recipe (Recipes -> "Skipping CI on chore(release) commits") for
+  # downstream consumers; this workflow demonstrates it in monorel's
+  # own setup. Today monorel is single-module so the chore(release)
+  # commit doesn't add new versions to its go.sum and the race the
+  # filter prevents wouldn't bite. Forward-compatible if monorel
+  # ever grows sub-modules.
   test:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,6 +39,7 @@ jobs:
       - run: go test -race -count=1 ./...
 
   lint:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +58,7 @@ jobs:
       - run: staticcheck ./...
 
   tidy:
+    if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-gitea.yml
+++ b/.github/workflows/e2e-gitea.yml
@@ -40,6 +40,12 @@ permissions:
 
 jobs:
   e2e:
+    # Skip on chore(release) push commits. The e2e suite spins up a
+    # Forgejo container and exercises monorel against an ephemeral
+    # repo inside it; nothing about the chore(release) merge changes
+    # the suite's behavior, so re-running it on the release commit
+    # just burns CI minutes.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## Summary

monorel's own [`ci/github/README.md`](./ci/github/README.md#skipping-ci-on-chorerelease-commits) documents a recipe telling downstream consumers to put

```yaml
if: github.event_name == 'pull_request' || !startsWith(github.event.head_commit.message, 'chore(release):')
```

on every job that runs `go mod tidy` or otherwise resolves Go module versions. monorel's own CI didn't follow that recipe.

This PR applies the filter to the three jobs in `ci.yml` that resolve module versions (`test`, `lint`, `tidy`) and to the `e2e` job in `e2e-gitea.yml`. The two PR-only jobs in `ci.yml` (`commit-lint`, `docs-build`) already gate on `github.event_name == 'pull_request'`; no change needed.

## Why now

The race the filter prevents doesn't currently bite monorel because it's a single-module repo and the chore(release) commit doesn't bump `go.sum` entries. Adding the filter is purely:

- **Free CI minutes saved** on chore(release) merges (the diff is CHANGELOG + `.changeset/*.md` deletion + monorel internal version string; nothing that warrants the full test matrix or the e2e Forgejo container).
- **Demonstrates the recipe** in monorel's own setup as a working reference for downstream consumers.
- **Forward-compatible** if monorel ever grows sub-modules (e.g., a hypothetical extracted library module someday).

## Test plan

- [ ] After merge, the next non-`chore(release):` push to main triggers a clean CI run (every filtered job runs as before).
- [ ] At the next release-pr merge, the `chore(release):` commit's CI run shows `test`, `lint`, `tidy`, and `e2e` jobs as `Skipped` rather than `Pass`/`Fail`. `release.yml` still runs and tags the release; nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)