### PR TITLE
docs(home): drop 'Coming from release-please?' hero action

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,9 +18,6 @@ hero:
     - theme: alt
       text: Quickstart
       link: /getting-started
-    - theme: alt
-      text: Coming from release-please?
-      link: /recipes/migration-from-release-please
 
 features:
   - title: Changesets, not commit messages


### PR DESCRIPTION
## Summary

Removes the third hero button on the homepage. Two actions (Why monorel? + Quickstart) is enough; the comparative framing fits better inside the introduction page.

## Test plan

- [x] vitepress build clean